### PR TITLE
Coverage additions from GCC coverage on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,23 @@ The default SQLite on Ubuntu systems is also fairly old.  Some of the tests (par
 the query plan tests) use features not available in this version.  You'll want to link
 against a newer sqlite to pass all the tests.
 
+From a bare Ubuntu installation, you might need to add these components:
+
+sudo apt install
+
+* make
+* gcc
+* flex
+* bison
+* sqlite3
+* libsqlite3-dev
+* gcovr
+
+After which I was able to do the normal installations.
+
 ### Options
 
-* If you add `CGSQL_GCC` to your environment the `Makefile` will add `CFLAGS += -std=c99 -D_Nullable= -D_Nonnull=`
+* If you add `CGSQL_GCC` to your environment the `Makefile` will add `CFLAGS += -std=c99
 to try to be more interoperable with gcc.
 
 * If you add `SQLITE_PATH` to your environment the `Makefile` will try to compile `sqlite3-all.c` from that path

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -100,7 +100,7 @@
 #define FRAME_BOUNDARY_END_CURRENT_ROW   0x00800
 #define FRAME_BOUNDARY_END_FOLLOWING     0x01000
 #define FRAME_BOUNDARY_END_UNBOUNDED     0x02000
-#define FRAME_BOUNDARY_END_FLAGS         0x03F00 // bit mask for the frame spec boundary end
+#define FRAME_BOUNDARY_END_FLAGS         0x03C00 // bit mask for the frame spec boundary end
 
 #define FRAME_EXCLUDE_NO_OTHERS          0x04000
 #define FRAME_EXCLUDE_CURRENT_ROW        0x08000

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -5706,9 +5706,9 @@ static void cg_c_init(void) {
   EXPR_INIT(tilde, cg_unary, "~", C_EXPR_PRI_UNARY);
   EXPR_INIT(uminus, cg_unary, "-", C_EXPR_PRI_UNARY);
   EXPR_INIT(eq, cg_binary_compare, "==", C_EXPR_PRI_EQ_NE);
+  EXPR_INIT(ne, cg_binary_compare, "!=", C_EXPR_PRI_EQ_NE);
   EXPR_INIT(lt, cg_binary_compare, "<", C_EXPR_PRI_LT_GT);
   EXPR_INIT(gt, cg_binary_compare, ">", C_EXPR_PRI_LT_GT);
-  EXPR_INIT(ne, cg_binary_compare, "!=", C_EXPR_PRI_LT_GT);
   EXPR_INIT(ge, cg_binary_compare, ">=", C_EXPR_PRI_LT_GT);
   EXPR_INIT(le, cg_binary_compare, "<=", C_EXPR_PRI_LT_GT);
   EXPR_INIT(call, cg_expr_call, "CALL", C_EXPR_PRI_ROOT);

--- a/sources/cov.sh
+++ b/sources/cov.sh
@@ -7,7 +7,7 @@
 OUT_DIR="out"
 
 coverage() {
-  if ! sh test.sh --coverage
+  if ! ./test.sh --coverage
   then
     echo "you can't run coverage until the tests all pass"
     return 1

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -971,11 +971,11 @@ frame_boundary_start:
   UNBOUNDED PRECEDING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_UNBOUNDED), NULL); }
   | expr PRECEDING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_PRECEDING), $expr); }
   | CURRENT_ROW  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_CURRENT_ROW), NULL); }
-  | expr FOLLOWING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_CURRENT_ROW), $expr); }
+  | expr FOLLOWING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_FOLLOWING), $expr); }
   ;
 
 frame_boundary_end:
-  expr PRECEDING  { $frame_boundary_end = new_ast_frame_boundary_end($expr, new_ast_opt(FRAME_BOUNDARY_END_PRECEDING)); }
+  expr PRECEDING  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_PRECEDING), $expr); }
   | CURRENT_ROW  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_CURRENT_ROW), NULL); }
   | expr FOLLOWING  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_FOLLOWING), $expr); }
   | UNBOUNDED FOLLOWING  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_UNBOUNDED), NULL); }
@@ -1656,7 +1656,7 @@ trigger_def:
   ;
 
 trigger_condition:
-  /* nil */  { $trigger_condition = 0; }
+  /* nil */  { $trigger_condition = TRIGGER_BEFORE; /* before is the default per https://sqlite.org/lang_createtrigger.html */ }
   | BEFORE  { $trigger_condition = TRIGGER_BEFORE; }
   | AFTER  { $trigger_condition = TRIGGER_AFTER; }
   | INSTEAD OF  { $trigger_condition = TRIGGER_INSTEAD_OF; }

--- a/sources/run_test_client.c
+++ b/sources/run_test_client.c
@@ -47,9 +47,10 @@ static int32_t trace_received = 0;
 }
 
 #define E(cond_, ...) _E(cond_, SQLITE_ERROR, __VA_ARGS__)
-#define SQL_E(rc_, ...) { \
+
+#define SQL_E(rc_) { \
   cql_code __saved_rc_ = (rc_); \
-  _E(SQLITE_OK == __saved_rc_, __saved_rc_, __VA_ARGS__); \
+  _E(SQLITE_OK == __saved_rc_, __saved_rc_, "failed return code %s:%d %s\n", __FILE__, __LINE__, #rc_); \
 }
 
 cql_code mockable_sqlite3_step(sqlite3_stmt *stmt) {
@@ -67,54 +68,54 @@ cql_code run_client(sqlite3 *db) {
   E(trace_received == 1, "failure proc did not trigger a trace\n");
   E(!cql_outstanding_refs, "outstanding refs in fails_because_bogus_table: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_c_rowsets(db), NULL);
+  SQL_E(test_c_rowsets(db));
   E(!cql_outstanding_refs, "outstanding refs in test_c_rowsets: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_rowset_same(db), NULL);
+  SQL_E(test_rowset_same(db));
   E(!cql_outstanding_refs, "outstanding refs in test_rowset_same: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_blob_rowsets(db), NULL);
+  SQL_E(test_blob_rowsets(db));
   E(!cql_outstanding_refs, "outstanding refs in test_blob_rowsets: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_ref_comparisons(db), NULL);
+  SQL_E(test_ref_comparisons(db));
   E(!cql_outstanding_refs, "outstanding refs in test_ref_comparisons: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_sparse_blob_rowsets(db), NULL);
+  SQL_E(test_sparse_blob_rowsets(db));
   E(!cql_outstanding_refs, "outstanding refs in test_sparse_blob_rowsets: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_bytebuf_growth(db), NULL);
+  SQL_E(test_bytebuf_growth(db));
   E(!cql_outstanding_refs, "outstanding refs in test bytebuf growth: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_cql_finalize_on_error(db), NULL);
+  SQL_E(test_cql_finalize_on_error(db));
   E(!cql_outstanding_refs, "outstanding refs in test finalize on error: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_c_one_row_result(db), NULL);
+  SQL_E(test_c_one_row_result(db));
   E(!cql_outstanding_refs, "outstanding refs in test_c_one_row_result: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_all_column_fetchers(db), NULL);
+  SQL_E(test_all_column_fetchers(db));
   E(!cql_outstanding_refs, "outstanding refs in test_all_column_fetchers: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_error_case_rowset(db), NULL);
+  SQL_E(test_error_case_rowset(db));
   E(!cql_outstanding_refs, "outstanding refs in test_error_case_rowset: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_autodrop_rowset(db), NULL);
+  SQL_E(test_autodrop_rowset(db));
   E(!cql_outstanding_refs, "outstanding refs in test_autodrop_rowset (run 1): %d\n", cql_outstanding_refs);
 
-  SQL_E(test_autodrop_rowset(db), NULL);
+  SQL_E(test_autodrop_rowset(db));
   E(!cql_outstanding_refs, "outstanding refs in test_autodrop_rowset (run 2): %d\n", cql_outstanding_refs);
 
-  SQL_E(test_one_row_result(db), NULL);
+  SQL_E(test_one_row_result(db));
   E(!cql_outstanding_refs, "outstanding refs in one_row_result: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_cql_bytebuf_open(db), NULL);
+  SQL_E(test_cql_bytebuf_open(db));
   E(!cql_outstanding_refs, "outstanding refs in test_cql_bytebuf_open: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_cql_bytebuf_alloc_within_bytebuf_exp_growth_cap(db), NULL);
+  SQL_E(test_cql_bytebuf_alloc_within_bytebuf_exp_growth_cap(db));
   E(!cql_outstanding_refs,
     "outstanding refs in test_cql_bytebuf_alloc_within_bytebuf_exp_growth_cap: %d\n",
     cql_outstanding_refs);
 
-  SQL_E(test_cql_bytebuf_alloc_over_bytebuf_exp_growth_cap(db), NULL);
+  SQL_E(test_cql_bytebuf_alloc_over_bytebuf_exp_growth_cap(db));
   E(!cql_outstanding_refs,
     "outstanding refs in test_cql_bytebuf_alloc_over_bytebuf_exp_growth_cap: %d\n",
     cql_outstanding_refs);
@@ -146,13 +147,13 @@ cql_code test_c_rowsets(sqlite3 *db) {
   tests++;
 
   // we haven't created the table yet
-  SQL_E(drop_mixed(db), "error cleaning up mixed table");
+  SQL_E(drop_mixed(db));
   get_mixed_result_set_ref result_set;
   E(SQLITE_OK != get_mixed_fetch_results(db, &result_set, 100), "table didn't exist, yet there was data...\n");
 
-  SQL_E(make_mixed(db), "failed creating table\n");
-  SQL_E(load_mixed_with_nulls(db), "failed loading table\n");
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100), "data access failed\n");
+  SQL_E(make_mixed(db));
+  SQL_E(load_mixed_with_nulls(db));
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100));
 
   cql_int32 count = get_mixed_result_count(result_set);
   E(count == 4, "expected 4 rows from mixed\n");
@@ -259,26 +260,25 @@ cql_code test_rowset_same(sqlite3 *db) {
   cql_string_ref updated_name = string_create();
   cql_blob_ref updated_bl = blob_from_string(updated_name);
 
-  SQL_E(drop_mixed(db), "error cleaning up mixed table");
-  SQL_E(make_mixed(db), "failed creating table\n");
-  SQL_E(load_mixed_with_nulls(db), "failed loading table\n");
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100), "data access failed\n");
+  SQL_E(drop_mixed(db));
+  SQL_E(make_mixed(db));
+  SQL_E(load_mixed_with_nulls(db));
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100));
 
   // Update row 0 with just a new name, so the identity columns should still match the previous result set
   SQL_E(update_mixed(db,
                      get_mixed_get_id(result_set, 0),
                      updated_name,
                      get_nullable_code(result_set, 0),
-                     get_mixed_get_bl(result_set, 0)),
-        "updating mixed row 0 failed\n");
+                     get_mixed_get_bl(result_set, 0)));
+        
 
   // Update row 1 with just a new code, so only 1 of the identity columns should not match the previous result set
   SQL_E(update_mixed(db,
                      get_mixed_get_id(result_set, 1),
                      get_mixed_get_name(result_set, 1),
                      make_nullable_code(0, 1234),
-                     get_mixed_get_bl(result_set, 1)),
-        "updating mixed row 1 failed\n");
+                     get_mixed_get_bl(result_set, 1)));
 
   // Update row 2 with just a new bl, so a ref type identity column should not match the previous result set
   // This also is testing that the last column in the identity columns is properly tested.
@@ -286,11 +286,10 @@ cql_code test_rowset_same(sqlite3 *db) {
                      get_mixed_get_id(result_set, 2),
                      get_mixed_get_name(result_set, 2),
                      get_nullable_code(result_set, 2),
-                     updated_bl),
-        "updating mixed row 2 failed\n");
+                     updated_bl));
 
   // Get the updated result set
-  SQL_E(get_mixed_fetch_results(db, &result_set_updated, 100), "updated data access failed\n");
+  SQL_E(get_mixed_fetch_results(db, &result_set_updated, 100));
 
   E(get_mixed_row_same(result_set, 0, result_set_updated, 0),
     "updated row 0 should be the same as original row 0 (identity column check)\n");
@@ -316,9 +315,9 @@ cql_code test_ref_comparisons(sqlite3 *db) {
 
   // we haven't created the table yet
   get_mixed_result_set_ref result_set;
-  SQL_E(load_mixed_dupes(db), "failed loading table\n");
+  SQL_E(load_mixed_dupes(db));
 
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100), "data access failed\n");
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100));
   E(get_mixed_result_count(result_set) == 6, "expected 6 rows from mixed\n");
 
   // Check that the row hashes are equal from the source to the copy
@@ -342,10 +341,10 @@ cql_code test_bytebuf_growth(sqlite3 *db) {
   tests++;
   printf("Running C client test with huge number of rows\n");
 
-  SQL_E(bulk_load_mixed(db, 10000), "failed loading table\n");
+  SQL_E(bulk_load_mixed(db, 10000));
 
   get_mixed_result_set_ref result_set;
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100000), "data access failed\n");
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100000));
   E(get_mixed_result_count(result_set) == 10000, "expected 10000 rows from mixed\n");
 
   cql_result_set_release(result_set);
@@ -359,10 +358,10 @@ cql_code test_cql_finalize_on_error(sqlite3 *db) {
   tests++;
 
   expectations++;
-  SQL_E(load_mixed(db), "failed loading table\n");
+  SQL_E(load_mixed(db));
 
   sqlite3_stmt *stmt = NULL;
-  SQL_E(sqlite3_prepare_v2(db, "select * from sqlite_master", -1, &stmt, NULL), "stmt prepare failed\n");
+  SQL_E(sqlite3_prepare_v2(db, "select * from sqlite_master", -1, &stmt, NULL));
 
   cql_finalize_on_error(SQLITE_ERROR,&stmt);
   E(stmt == NULL, "expected statement to be finalized\n");
@@ -473,10 +472,10 @@ cql_code test_blob_rowsets(sqlite3 *db) {
   printf("Running blob rowset test\n");
   tests++;
 
-  SQL_E(load_blobs(db), "failed creating blob_table\n");
+  SQL_E(load_blobs(db));
 
   get_blob_table_result_set_ref result_set;
-  SQL_E(get_blob_table_fetch_results(db, &result_set), "blob table data access failed\n");
+  SQL_E(get_blob_table_fetch_results(db, &result_set));
 
   E(get_blob_table_result_count(result_set) == 20, "expected 20 rows from blob table\n");
 
@@ -511,10 +510,10 @@ cql_code test_sparse_blob_rowsets(sqlite3 *db) {
   printf("Running sparse blob rowset test\n");
   tests++;
 
-  SQL_E(load_sparse_blobs(db), "failed creating blob_table\n");
+  SQL_E(load_sparse_blobs(db));
 
   get_blob_table_result_set_ref result_set;
-  SQL_E(get_blob_table_fetch_results(db, &result_set), "blob table data access failed\n");
+  SQL_E(get_blob_table_fetch_results(db, &result_set));
 
   E(get_blob_table_result_count(result_set) == 20, "expected 20 rows from blob table\n");
 
@@ -561,15 +560,15 @@ cql_code test_c_one_row_result(sqlite3 *db) {
   printf("Running C one row result set test\n");
   tests++;
 
-  SQL_E(drop_mixed(db), "error cleaning up mixed table");
+  SQL_E(drop_mixed(db));
 
   // we haven't created the table yet
   get_one_from_mixed_result_set_ref result_set;
   E(SQLITE_OK != get_one_from_mixed_fetch_results(db, &result_set, 1), "table didn't exist, yet there was data...\n");
-  SQL_E(make_mixed(db), "failed creating table\n");
-  SQL_E(load_mixed_with_nulls(db), "failed loading table\n");
+  SQL_E(make_mixed(db));
+  SQL_E(load_mixed_with_nulls(db));
 
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 1), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 1));
   E(get_one_from_mixed_result_count(result_set) == 1, "expected 1 rows from mixed\n");
 
   cql_bool b_is_null;
@@ -592,7 +591,7 @@ cql_code test_c_one_row_result(sqlite3 *db) {
 
   // Compare to a result from a row with different values
   get_one_from_mixed_result_set_ref result_set2;
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 2), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 2));
   E(get_one_from_mixed_result_count(result_set2) == 1, "expected 1 rows from mixed\n");
 
   cql_bool b_is_null2;
@@ -629,7 +628,7 @@ cql_code test_c_one_row_result(sqlite3 *db) {
   cql_result_set_release(result_set2);
 
   // Compare results fetched from the same row
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 1), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 1));
 
   E(get_one_from_mixed_equal(result_set, result_set2), "result sets for same row are not equal\n");
   E(get_one_from_mixed_hash(result_set) == get_one_from_mixed_hash(result_set2),
@@ -638,7 +637,7 @@ cql_code test_c_one_row_result(sqlite3 *db) {
   cql_result_set_release(result_set);
   cql_result_set_release(result_set2);
 
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 999), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 999));
   E(get_one_from_mixed_result_count(result_set) == 0, "expected 0 rows from mixed\n");
 
   cql_result_set_release(result_set);
@@ -652,7 +651,7 @@ cql_code test_all_column_fetchers(sqlite3 *db) {
   tests++;
 
   load_all_types_table_result_set_ref result_set;
-  SQL_E(load_all_types_table_fetch_results(db, &result_set), "all types table data access failed\n");
+  SQL_E(load_all_types_table_fetch_results(db, &result_set));
   E(load_all_types_table_result_count(result_set) == 2, "expected 2 rows from result table\n");
   E(cql_result_set_get_meta(result_set)->columnCount == 12, "expected 12 columns from result table\n");
   cql_result_set_ref rs = (cql_result_set_ref)result_set;
@@ -732,7 +731,7 @@ cql_code test_error_case_rowset(sqlite3 *db) {
   printf("Running error case rowset test\n");
   tests++;
 
-  SQL_E(load_sparse_blobs(db), "failed creating blob_table\n");
+  SQL_E(load_sparse_blobs(db));
 
   steps_until_fail = 5;
 
@@ -753,7 +752,7 @@ cql_code test_autodrop_rowset(sqlite3 *db) {
 
   read_three_tables_and_autodrop_result_set_ref result_set;
 
-  SQL_E(SQLITE_OK != read_three_tables_and_autodrop_fetch_results(db, &result_set), "failed reading from temp tables\n");
+  SQL_E(SQLITE_OK != read_three_tables_and_autodrop_fetch_results(db, &result_set));
 
   for (cql_int32 i = 0; i < 3; i++) {
     int32_t id = read_three_tables_and_autodrop_get_id(result_set, i);

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -2867,6 +2867,121 @@ set x := 1 | (2 << 3);
 -- + x = 1 << (2 << 3);
 set x := 1 << (2 << 3);
 
+-- + x = 1 < (2 > 3);
+set x := 1 < (2 > 3);
+
+-- + x = 1 << (2 >> 3);
+set x := 1 << (2 >> 3);
+
+-- + x = 1 | (2 | 3);
+set x := 1 | (2 | 3);
+
+-- + x = 1 | 2 | 3;
+set x := (1 | 2) | 3;
+
+-- + x = 1 == (2 != 3);
+set x := 1 == (2 != 3);
+
+create table SalesInfo(
+  month integer,
+  amount real
+);
+
+-- TEST: ORDERBY BETWEEN PRECEEDING AND FOLLOWING NO FILTER NO EXCLUDE
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: simple OVER and ORDER BY
+-- + SUM(amount) OVER (ORDER BY month) AS RunningTotal
+SELECT month, amount, SUM(amount) OVER
+  (ORDER BY month) RunningTotal
+FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude no others
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude no others with FILTER
+-- + AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) FILTER(WHERE month = 1) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude current row
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude group
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: RANGE expr preceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS expr preceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS unbounded proceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS expr following and expr preceeding 
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS between current row and unbounded following
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS between unbounded preceding and current row with no exclude
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS between unbounded preceding and current row with exclude ties
+-- +  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: correct parse and re-emit of CURRENT_ROW
+-- + AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: correct parse and re-emit of CURRENT_ROW
+-- + AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (GROUPS CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
 
 --------------------------------------------------------------------
 -------------------- add new tests before this point ---------------

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -8610,6 +8610,249 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET x := 1 << (2 << 3);
   */
   x = 1 << (2 << 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 < (2 > 3);
+  */
+  x = 1 < (2 > 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 << (2 >> 3);
+  */
+  x = 1 << (2 >> 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | (2 | 3);
+  */
+  x = 1 | (2 | 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | 2 | 3;
+  */
+  x = 1 | 2 | 3;
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 = 2 <> 3;
+  */
+  x = 1 == (2 != 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    SUM(amount) OVER (ORDER BY month) AS RunningTotal
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "SUM(amount) OVER (ORDER BY month) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (GROUPS CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
 cql_cleanup:
   cql_string_release(t0_nullable);

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -1798,6 +1798,48 @@ extern cql_int32 x;
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern void end_proc(void);
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -8610,6 +8610,249 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET x := 1 << (2 << 3);
   */
   x = 1 << (2 << 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 < (2 > 3);
+  */
+  x = 1 < (2 > 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 << (2 >> 3);
+  */
+  x = 1 << (2 >> 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | (2 | 3);
+  */
+  x = 1 | (2 | 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | 2 | 3;
+  */
+  x = 1 | 2 | 3;
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 = 2 <> 3;
+  */
+  x = 1 == (2 != 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    SUM(amount) OVER (ORDER BY month) AS RunningTotal
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "SUM(amount) OVER (ORDER BY month) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (GROUPS CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
 cql_cleanup:
   cql_string_release(t0_nullable);

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -1798,6 +1798,48 @@ extern cql_int32 x;
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern void end_proc(void);
 
 // The statement ending at line XXXX

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -2778,6 +2778,23 @@ BEGIN_TEST(cursor_args)
   call dummy(from args);
 END_TEST(cursor_args)
 
+DECLARE PROCEDURE cql_exec_internal(sql TEXT NOT NULL) USING TRANSACTION;
+create table xyzzy(id integer, name text);
+
+BEGIN_TEST(exec_internal)
+  call cql_exec_internal("create table xyzzy(id integer, name text);");
+  insert into xyzzy using 1 id, 'x' name;
+  insert into xyzzy using 2 id, 'y' name;
+  declare C cursor for select * from xyzzy;
+  declare D cursor like C;
+  fetch C;
+  fetch D using 1 id, 'x' name;
+  EXPECT(cql_cursor_diff_val(C,D) is null);
+  fetch C;
+  fetch D using 2 id, 'y' name;
+  EXPECT(cql_cursor_diff_val(C,D) is null);
+END_TEST(exec_internal)
+
 END_SUITE()
 
 -- manually force tracing on by redefining the macros

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -892,4 +892,8 @@ Error at test/sem_test.sql:XXXX : in proc_savepoint_stmt : CQL0351: statement sh
 Error at test/sem_test.sql:XXXX : in rollback_return_stmt : CQL0350: statement must appear inside of a PROC SAVEPOINT block
 Error at test/sem_test.sql:XXXX : in commit_return_stmt : CQL0350: statement must appear inside of a PROC SAVEPOINT block
 Error at test/sem_test.sql:XXXX : in return_stmt : CQL0352: use COMMIT RETURN or ROLLBACK RETURN in within a proc savepoint block
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
 semantic errors present; no code gen.

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -40890,7 +40890,7 @@ SELECT id,
 The statement ending at line XXXX
 
 SELECT id, 
-  row_number() OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW UNBOUNDED FOLLOWINGEXCLUDE GROUP)
+  row_number() OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING EXCLUDE GROUP)
   FROM foo;
 
   {select_stmt}: select: { id: integer notnull, _anon: integer notnull }
@@ -50464,4 +50464,257 @@ Error at test/sem_test.sql:XXXX : in return_stmt : CQL0352: use COMMIT RETURN or
       | {proc_savepoint_stmt}: err
         | {stmt_list}: err
           | {return_stmt}: err
+
+The statement ending at line XXXX
+
+CREATE TABLE SalesInfo(
+  month INTEGER,
+  amount REAL
+);
+
+  {create_table_stmt}: SalesInfo: { month: integer, amount: real }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name SalesInfo}
+  | {col_key_list}
+    | {col_def}: month: integer
+    | | {col_def_type_attrs}
+    |   | {col_def_name_type}
+    |     | {name month}
+    |     | {type_int}: integer
+    | {col_key_list}
+      | {col_def}: amount: real
+        | {col_def_type_attrs}
+          | {col_def_name_type}
+            | {name amount}
+            | {type_real}: real
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND sum(month) FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: amount: real
+  |     |       | | | {name AVG}: amount: real
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | {arg_list}: ok
+  |     |       | |     | {name amount}: amount: real
+  |     |       | | {window_defn}: err
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_orderby}: ok
+  |     |       |     | | {groupby_list}: ok
+  |     |       |     |   | {groupby_item}
+  |     |       |     |     | {name month}: month: integer
+  |     |       |     | {opt_frame_spec}: err
+  |     |       |       | {int 266370}
+  |     |       |       | {expr_list}
+  |     |       |         | {int 1}: integer notnull
+  |     |       |         | {call}: err
+  |     |       |           | {name sum}
+  |     |       |           | {call_arg_list}
+  |     |       |             | {call_filter_clause}
+  |     |       |             | {arg_list}: ok
+  |     |       |               | {name month}: month: integer
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) OVER (PARTITION BY sum(month) ROWS BETWEEN 1 PRECEDING AND 3 FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: amount: real
+  |     |       | | | {name AVG}: amount: real
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | {arg_list}: ok
+  |     |       | |     | {name amount}: amount: real
+  |     |       | | {window_defn}: err
+  |     |       |   | {opt_partition_by}: err
+  |     |       |   | | {expr_list}: err
+  |     |       |   |   | {call}: err
+  |     |       |   |     | {name sum}
+  |     |       |   |     | {call_arg_list}
+  |     |       |   |       | {call_filter_clause}
+  |     |       |   |       | {arg_list}: ok
+  |     |       |   |         | {name month}: month: integer
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_frame_spec}: ok
+  |     |       |       | {int 266370}
+  |     |       |       | {expr_list}
+  |     |       |         | {int 1}: integer notnull
+  |     |       |         | {int 3}: integer notnull
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN sum(month) PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: amount: real
+  |     |       | | | {name AVG}: amount: real
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | {arg_list}: ok
+  |     |       | |     | {name amount}: amount: real
+  |     |       | | {window_defn}: err
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_orderby}: ok
+  |     |       |     | | {groupby_list}: ok
+  |     |       |     |   | {groupby_item}
+  |     |       |     |     | {name month}: month: integer
+  |     |       |     | {opt_frame_spec}: err
+  |     |       |       | {int 266370}
+  |     |       |       | {expr_list}
+  |     |       |         | {call}: err
+  |     |       |         | | {name sum}
+  |     |       |         | | {call_arg_list}
+  |     |       |         |   | {call_filter_clause}
+  |     |       |         |   | {arg_list}: ok
+  |     |       |         |     | {name month}: month: integer
+  |     |       |         | {int 1}: integer notnull
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) FILTER (WHERE sum(month) = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: err
+  |     |       | | | {name AVG}
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | | {opt_filter_clause}: err
+  |     |       | |   |   | {opt_where}: err
+  |     |       | |   |     | {eq}: err
+  |     |       | |   |       | {call}: err
+  |     |       | |   |       | | {name sum}
+  |     |       | |   |       | | {call_arg_list}
+  |     |       | |   |       |   | {call_filter_clause}
+  |     |       | |   |       |   | {arg_list}: ok
+  |     |       | |   |       |     | {name month}: month: integer
+  |     |       | |   |       | {int 1}: integer notnull
+  |     |       | |   | {arg_list}
+  |     |       | |     | {name amount}
+  |     |       | | {window_defn}: ok
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_orderby}: ok
+  |     |       |     | | {groupby_list}: ok
+  |     |       |     |   | {groupby_item}
+  |     |       |     |     | {name month}: month: integer
+  |     |       |     | {opt_frame_spec}: ok
+  |     |       |       | {int 20610}
+  |     |       |       | {expr_list}
+  |     |       |         | {int 1}: integer notnull
+  |     |       |         | {int 2}: integer notnull
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
 

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -12503,3 +12503,35 @@ begin
    end;
 end;
 
+create table SalesInfo(
+  month integer,
+  amount real
+);
+
+-- TEST: sum is not allowed in a window range
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND sum(month) FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: sum is not allowed in a window range
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) OVER
+  (PARTITION BY sum(month) ROWS BETWEEN 1 PRECEDING AND 3 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: sum is not allowed in a window range
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN sum(month) PRECEDING AND 1 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: sum is not allowed in a filter expression
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) FILTER(WHERE sum(month) = 1) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -949,6 +949,14 @@ BEGIN
   SELECT a_result;
 END;
 
+CREATE TEMP TRIGGER IF NOT EXISTS trigger1
+  BEFORE DELETE ON target_table1
+  FOR EACH ROW
+  WHEN complex_when_expression
+BEGIN
+  SELECT a_result;
+END;
+
 CREATE TRIGGER trigger2
   AFTER INSERT ON target_table2
 BEGIN
@@ -1184,6 +1192,94 @@ BEGIN
     END IF;
   END;
 END;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  SUM(amount) OVER (ORDER BY month) AS RunningTotal
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (PARTITION BY something ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SET trigger := 1;
+
+DECLARE x INTEGER NOT NULL @SENSITIVE;
+
+DECLARE x INTEGER NOT NULL @SENSITIVE;
+
+SET z := 1 BETWEEN (1 & 2) AND 3;
+
+SET z := 1 BETWEEN (1 | 2) AND 3;
+
+SET z := 1 BETWEEN (1 << 2) AND 3;
+
+SET z := 1 BETWEEN (1 >> 2) AND 3;
+
+SET z := 1 BETWEEN 1 + 2 AND 3;
+
+SET z := 1 BETWEEN 1 - 2 AND 3;
+
+SET z := 1 BETWEEN 1 * 2 AND 3;
+
+SET z := 1 BETWEEN 1 / 2 AND 3;
+
+SET z := 1 BETWEEN 1 % 2 AND 3;
+
+SET z := 1 BETWEEN -1 AND 3;
+
+SET z := 1 BETWEEN 'x' || 'y' AND 'z';
 
 SET file := 'path/I/do/not/like';
 

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -926,6 +926,14 @@ begin
   select a_result;
 end;
 
+create temp trigger if not exists trigger1
+   delete on target_table1
+   for each row
+   when complex_when_expression
+begin
+  select a_result;
+end;
+
 create trigger trigger2
    after insert on target_table2
 begin
@@ -1111,7 +1119,7 @@ create table foo
 
 create proc foo()
 begin
-  proc savepoint 
+  proc savepoint
   begin
      if 1 then
        rollback return;
@@ -1120,6 +1128,84 @@ begin
      end if;
   end;
 end;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, SUM(amount) OVER
+  (ORDER BY month) RunningTotal
+FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (PARTITION BY something ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (GROUPS CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+/* test trigger is a valid name */
+set trigger := 1;
+
+declare x integer not null @sensitive;
+declare x integer @sensitive not null;
+
+set z := 1 between 1 & 2 and 3;
+set z := 1 between 1 | 2 and 3;
+set z := 1 between 1 << 2 and 3;
+set z := 1 between 1 >> 2 and 3;
+set z := 1 between 1 + 2 and 3;
+set z := 1 between 1 - 2 and 3;
+set z := 1 between 1 * 2 and 3;
+set z := 1 between 1 / 2 and 3;
+set z := 1 between 1 % 2 and 3;
+set z := 1 between -1 and 3;
+set z := 1 between 'x' || 'y' and 'z';
 
 --- keep this at the end because the line numbers will be whack after this so syntax errors will be annoying...
 


### PR DESCRIPTION
There were a number of missing lines of coverage in cql.y that were discovered by gcc on Ubuntu.  This led to examining the WINDOW family of functions and adding test cases to parse them and generate their output.  There were several bugs in this code mostly to do with handling of spacing but a few where the AST was wrong.