### PR TITLE
Adding support for "x like shape, y like shape" in procedure arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,14 @@ sudo apt install
 * bison
 * sqlite3
 * libsqlite3-dev
-* gcovr
 
 After which I was able to do the normal installations.
+
+For the coverage build you need
+* gcovr
+
+And if you want to do the AST visualizations in PNG form you need
+* graphviz
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,23 @@ The default SQLite on Ubuntu systems is also fairly old.  Some of the tests (par
 the query plan tests) use features not available in this version.  You'll want to link
 against a newer sqlite to pass all the tests.
 
+From a bare Ubuntu installation, you might need to add these components:
+
+sudo apt install
+
+* make
+* gcc
+* flex
+* bison
+* sqlite3
+* libsqlite3-dev
+* gcovr
+
+After which I was able to do the normal installations.
+
 ### Options
 
-* If you add `CGSQL_GCC` to your environment the `Makefile` will add `CFLAGS += -std=c99 -D_Nullable= -D_Nonnull=`
+* If you add `CGSQL_GCC` to your environment the `Makefile` will add `CFLAGS += -std=c99
 to try to be more interoperable with gcc.
 
 * If you add `SQLITE_PATH` to your environment the `Makefile` will try to compile `sqlite3-all.c` from that path

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -100,7 +100,7 @@
 #define FRAME_BOUNDARY_END_CURRENT_ROW   0x00800
 #define FRAME_BOUNDARY_END_FOLLOWING     0x01000
 #define FRAME_BOUNDARY_END_UNBOUNDED     0x02000
-#define FRAME_BOUNDARY_END_FLAGS         0x03F00 // bit mask for the frame spec boundary end
+#define FRAME_BOUNDARY_END_FLAGS         0x03C00 // bit mask for the frame spec boundary end
 
 #define FRAME_EXCLUDE_NO_OTHERS          0x04000
 #define FRAME_EXCLUDE_CURRENT_ROW        0x08000

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -5706,9 +5706,9 @@ static void cg_c_init(void) {
   EXPR_INIT(tilde, cg_unary, "~", C_EXPR_PRI_UNARY);
   EXPR_INIT(uminus, cg_unary, "-", C_EXPR_PRI_UNARY);
   EXPR_INIT(eq, cg_binary_compare, "==", C_EXPR_PRI_EQ_NE);
+  EXPR_INIT(ne, cg_binary_compare, "!=", C_EXPR_PRI_EQ_NE);
   EXPR_INIT(lt, cg_binary_compare, "<", C_EXPR_PRI_LT_GT);
   EXPR_INIT(gt, cg_binary_compare, ">", C_EXPR_PRI_LT_GT);
-  EXPR_INIT(ne, cg_binary_compare, "!=", C_EXPR_PRI_LT_GT);
   EXPR_INIT(ge, cg_binary_compare, ">=", C_EXPR_PRI_LT_GT);
   EXPR_INIT(le, cg_binary_compare, "<=", C_EXPR_PRI_LT_GT);
   EXPR_INIT(call, cg_expr_call, "CALL", C_EXPR_PRI_ROOT);

--- a/sources/cov.sh
+++ b/sources/cov.sh
@@ -7,7 +7,7 @@
 OUT_DIR="out"
 
 coverage() {
-  if ! sh test.sh --coverage
+  if ! ./test.sh --coverage
   then
     echo "you can't run coverage until the tests all pass"
     return 1

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -207,7 +207,7 @@ static void cql_reset_globals(void);
 
 /* proc stuff */
 %type <aval> create_proc_stmt declare_func_stmt declare_proc_stmt
-%type <aval> arg_expr arg_list opt_inout param params
+%type <aval> arg_expr arg_list inout param params
 
 /* statements */
 %type <aval> stmt
@@ -1422,16 +1422,16 @@ create_proc_stmt:
     $create_proc_stmt = new_ast_create_proc_stmt($name, new_ast_proc_params_stmts($params, $opt_stmt_list)); }
   ;
 
-opt_inout:
-  /* nil */  { $opt_inout = NULL ; }
-  | IN  { $opt_inout = new_ast_in(); }
-  | OUT  { $opt_inout = new_ast_out(); }
-  | INOUT  { $opt_inout = new_ast_inout(); }
+inout:
+  IN  { $inout = new_ast_in(); }
+  | OUT  { $inout = new_ast_out(); }
+  | INOUT  { $inout = new_ast_inout(); }
   ;
 
 typed_name:
   name data_type_opt_notnull  { $typed_name = new_ast_typed_name($name, $data_type_opt_notnull); }
-  | shape_def  { $typed_name = $shape_def; }
+  | shape_def  { $typed_name = new_ast_typed_name(NULL, $shape_def); }
+  | name shape_def  { $typed_name = new_ast_typed_name($name, $shape_def); }
   ;
 
 typed_names[result]:
@@ -1440,8 +1440,10 @@ typed_names[result]:
   ;
 
 param:
-  opt_inout name data_type_opt_notnull  { $param = new_ast_param($opt_inout, new_ast_param_detail($name, $data_type_opt_notnull)); }
-  | shape_def  { $param = new_ast_param($shape_def, NULL); }
+  name data_type_opt_notnull  { $param = new_ast_param(NULL, new_ast_param_detail($name, $data_type_opt_notnull)); }
+  | inout name data_type_opt_notnull  { $param = new_ast_param($inout, new_ast_param_detail($name, $data_type_opt_notnull)); }
+  | shape_def  { $param = new_ast_param(NULL, new_ast_param_detail(NULL, $shape_def)); }
+  | name shape_def  { $param = new_ast_param(NULL, new_ast_param_detail($name, $shape_def)); }
   ;
 
 params[result]:

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -971,11 +971,11 @@ frame_boundary_start:
   UNBOUNDED PRECEDING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_UNBOUNDED), NULL); }
   | expr PRECEDING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_PRECEDING), $expr); }
   | CURRENT_ROW  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_CURRENT_ROW), NULL); }
-  | expr FOLLOWING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_CURRENT_ROW), $expr); }
+  | expr FOLLOWING  { $frame_boundary_start = new_ast_frame_boundary_start(new_ast_opt(FRAME_BOUNDARY_START_FOLLOWING), $expr); }
   ;
 
 frame_boundary_end:
-  expr PRECEDING  { $frame_boundary_end = new_ast_frame_boundary_end($expr, new_ast_opt(FRAME_BOUNDARY_END_PRECEDING)); }
+  expr PRECEDING  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_PRECEDING), $expr); }
   | CURRENT_ROW  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_CURRENT_ROW), NULL); }
   | expr FOLLOWING  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_FOLLOWING), $expr); }
   | UNBOUNDED FOLLOWING  { $frame_boundary_end = new_ast_frame_boundary_end(new_ast_opt(FRAME_BOUNDARY_END_UNBOUNDED), NULL); }
@@ -1656,7 +1656,7 @@ trigger_def:
   ;
 
 trigger_condition:
-  /* nil */  { $trigger_condition = 0; }
+  /* nil */  { $trigger_condition = TRIGGER_BEFORE; /* before is the default per https://sqlite.org/lang_createtrigger.html */ }
   | BEFORE  { $trigger_condition = TRIGGER_BEFORE; }
   | AFTER  { $trigger_condition = TRIGGER_AFTER; }
   | INSTEAD OF  { $trigger_condition = TRIGGER_INSTEAD_OF; }

--- a/sources/dotpng.sh
+++ b/sources/dotpng.sh
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-./out/cql --dot < "$1" > "out/$1.dot"
-dot "out/$1.dot" -Tpng -o "out/$1.png"
+./out/cql --dot < "$1" > "out/$1.dot" || exit 1
+dot "out/$1.dot" -Tpng -o "out/$1.png" || exit 1
 echo "Created out/$1.dot and made out/$1.png with it."
 open "out/$1.png"

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -2322,12 +2322,22 @@ static void gen_normal_param(ast_node *ast) {
 
 static void gen_like_param(ast_node *ast) {
   Contract(is_ast_param(ast));
-  EXTRACT_NOTNULL(like, ast->left);
+  EXTRACT_NOTNULL(param_detail, ast->right);
+  EXTRACT_NOTNULL(like, param_detail->right);
+
+  if (param_detail->left) {
+    EXTRACT_STRING(name, param_detail->left);
+    gen_printf("%s ", name);
+  }
+
   gen_shape_def(like);
 }
 
 static void gen_param(ast_node *ast) {
-  if (is_ast_like(ast->left)) {
+  Contract(is_ast_param(ast));
+
+  EXTRACT_NOTNULL(param_detail, ast->right);
+  if (is_ast_like(param_detail->right)) {
     gen_like_param(ast);
   }
   else {
@@ -2426,13 +2436,17 @@ cql_noexport void gen_declare_proc_from_create_proc(ast_node *ast) {
 }
 
 static void gen_typed_name(ast_node *ast) {
-  if (is_ast_like(ast)) {
-    gen_shape_def(ast);
-  }
-  else {
-    EXTRACT(typed_name, ast);
+  EXTRACT(typed_name, ast);
+
+  if (typed_name->left) {
     EXTRACT_STRING(name, typed_name->left);
     gen_printf("%s ", name);
+  }
+
+  if (is_ast_like(typed_name->right)) {
+    gen_shape_def(typed_name->right);
+  }
+  else {
     gen_data_type(typed_name->right);
   }
 }

--- a/sources/run_test_client.c
+++ b/sources/run_test_client.c
@@ -47,9 +47,10 @@ static int32_t trace_received = 0;
 }
 
 #define E(cond_, ...) _E(cond_, SQLITE_ERROR, __VA_ARGS__)
-#define SQL_E(rc_, ...) { \
+
+#define SQL_E(rc_) { \
   cql_code __saved_rc_ = (rc_); \
-  _E(SQLITE_OK == __saved_rc_, __saved_rc_, __VA_ARGS__); \
+  _E(SQLITE_OK == __saved_rc_, __saved_rc_, "failed return code %s:%d %s\n", __FILE__, __LINE__, #rc_); \
 }
 
 cql_code mockable_sqlite3_step(sqlite3_stmt *stmt) {
@@ -67,54 +68,54 @@ cql_code run_client(sqlite3 *db) {
   E(trace_received == 1, "failure proc did not trigger a trace\n");
   E(!cql_outstanding_refs, "outstanding refs in fails_because_bogus_table: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_c_rowsets(db), NULL);
+  SQL_E(test_c_rowsets(db));
   E(!cql_outstanding_refs, "outstanding refs in test_c_rowsets: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_rowset_same(db), NULL);
+  SQL_E(test_rowset_same(db));
   E(!cql_outstanding_refs, "outstanding refs in test_rowset_same: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_blob_rowsets(db), NULL);
+  SQL_E(test_blob_rowsets(db));
   E(!cql_outstanding_refs, "outstanding refs in test_blob_rowsets: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_ref_comparisons(db), NULL);
+  SQL_E(test_ref_comparisons(db));
   E(!cql_outstanding_refs, "outstanding refs in test_ref_comparisons: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_sparse_blob_rowsets(db), NULL);
+  SQL_E(test_sparse_blob_rowsets(db));
   E(!cql_outstanding_refs, "outstanding refs in test_sparse_blob_rowsets: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_bytebuf_growth(db), NULL);
+  SQL_E(test_bytebuf_growth(db));
   E(!cql_outstanding_refs, "outstanding refs in test bytebuf growth: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_cql_finalize_on_error(db), NULL);
+  SQL_E(test_cql_finalize_on_error(db));
   E(!cql_outstanding_refs, "outstanding refs in test finalize on error: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_c_one_row_result(db), NULL);
+  SQL_E(test_c_one_row_result(db));
   E(!cql_outstanding_refs, "outstanding refs in test_c_one_row_result: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_all_column_fetchers(db), NULL);
+  SQL_E(test_all_column_fetchers(db));
   E(!cql_outstanding_refs, "outstanding refs in test_all_column_fetchers: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_error_case_rowset(db), NULL);
+  SQL_E(test_error_case_rowset(db));
   E(!cql_outstanding_refs, "outstanding refs in test_error_case_rowset: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_autodrop_rowset(db), NULL);
+  SQL_E(test_autodrop_rowset(db));
   E(!cql_outstanding_refs, "outstanding refs in test_autodrop_rowset (run 1): %d\n", cql_outstanding_refs);
 
-  SQL_E(test_autodrop_rowset(db), NULL);
+  SQL_E(test_autodrop_rowset(db));
   E(!cql_outstanding_refs, "outstanding refs in test_autodrop_rowset (run 2): %d\n", cql_outstanding_refs);
 
-  SQL_E(test_one_row_result(db), NULL);
+  SQL_E(test_one_row_result(db));
   E(!cql_outstanding_refs, "outstanding refs in one_row_result: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_cql_bytebuf_open(db), NULL);
+  SQL_E(test_cql_bytebuf_open(db));
   E(!cql_outstanding_refs, "outstanding refs in test_cql_bytebuf_open: %d\n", cql_outstanding_refs);
 
-  SQL_E(test_cql_bytebuf_alloc_within_bytebuf_exp_growth_cap(db), NULL);
+  SQL_E(test_cql_bytebuf_alloc_within_bytebuf_exp_growth_cap(db));
   E(!cql_outstanding_refs,
     "outstanding refs in test_cql_bytebuf_alloc_within_bytebuf_exp_growth_cap: %d\n",
     cql_outstanding_refs);
 
-  SQL_E(test_cql_bytebuf_alloc_over_bytebuf_exp_growth_cap(db), NULL);
+  SQL_E(test_cql_bytebuf_alloc_over_bytebuf_exp_growth_cap(db));
   E(!cql_outstanding_refs,
     "outstanding refs in test_cql_bytebuf_alloc_over_bytebuf_exp_growth_cap: %d\n",
     cql_outstanding_refs);
@@ -146,13 +147,13 @@ cql_code test_c_rowsets(sqlite3 *db) {
   tests++;
 
   // we haven't created the table yet
-  SQL_E(drop_mixed(db), "error cleaning up mixed table");
+  SQL_E(drop_mixed(db));
   get_mixed_result_set_ref result_set;
   E(SQLITE_OK != get_mixed_fetch_results(db, &result_set, 100), "table didn't exist, yet there was data...\n");
 
-  SQL_E(make_mixed(db), "failed creating table\n");
-  SQL_E(load_mixed_with_nulls(db), "failed loading table\n");
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100), "data access failed\n");
+  SQL_E(make_mixed(db));
+  SQL_E(load_mixed_with_nulls(db));
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100));
 
   cql_int32 count = get_mixed_result_count(result_set);
   E(count == 4, "expected 4 rows from mixed\n");
@@ -259,26 +260,25 @@ cql_code test_rowset_same(sqlite3 *db) {
   cql_string_ref updated_name = string_create();
   cql_blob_ref updated_bl = blob_from_string(updated_name);
 
-  SQL_E(drop_mixed(db), "error cleaning up mixed table");
-  SQL_E(make_mixed(db), "failed creating table\n");
-  SQL_E(load_mixed_with_nulls(db), "failed loading table\n");
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100), "data access failed\n");
+  SQL_E(drop_mixed(db));
+  SQL_E(make_mixed(db));
+  SQL_E(load_mixed_with_nulls(db));
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100));
 
   // Update row 0 with just a new name, so the identity columns should still match the previous result set
   SQL_E(update_mixed(db,
                      get_mixed_get_id(result_set, 0),
                      updated_name,
                      get_nullable_code(result_set, 0),
-                     get_mixed_get_bl(result_set, 0)),
-        "updating mixed row 0 failed\n");
+                     get_mixed_get_bl(result_set, 0)));
+        
 
   // Update row 1 with just a new code, so only 1 of the identity columns should not match the previous result set
   SQL_E(update_mixed(db,
                      get_mixed_get_id(result_set, 1),
                      get_mixed_get_name(result_set, 1),
                      make_nullable_code(0, 1234),
-                     get_mixed_get_bl(result_set, 1)),
-        "updating mixed row 1 failed\n");
+                     get_mixed_get_bl(result_set, 1)));
 
   // Update row 2 with just a new bl, so a ref type identity column should not match the previous result set
   // This also is testing that the last column in the identity columns is properly tested.
@@ -286,11 +286,10 @@ cql_code test_rowset_same(sqlite3 *db) {
                      get_mixed_get_id(result_set, 2),
                      get_mixed_get_name(result_set, 2),
                      get_nullable_code(result_set, 2),
-                     updated_bl),
-        "updating mixed row 2 failed\n");
+                     updated_bl));
 
   // Get the updated result set
-  SQL_E(get_mixed_fetch_results(db, &result_set_updated, 100), "updated data access failed\n");
+  SQL_E(get_mixed_fetch_results(db, &result_set_updated, 100));
 
   E(get_mixed_row_same(result_set, 0, result_set_updated, 0),
     "updated row 0 should be the same as original row 0 (identity column check)\n");
@@ -316,9 +315,9 @@ cql_code test_ref_comparisons(sqlite3 *db) {
 
   // we haven't created the table yet
   get_mixed_result_set_ref result_set;
-  SQL_E(load_mixed_dupes(db), "failed loading table\n");
+  SQL_E(load_mixed_dupes(db));
 
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100), "data access failed\n");
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100));
   E(get_mixed_result_count(result_set) == 6, "expected 6 rows from mixed\n");
 
   // Check that the row hashes are equal from the source to the copy
@@ -342,10 +341,10 @@ cql_code test_bytebuf_growth(sqlite3 *db) {
   tests++;
   printf("Running C client test with huge number of rows\n");
 
-  SQL_E(bulk_load_mixed(db, 10000), "failed loading table\n");
+  SQL_E(bulk_load_mixed(db, 10000));
 
   get_mixed_result_set_ref result_set;
-  SQL_E(get_mixed_fetch_results(db, &result_set, 100000), "data access failed\n");
+  SQL_E(get_mixed_fetch_results(db, &result_set, 100000));
   E(get_mixed_result_count(result_set) == 10000, "expected 10000 rows from mixed\n");
 
   cql_result_set_release(result_set);
@@ -359,10 +358,10 @@ cql_code test_cql_finalize_on_error(sqlite3 *db) {
   tests++;
 
   expectations++;
-  SQL_E(load_mixed(db), "failed loading table\n");
+  SQL_E(load_mixed(db));
 
   sqlite3_stmt *stmt = NULL;
-  SQL_E(sqlite3_prepare_v2(db, "select * from sqlite_master", -1, &stmt, NULL), "stmt prepare failed\n");
+  SQL_E(sqlite3_prepare_v2(db, "select * from sqlite_master", -1, &stmt, NULL));
 
   cql_finalize_on_error(SQLITE_ERROR,&stmt);
   E(stmt == NULL, "expected statement to be finalized\n");
@@ -473,10 +472,10 @@ cql_code test_blob_rowsets(sqlite3 *db) {
   printf("Running blob rowset test\n");
   tests++;
 
-  SQL_E(load_blobs(db), "failed creating blob_table\n");
+  SQL_E(load_blobs(db));
 
   get_blob_table_result_set_ref result_set;
-  SQL_E(get_blob_table_fetch_results(db, &result_set), "blob table data access failed\n");
+  SQL_E(get_blob_table_fetch_results(db, &result_set));
 
   E(get_blob_table_result_count(result_set) == 20, "expected 20 rows from blob table\n");
 
@@ -511,10 +510,10 @@ cql_code test_sparse_blob_rowsets(sqlite3 *db) {
   printf("Running sparse blob rowset test\n");
   tests++;
 
-  SQL_E(load_sparse_blobs(db), "failed creating blob_table\n");
+  SQL_E(load_sparse_blobs(db));
 
   get_blob_table_result_set_ref result_set;
-  SQL_E(get_blob_table_fetch_results(db, &result_set), "blob table data access failed\n");
+  SQL_E(get_blob_table_fetch_results(db, &result_set));
 
   E(get_blob_table_result_count(result_set) == 20, "expected 20 rows from blob table\n");
 
@@ -561,15 +560,15 @@ cql_code test_c_one_row_result(sqlite3 *db) {
   printf("Running C one row result set test\n");
   tests++;
 
-  SQL_E(drop_mixed(db), "error cleaning up mixed table");
+  SQL_E(drop_mixed(db));
 
   // we haven't created the table yet
   get_one_from_mixed_result_set_ref result_set;
   E(SQLITE_OK != get_one_from_mixed_fetch_results(db, &result_set, 1), "table didn't exist, yet there was data...\n");
-  SQL_E(make_mixed(db), "failed creating table\n");
-  SQL_E(load_mixed_with_nulls(db), "failed loading table\n");
+  SQL_E(make_mixed(db));
+  SQL_E(load_mixed_with_nulls(db));
 
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 1), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 1));
   E(get_one_from_mixed_result_count(result_set) == 1, "expected 1 rows from mixed\n");
 
   cql_bool b_is_null;
@@ -592,7 +591,7 @@ cql_code test_c_one_row_result(sqlite3 *db) {
 
   // Compare to a result from a row with different values
   get_one_from_mixed_result_set_ref result_set2;
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 2), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 2));
   E(get_one_from_mixed_result_count(result_set2) == 1, "expected 1 rows from mixed\n");
 
   cql_bool b_is_null2;
@@ -629,7 +628,7 @@ cql_code test_c_one_row_result(sqlite3 *db) {
   cql_result_set_release(result_set2);
 
   // Compare results fetched from the same row
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 1), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set2, 1));
 
   E(get_one_from_mixed_equal(result_set, result_set2), "result sets for same row are not equal\n");
   E(get_one_from_mixed_hash(result_set) == get_one_from_mixed_hash(result_set2),
@@ -638,7 +637,7 @@ cql_code test_c_one_row_result(sqlite3 *db) {
   cql_result_set_release(result_set);
   cql_result_set_release(result_set2);
 
-  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 999), "data access failed\n");
+  SQL_E(get_one_from_mixed_fetch_results(db, &result_set, 999));
   E(get_one_from_mixed_result_count(result_set) == 0, "expected 0 rows from mixed\n");
 
   cql_result_set_release(result_set);
@@ -652,7 +651,7 @@ cql_code test_all_column_fetchers(sqlite3 *db) {
   tests++;
 
   load_all_types_table_result_set_ref result_set;
-  SQL_E(load_all_types_table_fetch_results(db, &result_set), "all types table data access failed\n");
+  SQL_E(load_all_types_table_fetch_results(db, &result_set));
   E(load_all_types_table_result_count(result_set) == 2, "expected 2 rows from result table\n");
   E(cql_result_set_get_meta(result_set)->columnCount == 12, "expected 12 columns from result table\n");
   cql_result_set_ref rs = (cql_result_set_ref)result_set;
@@ -732,7 +731,7 @@ cql_code test_error_case_rowset(sqlite3 *db) {
   printf("Running error case rowset test\n");
   tests++;
 
-  SQL_E(load_sparse_blobs(db), "failed creating blob_table\n");
+  SQL_E(load_sparse_blobs(db));
 
   steps_until_fail = 5;
 
@@ -753,7 +752,7 @@ cql_code test_autodrop_rowset(sqlite3 *db) {
 
   read_three_tables_and_autodrop_result_set_ref result_set;
 
-  SQL_E(SQLITE_OK != read_three_tables_and_autodrop_fetch_results(db, &result_set), "failed reading from temp tables\n");
+  SQL_E(SQLITE_OK != read_three_tables_and_autodrop_fetch_results(db, &result_set));
 
   for (cql_int32 i = 0; i < 3; i++) {
     int32_t id = read_three_tables_and_autodrop_get_id(result_set, i);

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -367,6 +367,7 @@ static symtab *extension_fragments;
 static symtab *assembly_fragments;
 static symtab *extensions_by_basename;
 static symtab *builtin_aggregated_funcs;
+static symtab *shapes;
 
 static ast_node *current_table_ast;
 static CSTR current_table_name;
@@ -1211,6 +1212,11 @@ static ast_node *find_usable_trigger(CSTR name, ast_node *err_target, CSTR msg) 
 // Wrappers for the proc table.
 static bool_t add_proc(ast_node *ast, CSTR name) {
   return symtab_add(procs, name, ast);
+}
+
+static ast_node *find_shape(CSTR name) {
+  symtab_entry *entry = symtab_find(shapes, name);
+  return entry ? (ast_node*)(entry->val) : NULL;
 }
 
 ast_node *find_proc(CSTR name) {
@@ -4214,6 +4220,38 @@ static bool_t try_resolve_auto_cursor(ast_node *ast, CSTR name, CSTR cursor) {
    return false;
 }
 
+// Returns if the scope name is a valid shape then try to look it up
+// as a shape arg auto-field (which might generate errors).  If it isn't a
+// shape then just report not found.
+static bool_t try_resolve_using_shape(ast_node *ast, CSTR name, CSTR shapename) {
+   Contract(shapename);
+   ast_node *shape = find_shape(shapename);
+   if (!shape) {
+     // try something else
+     return false;
+   }
+
+  // Find the name if it exists;  emit the canonical field name, which
+  // has the exact case from the declaration.  The user might have used
+  // something like C.VaLuE when the field is "value". The local has to match.
+
+  sem_struct *sptr = shape->sem->sptr;
+  Invariant(sptr->count > 0);
+
+  for (int32_t i = 0; i < sptr->count; i++) {
+     if (!Strcasecmp(sptr->names[i], name)) {
+        ast->sem = new_sem(sptr->semtypes[i] | SEM_TYPE_VARIABLE);
+        ast->sem->name = dup_printf("%s_%s", shapename, sptr->names[i]);
+        return true;
+     }
+  }
+
+  // if we get this far we're stopping the search
+  report_error(ast, "CQL0068: field not found in shape", name);
+  record_error(ast);
+  return true;
+}
+
 // Try to look up a [possibly] scoped name in one of the places:
 // 1. a column in the current joinscope if any (this must not conflict with #2)
 // 2. a local or global variable
@@ -4246,6 +4284,10 @@ static void sem_resolve_id(ast_node *ast, CSTR name, CSTR scope) {
   // a scope might refer to a cursor, since these are always scoped
   // there is no issue with confusion with locals.
   if (scope && try_resolve_auto_cursor(ast, name, scope)) {
+    return;
+  }
+
+  if (scope && try_resolve_using_shape(ast, name, scope)) {
     return;
   }
 
@@ -6226,7 +6268,7 @@ static void sem_expr_raise(ast_node *ast, CSTR cstr) {
 // We can't just return the error in the tree like we usually do because
 // arg_list might be null and we're trying to do all the helper logic here.
 static bool_t sem_rewrite_call_args_if_needed(ast_node *arg_list) {
- if (arg_list) {
+  if (arg_list) {
     // if there are any cursor forms in the arg list that need to be expanded, do that here.
     sem_rewrite_from_cursor_args(arg_list);
     if (is_error(arg_list)) {
@@ -12069,7 +12111,9 @@ static bool_t sem_rewrite_col_key_list(ast_node *head) {
 // * arg names get a _ suffix so they don't conflict with column names
 static void sem_rewrite_one_param(ast_node *param, symtab *param_names) {
   Contract(is_ast_param(param));
-  EXTRACT_NOTNULL(like, param->left);
+  EXTRACT_NOTNULL(param_detail, param->right);
+  EXTRACT_ANY(formal, param_detail->left);
+  EXTRACT_NOTNULL(like, param_detail->right);
   EXTRACT_STRING(like_name, like->left);
 
   ast_node *found_ast = sem_find_likeable_ast(like);
@@ -12086,17 +12130,33 @@ static void sem_rewrite_one_param(ast_node *param, symtab *param_names) {
   sem_struct *sptr = found_ast->sem->sptr;
   uint32_t count = sptr->count;
   bool_t first_rewrite = true;
+  CSTR formal_name = NULL;
+
+  if (formal) {
+    EXTRACT_STRING(fname, formal);
+    formal_name = fname;
+    ast_node *shape_ast = new_ast_str(formal_name);
+    shape_ast->sem = found_ast->sem;
+    sem_add_flags(shape_ast, 0); // force clone the semantic type
+    shape_ast->sem->name = formal_name;
+    symtab_add(shapes, formal_name, shape_ast);
+  }
 
   for (int32_t i = 0; i < count; i++) {
     sem_t sem_type = sptr->semtypes[i];
     CSTR param_name = sptr->names[i];
 
-    // If the shape came from a procedure we keep the args unchanged
-    // If the shape came from a data type or cursor then we add _
-    // The idea here is that if it came from a procedure we want to keep the same signature
-    // exactly and if any _ needed to be added to avoid conflict with a column name then it already was.
-    if (!(sem_type & (SEM_TYPE_IN_PARAMETER | SEM_TYPE_OUT_PARAMETER))) {
-      param_name = dup_printf("%s_", sptr->names[i]);
+    if (formal_name) {
+      param_name = dup_printf("%s_%s", formal_name, param_name);
+    }
+    else {
+      // If the shape came from a procedure we keep the args unchanged
+      // If the shape came from a data type or cursor then we add _
+      // The idea here is that if it came from a procedure we want to keep the same signature
+      // exactly and if any _ needed to be added to avoid conflict with a column name then it already was.
+      if (!(sem_type & (SEM_TYPE_IN_PARAMETER | SEM_TYPE_OUT_PARAMETER))) {
+        param_name = dup_printf("%s_", param_name);
+      }
     }
 
     // skip any that we have already added or that are manually present
@@ -12106,7 +12166,7 @@ static void sem_rewrite_one_param(ast_node *param, symtab *param_names) {
 
     ast_node *type = sem_generate_data_type(sem_type);
     ast_node *name_ast = new_ast_str(param_name);
-    ast_node *param_detail = new_ast_param_detail(name_ast, type);
+    ast_node *param_detail_new = new_ast_param_detail(name_ast, type);
 
     ast_node *inout = NULL; // IN by default
     if (sem_type & SEM_TYPE_OUT_PARAMETER) {
@@ -12121,7 +12181,7 @@ static void sem_rewrite_one_param(ast_node *param, symtab *param_names) {
     if (!first_rewrite) {
       // for the 2nd and subsequent args make a new node
       ast_node *params = param->parent;
-      ast_node *new_param = new_ast_param(inout, param_detail);
+      ast_node *new_param = new_ast_param(inout, param_detail_new);
       ast_set_right(params, new_ast_params(new_param, params->right));
       param = new_param;
     }
@@ -12129,11 +12189,10 @@ static void sem_rewrite_one_param(ast_node *param, symtab *param_names) {
       // for the first arg, just replace the param details
       // recall that we are on a param node and it is the like entry
       Invariant(is_ast_param(param));
-      Invariant(is_ast_like(param->left));
 
       // replace the like entry with a real param detail
       // on the next iteration, we will insert to the right of ast
-      ast_set_right(param, param_detail);
+      ast_set_right(param, param_detail_new);
       ast_set_left(param, inout);
       first_rewrite = false;
     }
@@ -12292,8 +12351,9 @@ static void sem_rewrite_params(ast_node *head) {
   for (ast_node *ast = head; ast; ast = ast->right) {
     Contract(is_ast_params(ast));
     EXTRACT_NOTNULL(param, ast->left)
+    EXTRACT_NOTNULL(param_detail, param->right)
 
-    if (is_ast_like(param->left)) {
+    if (is_ast_like(param_detail->right)) {
       sem_rewrite_one_param(param, param_names);
       if (is_error(param)) {
         record_error(head);
@@ -12302,8 +12362,6 @@ static void sem_rewrite_params(ast_node *head) {
     }
     else {
       // Just extract the name and record that we used it -- no rewrite needed.
-      Contract(is_ast_param(param));
-      EXTRACT_NOTNULL(param_detail, param->right);
       EXTRACT_STRING(param_name, param_detail->left);
       symtab_add(param_names, param_name, NULL);
     }
@@ -12433,10 +12491,10 @@ static bool_t sem_autotest_dummy_test(
     // find table name
     if (!is_ast_misc_attr_value_list(dummy_test_list->left) || !is_ast_str(dummy_test_list->left->left)) {
       report_dummy_test_error(
-	dummy_test_list->left,
-	"CQL0273: autotest attribute has incorrect format (table name should be nested) in",
-	"dummy_test",
-	error);
+      dummy_test_list->left,
+        "CQL0273: autotest attribute has incorrect format (table name should be nested) in",
+        "dummy_test",
+        error);
       goto cleanup;
     }
 
@@ -12445,10 +12503,10 @@ static bool_t sem_autotest_dummy_test(
     ast_node *table = find_table_or_view_even_hidden(table_name);
     if (!table) {
       report_dummy_test_error(
-	table_list->left,
-	"CQL0274: autotest attribute 'dummy_test' has non existent table",
-	table_name,
-	error);
+        table_list->left,
+        "CQL0274: autotest attribute 'dummy_test' has non existent table",
+        table_name,
+        error);
       goto cleanup;
     }
 
@@ -12458,32 +12516,32 @@ static bool_t sem_autotest_dummy_test(
     ast_node *column_name_list = table_list->right;
     if (!is_ast_misc_attr_value_list(column_name_list->left)) {
       report_dummy_test_error(
-	table_list->left,
-	"CQL0273: autotest attribute has incorrect format (column name should be nested) in",
-	"dummy_test",
-	error);
+        table_list->left,
+        "CQL0273: autotest attribute has incorrect format (column name should be nested) in",
+        "dummy_test",
+        error);
       goto cleanup;
     }
 
     for (ast_node *list = column_name_list->left; list; list = list->right) {
       if (!is_ast_str(list->left)) {
-	report_dummy_test_error(
-	  table_list->left,
-	  "CQL0273: autotest attribute has incorrect format (column name should be nested) in",
-	  "dummy_test",
-	  error);
-	goto cleanup;
+        report_dummy_test_error(
+          table_list->left,
+          "CQL0273: autotest attribute has incorrect format (column name should be nested) in",
+          "dummy_test",
+          error);
+        goto cleanup;
       }
       ast_node *misc_attr_value = list->left;
       EXTRACT_STRING(column_name, misc_attr_value);
       sem_t col_type = find_column_type(table_name, column_name);
       if (!col_type) {
-	report_dummy_test_error(
-	  misc_attr_value,
-	  "CQL0275: autotest attribute 'dummy_test' has non existent column",
-	  column_name,
-	  error);
-	goto cleanup;
+        report_dummy_test_error(
+          misc_attr_value,
+          "CQL0275: autotest attribute 'dummy_test' has non existent column",
+          column_name,
+          error);
+        goto cleanup;
       }
       record_ok(misc_attr_value);
       sem_t *col_type_ptr = bytebuf_alloc(&column_types, sizeof(sem_t));
@@ -12496,92 +12554,92 @@ static bool_t sem_autotest_dummy_test(
     // find column values
     if (!is_ast_misc_attr_value_list(column_name_list->right)) {
       report_dummy_test_error(
-	table_list->left,
-	"CQL0273: autotest attribute has incorrect format (column value should be nested) in",
-	"dummy_test",
-	error);
+        table_list->left,
+        "CQL0273: autotest attribute has incorrect format (column value should be nested) in",
+        "dummy_test",
+        error);
       goto cleanup;
     }
 
     for (ast_node *column_values_list = column_name_list->right; column_values_list; column_values_list = column_values_list->right) {
       if (!is_ast_misc_attr_value_list(column_values_list->left)) {
-	report_dummy_test_error(
-	  table_list->left,
-	  "CQL0273: autotest attribute has incorrect format (column value should be nested) in",
-	  "dummy_test",
-	  error);
-	goto cleanup;
+        report_dummy_test_error(
+          table_list->left,
+          "CQL0273: autotest attribute has incorrect format (column value should be nested) in",
+          "dummy_test",
+          error);
+        goto cleanup;
       }
 
       int32_t column_value_count = 0;
       for (ast_node *list = column_values_list->left; list; list = list->right) {
 
-	if (column_value_count >= column_count) {
-	  report_dummy_test_error(
-	    table_list->left,
-	    "CQL0273: autotest attribute has incorrect format (too many column values) in",
-	    "dummy_test",
-	    error);
-	  goto cleanup;
-	}
+        if (column_value_count >= column_count) {
+          report_dummy_test_error(
+            table_list->left,
+            "CQL0273: autotest attribute has incorrect format (too many column values) in",
+            "dummy_test",
+            error);
+          goto cleanup;
+        }
 
-	ast_node *misc_attr_value = list->left;
-	sem_t col_type = ((sem_t *)column_types.ptr)[column_value_count];
-	sem_t core_type = core_type_of(col_type);
+        ast_node *misc_attr_value = list->left;
+        sem_t col_type = ((sem_t *)column_types.ptr)[column_value_count];
+        sem_t core_type = core_type_of(col_type);
 
-	if (is_ast_uminus(misc_attr_value)) {
-	  Contract(is_ast_num(misc_attr_value->left));
-	  misc_attr_value = misc_attr_value->left;
-	}
+        if (is_ast_uminus(misc_attr_value)) {
+          Contract(is_ast_num(misc_attr_value->left));
+          misc_attr_value = misc_attr_value->left;
+        }
 
-	bool_t ok = false;
+        bool_t ok = false;
 
-	if (is_ast_num(misc_attr_value)) {
-	   // an integer literal is good for any numeric type
-	   EXTRACT_NUM_TYPE(num_type, misc_attr_value);
+        if (is_ast_num(misc_attr_value)) {
+           // an integer literal is good for any numeric type
+           EXTRACT_NUM_TYPE(num_type, misc_attr_value);
 
-	   if (num_type == NUM_INT) {
-	     // an integer literal is good for any numeric type
-	     ok = is_numeric(core_type);
-	   }
-	   else if (num_type == NUM_LONG) {
-	     // NUM_LONG might not fit in REAL, compatible only with itself
-	     ok = core_type == SEM_TYPE_LONG_INTEGER;
-	   }
-	   else {
-	     Contract(num_type == NUM_REAL);
-	     // a real literal is only good for a real column
-	     ok = core_type == SEM_TYPE_REAL;
-	   }
-	}
-	else if (is_ast_strlit(misc_attr_value)) {
-	   // a string literal is ok for any text column
-	   ok = core_type == SEM_TYPE_TEXT;
-	}
-	else if (is_ast_null(misc_attr_value)) {
-	   // the null token is ok for any nullable column
-	   ok = is_nullable(col_type);
-	}
+           if (num_type == NUM_INT) {
+             // an integer literal is good for any numeric type
+             ok = is_numeric(core_type);
+           }
+           else if (num_type == NUM_LONG) {
+             // NUM_LONG might not fit in REAL, compatible only with itself
+             ok = core_type == SEM_TYPE_LONG_INTEGER;
+           }
+           else {
+             Contract(num_type == NUM_REAL);
+             // a real literal is only good for a real column
+             ok = core_type == SEM_TYPE_REAL;
+           }
+        }
+        else if (is_ast_strlit(misc_attr_value)) {
+           // a string literal is ok for any text column
+           ok = core_type == SEM_TYPE_TEXT;
+        }
+        else if (is_ast_null(misc_attr_value)) {
+           // the null token is ok for any nullable column
+           ok = is_nullable(col_type);
+        }
 
-	if (!ok) {
-	  report_dummy_test_error(
-	    misc_attr_value,
-	    "CQL0276: autotest attribute 'dummy_test' has invalid value type in",
-	    ((CSTR *) column_names.ptr)[column_value_count],
-	    error);
-	  goto cleanup;
-	}
-	record_ok(misc_attr_value);
-	column_value_count++;
+        if (!ok) {
+          report_dummy_test_error(
+            misc_attr_value,
+            "CQL0276: autotest attribute 'dummy_test' has invalid value type in",
+            ((CSTR *) column_names.ptr)[column_value_count],
+            error);
+          goto cleanup;
+        }
+        record_ok(misc_attr_value);
+        column_value_count++;
       }
 
       if (column_count != column_value_count) {
-	report_dummy_test_error(
-	  table_list->left,
-	  "CQL0273: autotest attribute has incorrect format (mismatch number of column and values) in",
-	  "dummy_test",
-	  error);
-	goto cleanup;
+        report_dummy_test_error(
+          table_list->left,
+          "CQL0273: autotest attribute has incorrect format (mismatch number of column and values) in",
+          "dummy_test",
+          error);
+        goto cleanup;
       }
     }
 
@@ -13731,6 +13789,7 @@ static void sem_inside_create_proc_stmt(ast_node *ast) {
   bool_t error = false;
   has_dml = 0;
   current_variables = locals = symtab_new();
+  shapes = symtab_new();
   between_count = 0;
   in_proc_savepoint = false;
 
@@ -13767,7 +13826,9 @@ static void sem_inside_create_proc_stmt(ast_node *ast) {
 
 cleanup:
   symtab_delete(locals);
+  symtab_delete(shapes);
   locals = NULL;
+  shapes = NULL;
   current_variables = globals;
   between_count = saved_between_count;
 
@@ -14095,38 +14156,56 @@ static void sem_typed_name(ast_node *typed_name, symtab *names) {
 // * replace the "like T" slug with the first column of T
 // * for each additional column create a typed name node and link it in.
 // * emit any given name only once, (so you can do like T1, like T1 even if both have the same pk)
-static void sem_rewrite_one_typed_name(ast_node *like, symtab *used_names) {
-  Contract(is_ast_like(like));
+static void sem_rewrite_one_typed_name(ast_node *typed_name, symtab *used_names) {
+  Contract(is_ast_typed_name(typed_name));
+  EXTRACT_ANY(formal, typed_name->left);
+  EXTRACT_NOTNULL(like, typed_name->right);
   EXTRACT_STRING(like_name, like->left);
 
   ast_node *found_ast = sem_find_likeable_ast(like);
   if (!found_ast) {
-    record_error(like);
+    record_error(typed_name);
     return;
   }
 
   AST_REWRITE_INFO_SET(like->lineno, like->filename);
 
   // Nothing can go wrong from here on
-  record_ok(like);
+  record_ok(typed_name);
 
   sem_struct *sptr = found_ast->sem->sptr;
   uint32_t count = sptr->count;
   bool_t first_rewrite = true;
+  CSTR formal_name = NULL;
 
-  ast_node *insertion = like;
+  ast_node *insertion = typed_name;
+
+  if (formal) {
+    EXTRACT_STRING(fname, formal);
+    formal_name = fname;
+
+    // note that typed names are part of a procedure return type in a declaration
+    // they don't create a proc or a proc body and so we don't add to shapes,
+    // indeed shapes is null at this point
+    Invariant(!shapes);
+  }
 
   for (int32_t i = 0; i < count; i++) {
     sem_t sem_type = sptr->semtypes[i];
     CSTR name = sptr->names[i];
+    CSTR combined_name = name;
+
+    if (formal_name) {
+      combined_name = dup_printf("%s_%s", formal_name, name);
+    }
 
     // skip any that we have already added or that are manually present
-    if (!symtab_add(used_names, name, NULL)) {
+    if (!symtab_add(used_names, combined_name, NULL)) {
       continue;
     }
 
+    ast_node *name_ast = new_ast_str(combined_name);
     ast_node *type = sem_generate_data_type(sem_type);
-    ast_node *name_ast = new_ast_str(name);
     ast_node *new_typed_name = new_ast_typed_name(name_ast, type);
     ast_node *typed_names = insertion->parent;
 
@@ -14146,7 +14225,7 @@ static void sem_rewrite_one_typed_name(ast_node *like, symtab *used_names) {
   if (first_rewrite) {
     // since this can only happen if there is 100% duplication, that means there is always a previous typed name
     // if this were the first node we would have expanded ... something
-    EXTRACT_NOTNULL(typed_names, like->parent);
+    EXTRACT_NOTNULL(typed_names, typed_name->parent);
     EXTRACT_NAMED_NOTNULL(prev, typed_names, typed_names->parent);
     ast_set_right(prev, typed_names->right);
   }
@@ -14161,18 +14240,17 @@ static void sem_rewrite_typed_names(ast_node *head) {
 
   for (ast_node *ast = head; ast; ast = ast->right) {
     Contract(is_ast_typed_names(ast));
-    EXTRACT_ANY_NOTNULL(item, ast->left)
+    EXTRACT_NOTNULL(typed_name, ast->left);
 
-    if (is_ast_like(item)) {
-      sem_rewrite_one_typed_name(item, used_names);
-      if (is_error(item)) {
+    if (is_ast_like(typed_name->right)) {
+      sem_rewrite_one_typed_name(typed_name, used_names);
+      if (is_error(typed_name)) {
         record_error(head);
         goto cleanup;
       }
     }
     else {
       // Just extract the name and record that we used it -- no rewrite needed.
-      EXTRACT_NOTNULL(typed_name, item);
       EXTRACT_STRING(name, typed_name->left);
       symtab_add(used_names, name, NULL);
     }
@@ -14265,11 +14343,14 @@ static void sem_declare_func_stmt(ast_node *ast) {
 
   if (params) {
     current_variables = locals = symtab_new();
+    shapes = symtab_new();
 
     sem_params(params);
 
     symtab_delete(locals);
     locals = NULL;
+    symtab_delete(shapes);
+    shapes = NULL;
     current_variables = globals;
 
     if (is_error(params)) {
@@ -14907,6 +14988,20 @@ static void sem_cursor(ast_node *ast) {
   }
 }
 
+// Try to look up the indicated name as a named shape from the args
+// If so use the type of that shape
+static bool_t try_sem_shape(ast_node *ast) {
+  EXTRACT_STRING(name, ast);
+  ast_node *shape = find_shape(name);
+
+  if (shape) {
+    ast->sem = shape->sem;
+    return true;
+  }
+
+  return false;
+}
+
 // While semantic analysis is super simple.
 //  * the condition must be numeric
 //  * the statement list must be error-free
@@ -15162,13 +15257,15 @@ static void sem_rewrite_from_cursor_args(ast_node *head) {
     if (is_ast_from_cursor(arg)) {
       EXTRACT_ANY_NOTNULL(cursor, arg->left);
 
-      // Note if this is not an automatic cursor then we will fail later when we try to
-      // resolve the '.' expression.  That error message tells the story well enough
-      // so we don't need an extra check here.
-      sem_cursor(cursor);
-      if (is_error(cursor)) {
-        record_error(head);
-        return;
+      if (!try_sem_shape(cursor)) {
+        // Note if this is not an automatic cursor then we will fail later when we try to
+        // resolve the '.' expression.  That error message tells the story well enough
+        // so we don't need an extra check here.
+        sem_cursor(cursor);
+        if (is_error(cursor)) {
+          record_error(head);
+          return;
+        }
       }
 
       ast_node *like_ast = arg->right;

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -2867,6 +2867,121 @@ set x := 1 | (2 << 3);
 -- + x = 1 << (2 << 3);
 set x := 1 << (2 << 3);
 
+-- + x = 1 < (2 > 3);
+set x := 1 < (2 > 3);
+
+-- + x = 1 << (2 >> 3);
+set x := 1 << (2 >> 3);
+
+-- + x = 1 | (2 | 3);
+set x := 1 | (2 | 3);
+
+-- + x = 1 | 2 | 3;
+set x := (1 | 2) | 3;
+
+-- + x = 1 == (2 != 3);
+set x := 1 == (2 != 3);
+
+create table SalesInfo(
+  month integer,
+  amount real
+);
+
+-- TEST: ORDERBY BETWEEN PRECEEDING AND FOLLOWING NO FILTER NO EXCLUDE
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: simple OVER and ORDER BY
+-- + SUM(amount) OVER (ORDER BY month) AS RunningTotal
+SELECT month, amount, SUM(amount) OVER
+  (ORDER BY month) RunningTotal
+FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude no others
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude no others with FILTER
+-- + AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) FILTER(WHERE month = 1) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude current row
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude group
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: ROWS expr preceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: RANGE expr preceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS expr preceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS unbounded proceeding and expr following, exclude ties
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS expr following and expr preceeding 
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS between current row and unbounded following
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS between unbounded preceding and current row with no exclude
+-- + AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: GROUPS between unbounded preceding and current row with exclude ties
+-- +  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: correct parse and re-emit of CURRENT_ROW
+-- + AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: correct parse and re-emit of CURRENT_ROW
+-- + AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+SELECT month, amount, AVG(amount) OVER
+  (GROUPS CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
 
 --------------------------------------------------------------------
 -------------------- add new tests before this point ---------------

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -8610,6 +8610,249 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET x := 1 << (2 << 3);
   */
   x = 1 << (2 << 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 < (2 > 3);
+  */
+  x = 1 < (2 > 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 << (2 >> 3);
+  */
+  x = 1 << (2 >> 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | (2 | 3);
+  */
+  x = 1 | (2 | 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | 2 | 3;
+  */
+  x = 1 | 2 | 3;
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 = 2 <> 3;
+  */
+  x = 1 == (2 != 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    SUM(amount) OVER (ORDER BY month) AS RunningTotal
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "SUM(amount) OVER (ORDER BY month) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (GROUPS CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
 cql_cleanup:
   cql_string_release(t0_nullable);

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -1798,6 +1798,48 @@ extern cql_int32 x;
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern void end_proc(void);
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -8610,6 +8610,249 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET x := 1 << (2 << 3);
   */
   x = 1 << (2 << 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 < (2 > 3);
+  */
+  x = 1 < (2 > 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 << (2 >> 3);
+  */
+  x = 1 << (2 >> 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | (2 | 3);
+  */
+  x = 1 | (2 | 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 | 2 | 3;
+  */
+  x = 1 | 2 | 3;
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SET x := 1 = 2 <> 3;
+  */
+  x = 1 == (2 != 3);
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    SUM(amount) OVER (ORDER BY month) AS RunningTotal
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "SUM(amount) OVER (ORDER BY month) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) FILTER (WHERE month = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (PARTITION BY month ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
+  
+  // The statement ending at line XXXX
+  
+  /*
+  SELECT month, amount, 
+    AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+    FROM SalesInfo;
+  */
+  _rc_ = cql_prepare(_db_, _result_,
+    "SELECT month, amount,  "
+      "AVG(amount) OVER (GROUPS CURRENT ROW) "
+      "FROM SalesInfo");
+  if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 
 cql_cleanup:
   cql_string_release(t0_nullable);

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -1798,6 +1798,48 @@ extern cql_int32 x;
 // The statement ending at line XXXX
 
 // The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
+
+// The statement ending at line XXXX
 extern void end_proc(void);
 
 // The statement ending at line XXXX

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -2778,6 +2778,23 @@ BEGIN_TEST(cursor_args)
   call dummy(from args);
 END_TEST(cursor_args)
 
+DECLARE PROCEDURE cql_exec_internal(sql TEXT NOT NULL) USING TRANSACTION;
+create table xyzzy(id integer, name text);
+
+BEGIN_TEST(exec_internal)
+  call cql_exec_internal("create table xyzzy(id integer, name text);");
+  insert into xyzzy using 1 id, 'x' name;
+  insert into xyzzy using 2 id, 'y' name;
+  declare C cursor for select * from xyzzy;
+  declare D cursor like C;
+  fetch C;
+  fetch D using 1 id, 'x' name;
+  EXPECT(cql_cursor_diff_val(C,D) is null);
+  fetch C;
+  fetch D using 2 id, 'y' name;
+  EXPECT(cql_cursor_diff_val(C,D) is null);
+END_TEST(exec_internal)
+
 END_SUITE()
 
 -- manually force tracing on by redefining the macros

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -803,6 +803,7 @@ Error at test/sem_test.sql:XXXX : in select_stmt : CQL0251: fragment must end wi
 Error at test/sem_test.sql:XXXX : in fk_def : CQL0021: foreign key refers to non-existent table 'this_table_does_not_exist'
 Error at test/sem_test.sql:XXXX : in call_stmt : CQL0323: calls to undeclared procedures are forbidden if strict procedure mode is enabled 'some_external_thing'
 Error at test/sem_test.sql:XXXX : in like : CQL0202: must be a cursor, proc, table, or view 'invalid_type_name'
+Error at test/sem_test.sql:XXXX : in dot : CQL0068: field not found in shape 'xyzzy'
 Error at test/sem_test.sql:XXXX : in fk_def : CQL0324: referenced table was created in a later version so it cannot be used in a foreign key 'from_the_future'
 Error at test/sem_test.sql:XXXX : in str : CQL0171: name not found 'idx'
 Error at test/sem_test.sql:XXXX : in str : CQL0171: name not found 'idx'

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -892,4 +892,8 @@ Error at test/sem_test.sql:XXXX : in proc_savepoint_stmt : CQL0351: statement sh
 Error at test/sem_test.sql:XXXX : in rollback_return_stmt : CQL0350: statement must appear inside of a PROC SAVEPOINT block
 Error at test/sem_test.sql:XXXX : in commit_return_stmt : CQL0350: statement must appear inside of a PROC SAVEPOINT block
 Error at test/sem_test.sql:XXXX : in return_stmt : CQL0352: use COMMIT RETURN or ROLLBACK RETURN in within a proc savepoint block
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
 semantic errors present; no code gen.

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -40890,7 +40890,7 @@ SELECT id,
 The statement ending at line XXXX
 
 SELECT id, 
-  row_number() OVER (ROWS BETWEEN CURRENT ROW AND CURRENT ROW UNBOUNDED FOLLOWINGEXCLUDE GROUP)
+  row_number() OVER (ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING EXCLUDE GROUP)
   FROM foo;
 
   {select_stmt}: select: { id: integer notnull, _anon: integer notnull }
@@ -50464,4 +50464,257 @@ Error at test/sem_test.sql:XXXX : in return_stmt : CQL0352: use COMMIT RETURN or
       | {proc_savepoint_stmt}: err
         | {stmt_list}: err
           | {return_stmt}: err
+
+The statement ending at line XXXX
+
+CREATE TABLE SalesInfo(
+  month INTEGER,
+  amount REAL
+);
+
+  {create_table_stmt}: SalesInfo: { month: integer, amount: real }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name SalesInfo}
+  | {col_key_list}
+    | {col_def}: month: integer
+    | | {col_def_type_attrs}
+    |   | {col_def_name_type}
+    |     | {name month}
+    |     | {type_int}: integer
+    | {col_key_list}
+      | {col_def}: amount: real
+        | {col_def_type_attrs}
+          | {col_def_name_type}
+            | {name amount}
+            | {type_real}: real
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND sum(month) FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: amount: real
+  |     |       | | | {name AVG}: amount: real
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | {arg_list}: ok
+  |     |       | |     | {name amount}: amount: real
+  |     |       | | {window_defn}: err
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_orderby}: ok
+  |     |       |     | | {groupby_list}: ok
+  |     |       |     |   | {groupby_item}
+  |     |       |     |     | {name month}: month: integer
+  |     |       |     | {opt_frame_spec}: err
+  |     |       |       | {int 266370}
+  |     |       |       | {expr_list}
+  |     |       |         | {int 1}: integer notnull
+  |     |       |         | {call}: err
+  |     |       |           | {name sum}
+  |     |       |           | {call_arg_list}
+  |     |       |             | {call_filter_clause}
+  |     |       |             | {arg_list}: ok
+  |     |       |               | {name month}: month: integer
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) OVER (PARTITION BY sum(month) ROWS BETWEEN 1 PRECEDING AND 3 FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: amount: real
+  |     |       | | | {name AVG}: amount: real
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | {arg_list}: ok
+  |     |       | |     | {name amount}: amount: real
+  |     |       | | {window_defn}: err
+  |     |       |   | {opt_partition_by}: err
+  |     |       |   | | {expr_list}: err
+  |     |       |   |   | {call}: err
+  |     |       |   |     | {name sum}
+  |     |       |   |     | {call_arg_list}
+  |     |       |   |       | {call_filter_clause}
+  |     |       |   |       | {arg_list}: ok
+  |     |       |   |         | {name month}: month: integer
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_frame_spec}: ok
+  |     |       |       | {int 266370}
+  |     |       |       | {expr_list}
+  |     |       |         | {int 1}: integer notnull
+  |     |       |         | {int 3}: integer notnull
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN sum(month) PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: amount: real
+  |     |       | | | {name AVG}: amount: real
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | {arg_list}: ok
+  |     |       | |     | {name amount}: amount: real
+  |     |       | | {window_defn}: err
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_orderby}: ok
+  |     |       |     | | {groupby_list}: ok
+  |     |       |     |   | {groupby_item}
+  |     |       |     |     | {name month}: month: integer
+  |     |       |     | {opt_frame_spec}: err
+  |     |       |       | {int 266370}
+  |     |       |       | {expr_list}
+  |     |       |         | {call}: err
+  |     |       |         | | {name sum}
+  |     |       |         | | {call_arg_list}
+  |     |       |         |   | {call_filter_clause}
+  |     |       |         |   | {arg_list}: ok
+  |     |       |         |     | {name month}: month: integer
+  |     |       |         | {int 1}: integer notnull
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
+
+The statement ending at line XXXX
+
+SELECT month, amount, 
+  AVG(amount) FILTER (WHERE sum(month) = 1) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+  FROM SalesInfo;
+
+Error at test/sem_test.sql:XXXX : in call : CQL0080: function may not appear in this context 'sum'
+
+  {select_stmt}: err
+  | {select_core_list}: err
+  | | {select_core}: err
+  |   | {select_expr_list_con}: err
+  |     | {select_expr_list}: err
+  |     | | {select_expr}: month: integer
+  |     | | | {name month}: month: integer
+  |     | | {select_expr_list}
+  |     |   | {select_expr}: amount: real
+  |     |   | | {name amount}: amount: real
+  |     |   | {select_expr_list}
+  |     |     | {select_expr}: err
+  |     |       | {window_func_inv}: err
+  |     |       | | {call}: err
+  |     |       | | | {name AVG}
+  |     |       | | | {call_arg_list}
+  |     |       | |   | {call_filter_clause}
+  |     |       | |   | | {opt_filter_clause}: err
+  |     |       | |   |   | {opt_where}: err
+  |     |       | |   |     | {eq}: err
+  |     |       | |   |       | {call}: err
+  |     |       | |   |       | | {name sum}
+  |     |       | |   |       | | {call_arg_list}
+  |     |       | |   |       |   | {call_filter_clause}
+  |     |       | |   |       |   | {arg_list}: ok
+  |     |       | |   |       |     | {name month}: month: integer
+  |     |       | |   |       | {int 1}: integer notnull
+  |     |       | |   | {arg_list}
+  |     |       | |     | {name amount}
+  |     |       | | {window_defn}: ok
+  |     |       |   | {window_defn_orderby}
+  |     |       |     | {opt_orderby}: ok
+  |     |       |     | | {groupby_list}: ok
+  |     |       |     |   | {groupby_item}
+  |     |       |     |     | {name month}: month: integer
+  |     |       |     | {opt_frame_spec}: ok
+  |     |       |       | {int 20610}
+  |     |       |       | {expr_list}
+  |     |       |         | {int 1}: integer notnull
+  |     |       |         | {int 2}: integer notnull
+  |     |       | {opt_as_alias}
+  |     |         | {name SalesMovingAverage}
+  |     | {select_from_etc}: TABLE { SalesInfo: SalesInfo }
+  |       | {table_or_subquery_list}: TABLE { SalesInfo: SalesInfo }
+  |       | | {table_or_subquery}: TABLE { SalesInfo: SalesInfo }
+  |       |   | {name SalesInfo}: TABLE { SalesInfo: SalesInfo }
+  |       | {select_where}
+  |         | {select_groupby}
+  |           | {select_having}
+  | {select_orderby}
+    | {select_limit}
+      | {select_offset}
 

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -21084,6 +21084,48 @@ END;
 
 The statement ending at line XXXX
 
+CREATE PROC qualified_like (x_id INTEGER NOT NULL, x_name TEXT, x_rate LONG_INT, y_id INTEGER NOT NULL, y_name TEXT, y_rate LONG_INT)
+BEGIN
+END;
+
+  {create_proc_stmt}: ok
+  | {name qualified_like}: ok
+  | {proc_params_stmts}
+    | {params}: ok
+      | {param}: x_id: integer notnull variable in
+      | | {param_detail}: x_id: integer notnull variable in
+      |   | {name x_id}: x_id: integer notnull variable in
+      |   | {notnull}: integer notnull
+      |     | {type_int}: integer
+      | {params}
+        | {param}: x_name: text variable in
+        | | {param_detail}: x_name: text variable in
+        |   | {name x_name}: x_name: text variable in
+        |   | {type_text}: text
+        | {params}
+          | {param}: x_rate: longint variable in
+          | | {param_detail}: x_rate: longint variable in
+          |   | {name x_rate}: x_rate: longint variable in
+          |   | {type_long}: longint
+          | {params}
+            | {param}: y_id: integer notnull variable in
+            | | {param_detail}: y_id: integer notnull variable in
+            |   | {name y_id}: y_id: integer notnull variable in
+            |   | {notnull}: integer notnull
+            |     | {type_int}: integer
+            | {params}
+              | {param}: y_name: text variable in
+              | | {param_detail}: y_name: text variable in
+              |   | {name y_name}: y_name: text variable in
+              |   | {type_text}: text
+              | {params}
+                | {param}: y_rate: longint variable in
+                  | {param_detail}: y_rate: longint variable in
+                    | {name y_rate}: y_rate: longint variable in
+                    | {type_long}: longint
+
+The statement ending at line XXXX
+
 CREATE PROC insert_bar (extra INTEGER, id_ INTEGER NOT NULL, name_ TEXT, rate_ LONG_INT)
 BEGIN
   INSERT INTO bar(id, name, rate) VALUES(id_, name_, rate_);
@@ -21578,8 +21620,9 @@ Error at test/sem_test.sql:XXXX : in like : CQL0202: must be a cursor, proc, tab
   | {proc_params_stmts}
     | {params}: err
     | | {param}: err
-    |   | {like}: err
-    |     | {name garbonzo}: err
+    |   | {param_detail}
+    |     | {like}: err
+    |       | {name garbonzo}: err
     | {stmt_list}
       | {declare_vars_type}
         | {name_list}
@@ -21949,8 +21992,9 @@ Error at test/sem_test.sql:XXXX : in like : CQL0178: proc has no result 'proc1'
   | {proc_params_stmts}
     | {params}: err
     | | {param}: err
-    |   | {like}: err
-    |     | {name proc1}: err
+    |   | {param_detail}
+    |     | {like}: err
+    |       | {name proc1}: err
     | {stmt_list}
       | {declare_vars_type}
         | {name_list}
@@ -45184,8 +45228,159 @@ Error at test/sem_test.sql:XXXX : in like : CQL0202: must be a cursor, proc, tab
   | | {int 3}
   | {proc_params_stmts}
     | {typed_names}: err
-      | {like}: err
-        | {name invalid_type_name}: err
+      | {typed_name}: err
+        | {like}: err
+          | {name invalid_type_name}: err
+
+The statement ending at line XXXX
+
+DECLARE PROC _stuff5 () (id INTEGER, name TEXT);
+
+  {declare_proc_stmt}: select: { id: integer, name: text } dml_proc
+  | {proc_name_type}
+  | | {name _stuff5}: select: { id: integer, name: text } dml_proc
+  | | {int 3}
+  | {proc_params_stmts}
+    | {typed_names}: select: { id: integer, name: text }
+      | {typed_name}: id: integer
+      | | {name id}
+      | | {type_int}: id: integer
+      | {typed_names}
+        | {typed_name}: name: text
+          | {name name}
+          | {type_text}: name: text
+
+The statement ending at line XXXX
+
+DECLARE PROC _stuff6 () (x_id INTEGER, x_name TEXT, y_id INTEGER, y_name TEXT);
+
+  {declare_proc_stmt}: select: { x_id: integer, x_name: text, y_id: integer, y_name: text } dml_proc
+  | {proc_name_type}
+  | | {name _stuff6}: select: { x_id: integer, x_name: text, y_id: integer, y_name: text } dml_proc
+  | | {int 3}
+  | {proc_params_stmts}
+    | {typed_names}: select: { x_id: integer, x_name: text, y_id: integer, y_name: text }
+      | {typed_name}: x_id: integer
+      | | {name x_id}
+      | | {type_int}: x_id: integer
+      | {typed_names}
+        | {typed_name}: x_name: text
+        | | {name x_name}
+        | | {type_text}: x_name: text
+        | {typed_names}
+          | {typed_name}: y_id: integer
+          | | {name y_id}
+          | | {type_int}: y_id: integer
+          | {typed_names}
+            | {typed_name}: y_name: text
+              | {name y_name}
+              | {type_text}: y_name: text
+
+The statement ending at line XXXX
+
+CREATE PROC using_like_shape (x_id INTEGER, x_name TEXT)
+BEGIN
+  CALL printf("%s\n", x.id);
+END;
+
+  {create_proc_stmt}: ok
+  | {name using_like_shape}: ok
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: x_id: integer variable in
+    | | | {param_detail}: x_id: integer variable in
+    | |   | {name x_id}: x_id: integer variable in
+    | |   | {type_int}: integer
+    | | {params}
+    |   | {param}: x_name: text variable in
+    |     | {param_detail}: x_name: text variable in
+    |       | {name x_name}: x_name: text variable in
+    |       | {type_text}: text
+    | {stmt_list}: ok
+      | {call_stmt}: ok
+        | {name printf}: ok
+        | {expr_list}: ok
+          | {strlit '%s
+'}: text notnull
+          | {expr_list}
+            | {dot}: x_id: integer variable
+              | {name x}
+              | {name id}
+
+The statement ending at line XXXX
+
+CREATE PROC using_like_shape_bad_name (x_id INTEGER, x_name TEXT)
+BEGIN
+  CALL printf("%s\n", x.xyzzy);
+END;
+
+Error at test/sem_test.sql:XXXX : in dot : CQL0068: field not found in shape 'xyzzy'
+
+  {create_proc_stmt}: err
+  | {name using_like_shape_bad_name}: err
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: x_id: integer variable in
+    | | | {param_detail}: x_id: integer variable in
+    | |   | {name x_id}: x_id: integer variable in
+    | |   | {type_int}: integer
+    | | {params}
+    |   | {param}: x_name: text variable in
+    |     | {param_detail}: x_name: text variable in
+    |       | {name x_name}: x_name: text variable in
+    |       | {type_text}: text
+    | {stmt_list}: err
+      | {call_stmt}: err
+        | {name printf}
+        | {expr_list}: err
+          | {strlit '%s
+'}: text notnull
+          | {expr_list}
+            | {dot}: err
+              | {name x}
+              | {name xyzzy}
+
+The statement ending at line XXXX
+
+CREATE PROC arg_shape_forwarder (args_arg1 INTEGER, args_arg2 TEXT, extra_args_id INTEGER, extra_args_name TEXT)
+BEGIN
+  CALL proc2(args.arg1, args.arg2);
+END;
+
+  {create_proc_stmt}: ok dml_proc
+  | {name arg_shape_forwarder}: ok dml_proc
+  | {proc_params_stmts}
+    | {params}: ok
+    | | {param}: args_arg1: integer variable in
+    | | | {param_detail}: args_arg1: integer variable in
+    | |   | {name args_arg1}: args_arg1: integer variable in
+    | |   | {type_int}: integer
+    | | {params}
+    |   | {param}: args_arg2: text variable in
+    |   | | {param_detail}: args_arg2: text variable in
+    |   |   | {name args_arg2}: args_arg2: text variable in
+    |   |   | {type_text}: text
+    |   | {params}
+    |     | {param}: extra_args_id: integer variable in
+    |     | | {param_detail}: extra_args_id: integer variable in
+    |     |   | {name extra_args_id}: extra_args_id: integer variable in
+    |     |   | {type_int}: integer
+    |     | {params}
+    |       | {param}: extra_args_name: text variable in
+    |         | {param_detail}: extra_args_name: text variable in
+    |           | {name extra_args_name}: extra_args_name: text variable in
+    |           | {type_text}: text
+    | {stmt_list}: ok
+      | {call_stmt}: ok dml_proc
+        | {name proc2}: ok dml_proc
+        | {expr_list}: ok
+          | {dot}: args_arg1: integer variable in
+          | | {name args}
+          | | {name arg1}
+          | {expr_list}
+            | {dot}: args_arg2: text variable in
+              | {name args}
+              | {name arg2}
 
 The statement ending at line XXXX
 
@@ -49769,9 +49964,10 @@ Error at test/sem_test.sql:XXXX : in like : CQL0069: name not found 'some_proc3'
   | {proc_params_stmts}
     | {params}: err
     | | {param}: err
-    |   | {like}: err
-    |     | {name some_proc3}: err
-    |     | {name some_proc3}: err
+    |   | {param_detail}
+    |     | {like}: err
+    |       | {name some_proc3}: err
+    |       | {name some_proc3}: err
     | {stmt_list}
       | {call_stmt}
         | {name some_proc}
@@ -49791,9 +49987,10 @@ Error at test/sem_test.sql:XXXX : in like : CQL0262: LIKE ... ARGUMENTS used on 
   | {proc_params_stmts}
     | {params}: err
       | {param}: err
-        | {like}: err
-          | {name proc1}: err
-          | {name proc1}: err
+        | {param_detail}
+          | {like}: err
+            | {name proc1}: err
+            | {name proc1}: err
 
 The statement ending at line XXXX
 

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -12503,3 +12503,35 @@ begin
    end;
 end;
 
+create table SalesInfo(
+  month integer,
+  amount real
+);
+
+-- TEST: sum is not allowed in a window range
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND sum(month) FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: sum is not allowed in a window range
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) OVER
+  (PARTITION BY sum(month) ROWS BETWEEN 1 PRECEDING AND 3 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: sum is not allowed in a window range
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN sum(month) PRECEDING AND 1 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+-- TEST: sum is not allowed in a filter expression
+-- + Error % function may not appear in this context 'sum'
+-- +1 Error
+SELECT month, amount, AVG(amount) FILTER(WHERE sum(month) = 1) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -949,6 +949,14 @@ BEGIN
   SELECT a_result;
 END;
 
+CREATE TEMP TRIGGER IF NOT EXISTS trigger1
+  BEFORE DELETE ON target_table1
+  FOR EACH ROW
+  WHEN complex_when_expression
+BEGIN
+  SELECT a_result;
+END;
+
 CREATE TRIGGER trigger2
   AFTER INSERT ON target_table2
 BEGIN
@@ -1184,6 +1192,94 @@ BEGIN
     END IF;
   END;
 END;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  SUM(amount) OVER (ORDER BY month) AS RunningTotal
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (PARTITION BY something ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SELECT month, amount, 
+  AVG(amount) OVER (GROUPS CURRENT ROW) AS SalesMovingAverage
+  FROM SalesInfo;
+
+SET trigger := 1;
+
+DECLARE x INTEGER NOT NULL @SENSITIVE;
+
+DECLARE x INTEGER NOT NULL @SENSITIVE;
+
+SET z := 1 BETWEEN (1 & 2) AND 3;
+
+SET z := 1 BETWEEN (1 | 2) AND 3;
+
+SET z := 1 BETWEEN (1 << 2) AND 3;
+
+SET z := 1 BETWEEN (1 >> 2) AND 3;
+
+SET z := 1 BETWEEN 1 + 2 AND 3;
+
+SET z := 1 BETWEEN 1 - 2 AND 3;
+
+SET z := 1 BETWEEN 1 * 2 AND 3;
+
+SET z := 1 BETWEEN 1 / 2 AND 3;
+
+SET z := 1 BETWEEN 1 % 2 AND 3;
+
+SET z := 1 BETWEEN -1 AND 3;
+
+SET z := 1 BETWEEN 'x' || 'y' AND 'z';
 
 SET file := 'path/I/do/not/like';
 

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -1281,6 +1281,10 @@ SET z := 1 BETWEEN -1 AND 3;
 
 SET z := 1 BETWEEN 'x' || 'y' AND 'z';
 
+CREATE PROC foo (x LIKE this, y LIKE that)
+BEGIN
+END;
+
 SET file := 'path/I/do/not/like';
 
 SET file := 'long/path/I/do/not/like';

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -926,6 +926,14 @@ begin
   select a_result;
 end;
 
+create temp trigger if not exists trigger1
+   delete on target_table1
+   for each row
+   when complex_when_expression
+begin
+  select a_result;
+end;
+
 create trigger trigger2
    after insert on target_table2
 begin
@@ -1111,7 +1119,7 @@ create table foo
 
 create proc foo()
 begin
-  proc savepoint 
+  proc savepoint
   begin
      if 1 then
        rollback return;
@@ -1120,6 +1128,84 @@ begin
      end if;
   end;
 end;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, SUM(amount) OVER
+  (ORDER BY month) RunningTotal
+FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING EXCLUDE NO OTHERS)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 3 PRECEDING AND 4 FOLLOWING EXCLUDE CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 4 PRECEDING AND 5 FOLLOWING EXCLUDE GROUP)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month ROWS BETWEEN 6 PRECEDING AND 7 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month RANGE BETWEEN 8 PRECEDING AND 9 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 10 PRECEDING AND 11 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND 12 FOLLOWING EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN 13 FOLLOWING AND 14 PRECEDING)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (PARTITION BY something ORDER BY month GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW EXCLUDE TIES)
+SalesMovingAverage FROM SalesInfo;
+
+SELECT month, amount, AVG(amount) OVER
+  (GROUPS CURRENT ROW)
+SalesMovingAverage FROM SalesInfo;
+
+/* test trigger is a valid name */
+set trigger := 1;
+
+declare x integer not null @sensitive;
+declare x integer @sensitive not null;
+
+set z := 1 between 1 & 2 and 3;
+set z := 1 between 1 | 2 and 3;
+set z := 1 between 1 << 2 and 3;
+set z := 1 between 1 >> 2 and 3;
+set z := 1 between 1 + 2 and 3;
+set z := 1 between 1 - 2 and 3;
+set z := 1 between 1 * 2 and 3;
+set z := 1 between 1 / 2 and 3;
+set z := 1 between 1 % 2 and 3;
+set z := 1 between -1 and 3;
+set z := 1 between 'x' || 'y' and 'z';
 
 --- keep this at the end because the line numbers will be whack after this so syntax errors will be annoying...
 

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1207,6 +1207,10 @@ set z := 1 between 1 % 2 and 3;
 set z := 1 between -1 and 3;
 set z := 1 between 'x' || 'y' and 'z';
 
+create proc foo(x like this, y like that)
+begin
+end;
+
 --- keep this at the end because the line numbers will be whack after this so syntax errors will be annoying...
 
 # 1 "long/path/I/do/not/like"


### PR DESCRIPTION
The idea here is that you you might want to create a procedure that takes two or more of something as an argument.  For instance:

create table Person (
 id integer not null,
 name text not null
);

create procedure foo(p1 like Person, p2 like Person)
begin
 ..
end;

This procedure would have arguments:

  p1_id, p1_name, p2_id, p2_name

Which could then be used maybe like this

call insert_person(from p1);
call insert_person(from p2);

the arguments can be accessed by name p1_name etc.  or equivalently p1.name
