### PR TITLE
Check clang nullable

### DIFF
--- a/sources/cqlrt.h
+++ b/sources/cqlrt.h
@@ -12,7 +12,7 @@
 #include <stdint.h>
 #include <sqlite3.h>
 
-#ifdef __GNUC__
+#ifndef __clang__
 #ifndef _Nonnull
     /* Clang-only nullability specifiers */
     #define _Nonnull

--- a/sources/cqlrt.h
+++ b/sources/cqlrt.h
@@ -12,6 +12,14 @@
 #include <stdint.h>
 #include <sqlite3.h>
 
+#ifdef __GNUC__
+#ifndef _Nonnull
+    /* Clang-only nullability specifiers */
+    #define _Nonnull
+    #define _Nullable
+#endif
+#endif
+
 #define cql_contract assert
 #define cql_invariant assert
 #define cql_log_database_error(...)

--- a/sources/diags.h
+++ b/sources/diags.h
@@ -34,3 +34,11 @@
 #pragma clang diagnostic error "-Wunused-variable"
 #pragma clang diagnostic error "-Wunused-function"
 #endif
+
+#ifdef __GNUC__
+#ifndef _Nonnull
+    /* Clang-only nullability specifiers */
+    #define _Nonnull
+    #define _Nullable
+#endif
+#endif

--- a/sources/diags.h
+++ b/sources/diags.h
@@ -35,7 +35,7 @@
 #pragma clang diagnostic error "-Wunused-function"
 #endif
 
-#ifdef __GNUC__
+#ifndef __clang__
 #ifndef _Nonnull
     /* Clang-only nullability specifiers */
     #define _Nonnull


### PR DESCRIPTION
Add a check for "clang nullability specifiers" and gcc, with this we don't need to define environment variables to compile with gcc and also netbeans IDE can parse correctly this project.