### PR TITLE
Minor cleanups in arg bundle handling

### DIFF
--- a/sources/ast.h
+++ b/sources/ast.h
@@ -675,6 +675,7 @@ AST0(insert_or_abort);
 AST0(insert_or_fail);
 AST1(from_arguments);
 AST(from_cursor);
+AST(from_shape);
 AST(insert_dummy_spec);
 AST1(column_spec);
 AST0(star)

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -201,7 +201,7 @@ static void cql_reset_globals(void);
 %type <aval> begin_schema_region_stmt end_schema_region_stmt schema_ad_hoc_migration_stmt region_list region_spec from_arguments
 
 /* expressions and types */
-%type <aval> expr basic_expr math_expr expr_list typed_name typed_names case_list call_expr_list call_expr cursor_arguments
+%type <aval> expr basic_expr math_expr expr_list typed_name typed_names case_list call_expr_list call_expr shape_arguments
 %type <aval> name name_list opt_name_list opt_name
 %type <aval> data_type data_type_numeric data_type_opt_notnull creation_type object_type
 
@@ -801,7 +801,7 @@ case_list[result]:
 
 arg_expr: '*' { $arg_expr = new_ast_star(); }
   | expr { $arg_expr = $expr; }
-  | cursor_arguments { $arg_expr = $cursor_arguments; }
+  | shape_arguments { $arg_expr = $shape_arguments; }
   | from_arguments { $arg_expr = $from_arguments; }
   ;
 
@@ -816,14 +816,14 @@ expr_list[result]:
   | expr ',' expr_list[el]  { $result = new_ast_expr_list($expr, $el); }
   ;
 
-cursor_arguments:
-  FROM name  { $cursor_arguments = new_ast_from_cursor($name, NULL); }
-  | FROM name shape_def  { $cursor_arguments = new_ast_from_cursor($name, $shape_def); }
+shape_arguments:
+  FROM name  { $shape_arguments = new_ast_from_shape($name, NULL); }
+  | FROM name shape_def  { $shape_arguments = new_ast_from_shape($name, $shape_def); }
   ;
 
 call_expr:
   expr  { $call_expr = $expr; }
-  | cursor_arguments  { $call_expr = $cursor_arguments; }
+  | shape_arguments  { $call_expr = $shape_arguments; }
   | from_arguments  { $call_expr = $from_arguments; }
   ;
 

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -45,7 +45,7 @@ static void gen_query_parts(ast_node *ast);
 static void gen_select_stmt(ast_node *_Nonnull ast);
 static void gen_opt_where_without_new_line(ast_node *ast);
 static void gen_opt_orderby(ast_node *ast);
-static void gen_cursor_arg(ast_node *ast);
+static void gen_shape_arg(ast_node *ast);
 static void gen_insert_list(ast_node *_Nullable ast);
 static void gen_column_spec(ast_node *ast);
 static void gen_from_cursor(ast_node *ast);
@@ -616,8 +616,8 @@ static void gen_arg_expr(ast_node *ast) {
   else if (is_ast_from_arguments(ast)) {
     gen_from_arguments(ast);
   }
-  else if (is_ast_from_cursor(ast)) {
-    gen_cursor_arg(ast);
+  else if (is_ast_from_shape(ast)) {
+    gen_shape_arg(ast);
   }
   else {
     gen_root_expr(ast);
@@ -653,10 +653,10 @@ static void gen_expr_list(ast_node *ast) {
   }
 }
 
-static void gen_cursor_arg(ast_node *ast) {
-  Contract(is_ast_from_cursor(ast));
-  EXTRACT_STRING(cursor, ast->left);
-  gen_printf("FROM %s", cursor);
+static void gen_shape_arg(ast_node *ast) {
+  Contract(is_ast_from_shape(ast));
+  EXTRACT_STRING(shape, ast->left);
+  gen_printf("FROM %s", shape);
   if (ast->right) {
     gen_printf(" ");
     gen_shape_def(ast->right);
@@ -666,8 +666,8 @@ static void gen_cursor_arg(ast_node *ast) {
 static void gen_call_expr_list(ast_node *ast) {
   while (ast) {
     ast_node *left = ast->left;
-    if (is_ast_from_cursor(left)) {
-      gen_cursor_arg(left);
+    if (is_ast_from_shape(left)) {
+      gen_shape_arg(left);
     }
     else if (is_ast_from_arguments(left)) {
       gen_from_arguments(left);

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -14692,11 +14692,14 @@ static void sem_declare_proc_stmt(ast_node *ast) {
 
   if (params) {
     current_variables = locals = symtab_new();
+    arg_bundles = symtab_new();
 
     sem_params(params);
 
     symtab_delete(locals);
     locals = NULL;
+    symtab_delete(arg_bundles);
+    arg_bundles = NULL;
     current_variables = globals;
 
     if (is_error(params)) {

--- a/sources/sem.c
+++ b/sources/sem.c
@@ -127,7 +127,7 @@ static void sem_rewrite_insert_list_from_arguments(ast_node *ast, uint32_t count
 static void sem_rewrite_insert_list_from_cursor(ast_node *ast, ast_node *from_cursor, uint32_t count);
 static void sem_rewrite_like_column_spec_if_needed(ast_node *columns_values);
 static void sem_rewrite_from_cursor_if_needed(ast_node *ast_stmt, ast_node *columns_values);
-static void sem_rewrite_from_cursor_args(ast_node *head);
+static void sem_rewrite_from_shape_args(ast_node *head);
 static void sem_rewrite_from_arguments_in_call(ast_node *head);
 static bool_t sem_rewrite_col_key_list(ast_node *ast);
 static void enqueue_pending_region_validation(ast_node *prev, ast_node *cur, CSTR name);
@@ -6356,7 +6356,7 @@ static void sem_expr_raise(ast_node *ast, CSTR cstr) {
 static bool_t sem_rewrite_call_args_if_needed(ast_node *arg_list) {
   if (arg_list) {
     // if there are any cursor forms in the arg list that need to be expanded, do that here.
-    sem_rewrite_from_cursor_args(arg_list);
+    sem_rewrite_from_shape_args(arg_list);
     if (is_error(arg_list)) {
       return false;
     }
@@ -15479,7 +15479,7 @@ static void sem_validate_args_vs_formals(ast_node *ast, CSTR name, ast_node *arg
 // FROM cursor_name [LIKE type ] entries we encounter.  We don't validate
 // the types here.  That happens after expansion.  It's possible that the
 // types don't match at all, but we don't care yet.
-static void sem_rewrite_from_cursor_args(ast_node *head) {
+static void sem_rewrite_from_shape_args(ast_node *head) {
   Contract(is_ast_expr_list(head) || is_ast_arg_list(head));
 
   // We might need to make arg_list nodes or expr_list nodes, they are the same really
@@ -15488,7 +15488,7 @@ static void sem_rewrite_from_cursor_args(ast_node *head) {
 
   for (ast_node *item = head ; item ; item = item->right) {
     EXTRACT_ANY_NOTNULL(arg, item->left);
-    if (is_ast_from_cursor(arg)) {
+    if (is_ast_from_shape(arg)) {
       EXTRACT_ANY_NOTNULL(cursor, arg->left);
 
       if (!try_sem_arg_bundle(cursor)) {

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -11986,6 +11986,27 @@ DECLARE PROC decl3 (id INTEGER) (A INTEGER NOT NULL, B BOOL);
 
 The statement ending at line XXXX
 
+DECLARE PROC decl4 (x_A INTEGER NOT NULL, x_B BOOL);
+
+  {declare_proc_stmt}: ok
+  | {proc_name_type}
+  | | {name decl4}: ok
+  | | {int 0}
+  | {proc_params_stmts}
+    | {params}: ok
+      | {param}: x_A: integer notnull variable in
+      | | {param_detail}: x_A: integer notnull variable in
+      |   | {name x_A}: x_A: integer notnull variable in
+      |   | {notnull}: integer notnull
+      |     | {type_int}: integer
+      | {params}
+        | {param}: x_B: bool variable in
+          | {param_detail}: x_B: bool variable in
+            | {name x_B}: x_B: bool variable in
+            | {type_bool}: bool
+
+The statement ending at line XXXX
+
 CREATE PROC bogus_nested_declare ()
 BEGIN
   DECLARE PROC yy ();

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -47583,7 +47583,7 @@ Error at test/sem_test.sql:XXXX : in str : CQL0204: cursor not found 'not_a_curs
       | {call_stmt}: err
         | {name shape_consumer}
         | {expr_list}: err
-          | {from_cursor}
+          | {from_shape}
             | {name not_a_cursor}: err
 
 The statement ending at line XXXX
@@ -47722,7 +47722,7 @@ Error at test/sem_test.sql:XXXX : in like : CQL0202: must be a cursor, proc, tab
       | {call_stmt}: err
         | {name shape_y_only}
         | {expr_list}: err
-          | {from_cursor}
+          | {from_shape}
             | {name C}: C: select: { x: integer notnull, y: text notnull } variable auto_cursor value_cursor
             | {like}: err
               | {name not_a_real_shape}: err

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -3342,6 +3342,12 @@ declare proc decl2(id integer) using transaction;
 -- + declare_proc_stmt}: select: { A: integer notnull, B: bool } dml_proc
 declare proc decl3(id integer) ( A integer not null, B bool );
 
+-- TEST: try an arg bundle inside of a declared proc
+-- make sure the rewrite was accurate
+-- + DECLARE PROC decl4 (x_A INTEGER NOT NULL, x_B BOOL);
+-- - Error
+declare proc decl4(x like decl3);
+
 -- TEST: declare inside of a proc
 -- + Error
 -- +1 Error


### PR DESCRIPTION
The declare proc statement handling did not set up the arg bundle name table so it couldn't use arg bundles.  It doesn't do anything with the bundles so this is just a case of make the table then throw it away so it's not null.

The term "cursor args" was used in many places where it could be a cursor or an arg_bundle.  This is now the more general term shape args.  There's no code change here it's just renames for clarity.