### PR TITLE
Added @enforce_push and @enforce_pop to manage enforcement options

### DIFF
--- a/CQL_Guide/x4.md
+++ b/CQL_Guide/x4.md
@@ -2999,3 +2999,11 @@ vault_sensitive attribution only allow names. Integer, string literal, c string 
 ### CQL0364: vault_sensitive annotation can only go on a procedure that uses the database
 
 The named procedure has the `vault_sensitive` annotation to automatically encode sensitive value in the result set. Encoding value require the database, but the procedure in question doesn't even use the database at all.  This annotation is therefore useless.
+
+----
+
+### CQL0365: @enforce_pop used but there is nothing to pop
+
+Each `@enforce_pop` should match an `@enforce_push`, but there is nothing to pop on the stack now.
+
+----

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -801,6 +801,8 @@ AST(trigger_when_stmts);
 AST(trigger_body_vers);
 AST1(enforce_strict_stmt);
 AST1(enforce_normal_stmt);
+AST0(enforce_push_stmt);
+AST0(enforce_pop_stmt);
 AST(concat);
 AST(declare_deployable_region_stmt);
 AST(declare_schema_region_stmt);

--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -6062,6 +6062,8 @@ cql_noexport void cg_c_init(void) {
 
   NO_OP_STMT_INIT(enforce_normal_stmt);
   NO_OP_STMT_INIT(enforce_strict_stmt);
+  NO_OP_STMT_INIT(enforce_push_stmt);
+  NO_OP_STMT_INIT(enforce_pop_stmt);
   NO_OP_STMT_INIT(declare_schema_region_stmt);
   NO_OP_STMT_INIT(declare_deployable_region_stmt);
   NO_OP_STMT_INIT(begin_schema_region_stmt);

--- a/sources/cql.l
+++ b/sources/cql.l
@@ -187,6 +187,8 @@ BLOB                         { return BLOB; }
 UPSERT                       { return UPSERT; }
 STATEMENT                    { return STATEMENT; }
 TYPE                         { return TYPE; }
+@ENFORCE_PUSH                { return AT_ENFORCE_PUSH; }
+@ENFORCE_POP                 { return AT_ENFORCE_POP; }
 @ENFORCE_STRICT              { return AT_ENFORCE_STRICT; }
 @ENFORCE_NORMAL              { return AT_ENFORCE_NORMAL; }
 @SENSITIVE                   { return AT_SENSITIVE; }

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -159,7 +159,7 @@ static void cql_reset_globals(void);
 %token CAST WITH RECURSIVE REPLACE IGNORE ADD COLUMN RENAME ALTER
 %token AT_ECHO AT_CREATE AT_RECREATE AT_DELETE AT_SCHEMA_UPGRADE_VERSION AT_PREVIOUS_SCHEMA AT_SCHEMA_UPGRADE_SCRIPT
 %token AT_PROC AT_FILE AT_ATTRIBUTE AT_SENSITIVE DEFERRED NOT_DEFERRABLE DEFERRABLE IMMEDIATE EXCLUSIVE RESTRICT ACTION INITIALLY NO
-%token BEFORE AFTER INSTEAD OF FOR_EACH_ROW EXISTS RAISE FAIL ABORT AT_ENFORCE_STRICT AT_ENFORCE_NORMAL
+%token BEFORE AFTER INSTEAD OF FOR_EACH_ROW EXISTS RAISE FAIL ABORT AT_ENFORCE_STRICT AT_ENFORCE_NORMAL AT_ENFORCE_PUSH AT_ENFORCE_POP
 %token AT_BEGIN_SCHEMA_REGION AT_END_SCHEMA_REGION
 %token AT_DECLARE_SCHEMA_REGION AT_DECLARE_DEPLOYABLE_REGION AT_SCHEMA_AD_HOC_MIGRATION PRIVATE
 
@@ -238,7 +238,7 @@ static void cql_reset_globals(void);
 %type <aval> trycatch_stmt
 %type <aval> version_annotation
 %type <aval> while_stmt
-%type <aval> enforce_strict_stmt enforce_normal_stmt enforcement_options shape_def
+%type <aval> enforce_strict_stmt enforce_normal_stmt enforce_push_stmt enforce_pop_stmt enforcement_options shape_def
 
 %start program
 
@@ -341,6 +341,8 @@ any_stmt: select_stmt
   | previous_schema_stmt
   | enforce_strict_stmt
   | enforce_normal_stmt
+  | enforce_push_stmt
+  | enforce_pop_stmt
   | declare_schema_region_stmt
   | declare_deployable_region_stmt
   | begin_schema_region_stmt
@@ -1767,6 +1769,14 @@ enforce_strict_stmt:
 
 enforce_normal_stmt:
   AT_ENFORCE_NORMAL enforcement_options  { $enforce_normal_stmt = new_ast_enforce_normal_stmt($enforcement_options); }
+  ;
+
+enforce_push_stmt:
+  AT_ENFORCE_PUSH { $enforce_push_stmt = new_ast_enforce_push_stmt(); }
+  ;
+
+enforce_pop_stmt:
+  AT_ENFORCE_POP { $enforce_pop_stmt = new_ast_enforce_pop_stmt(); }
   ;
 
 %%

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -3062,6 +3062,16 @@ static void gen_enforce_normal_stmt(ast_node * ast) {
   gen_enforcement_options(ast->left);
 }
 
+static void gen_enforce_push_stmt(ast_node * ast) {
+  Contract(is_ast_enforce_push_stmt(ast));
+  gen_printf("@ENFORCE_PUSH");
+}
+
+static void gen_enforce_pop_stmt(ast_node * ast) {
+  Contract(is_ast_enforce_pop_stmt(ast));
+  gen_printf("@ENFORCE_POP");
+}
+
 static void gen_region_spec(ast_node *ast) {
   Contract(is_ast_region_spec(ast));
   EXTRACT_OPTION(type, ast->right);
@@ -3317,6 +3327,8 @@ cql_noexport void gen_init() {
   STMT_INIT(previous_schema_stmt);
   STMT_INIT(enforce_strict_stmt);
   STMT_INIT(enforce_normal_stmt);
+  STMT_INIT(enforce_push_stmt);
+  STMT_INIT(enforce_pop_stmt);
   STMT_INIT(declare_schema_region_stmt);
   STMT_INIT(declare_deployable_region_stmt);
   STMT_INIT(begin_schema_region_stmt);

--- a/sources/run_test_client.c
+++ b/sources/run_test_client.c
@@ -715,7 +715,7 @@ cql_code test_all_column_encoded_fetchers(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 5), "expected bl0 is encoded\n");
   cql_blob_ref bl0_decode = cql_decode_blob_ref_new(db, bl0);
   cql_blob_ref bl0_exp = cql_blob_ref_new("0", 1);
-  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value %s\n", (char*)bl0_decode->ptr);
+  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value %s\n", (const char*)bl0_decode->ptr);
   cql_blob_release(bl0_decode);
   cql_blob_release(bl0_exp);
 
@@ -751,7 +751,7 @@ cql_code test_all_column_encoded_fetchers(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 11), "expected bl1 is encoded\n");
   cql_blob_ref bl1_decode = cql_decode_blob_ref_new(db, bl1);
   cql_blob_ref bl1_exp = cql_blob_ref_new("1", 1);
-  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value %s\n", (char*)bl1_decode->ptr);
+  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value %s\n", (const char*)bl1_decode->ptr);
   cql_blob_release(bl1_decode);
   cql_blob_release(bl1_exp);
 
@@ -804,7 +804,7 @@ cql_code test_all_column_encoded_cursor(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 5), "expected bl0 is encoded\n");
   cql_blob_ref bl0_decode = cql_decode_blob_ref_new(db, bl0);
   cql_blob_ref bl0_exp = cql_blob_ref_new("0", 1);
-  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value %s\n", (char*)bl0_decode->ptr);
+  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value %s\n", (const char*)bl0_decode->ptr);
   cql_blob_release(bl0_decode);
   cql_blob_release(bl0_exp);
 
@@ -840,7 +840,7 @@ cql_code test_all_column_encoded_cursor(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 11), "expected bl1 is encoded\n");
   cql_blob_ref bl1_decode = cql_decode_blob_ref_new(db, bl1);
   cql_blob_ref bl1_exp = cql_blob_ref_new("1", 1);
-  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value %s\n", (char*)bl1_decode->ptr);
+  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value %s\n", (const char*)bl1_decode->ptr);
   cql_blob_release(bl1_decode);
   cql_blob_release(bl1_exp);
 
@@ -892,7 +892,7 @@ cql_code test_all_column_encoded_out_union(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 5), "expected bl0 is encoded\n");
   cql_blob_ref bl0_decode = cql_decode_blob_ref_new(db, bl0);
   cql_blob_ref bl0_exp = cql_blob_ref_new("0", 1);
-  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value %s\n", bl0_decode->ptr);
+  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value %s\n", (const char *)bl0_decode->ptr);
   cql_blob_release(bl0_decode);
   cql_blob_release(bl0_exp);
 
@@ -928,7 +928,7 @@ cql_code test_all_column_encoded_out_union(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 11), "expected bl1 is encoded\n");
   cql_blob_ref bl1_decode = cql_decode_blob_ref_new(db, bl1);
   cql_blob_ref bl1_exp = cql_blob_ref_new("1", 1);
-  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value %s\n", bl1_decode->ptr);
+  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value %s\n", (const char *)bl1_decode->ptr);
   cql_blob_release(bl1_decode);
   cql_blob_release(bl1_exp);
 
@@ -980,7 +980,7 @@ cql_code test_all_column_encoded_multi_out_union(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 5), "expected bl0 is encoded\n");
   cql_blob_ref bl0_decode = cql_decode_blob_ref_new(db, bl0);
   cql_blob_ref bl0_exp = cql_blob_ref_new("0", 2);
-  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value \"%s\"\n", bl0_decode->ptr);
+  E(cql_blob_equal(bl0_decode, bl0_exp), "expected bl0 is \"0\", value \"%s\"\n", (const char *)bl0_decode->ptr);
   cql_blob_release(bl0_decode);
   cql_blob_release(bl0_exp);
 
@@ -1016,7 +1016,7 @@ cql_code test_all_column_encoded_multi_out_union(sqlite3 *db) {
   E(cql_result_set_get_is_encoded_col((cql_result_set_ref)rs, 11), "expected bl1 is encoded\n");
   cql_blob_ref bl1_decode = cql_decode_blob_ref_new(db, bl1);
   cql_blob_ref bl1_exp = cql_blob_ref_new("1", 2);
-  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value \"%s\"\n", bl1_decode->ptr);
+  E(cql_blob_equal(bl1_decode, bl1_exp), "expected bl1 is \"1\", value \"%s\"\n", (const char *)bl1_decode->ptr);
   cql_blob_release(bl1_decode);
   cql_blob_release(bl1_exp);
 

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -996,4 +996,6 @@ Error at test/sem_test.sql:XXXX : in num : CQL0363: all arguments must be names 
 Error at test/sem_test.sql:XXXX : in str : CQL0363: all arguments must be names 'vault_sensitive'
 Error at test/sem_test.sql:XXXX : in misc_attrs : CQL0364: vault_sensitive annotation can only go on a procedure that uses the database
 Error at test/sem_test.sql:XXXX : in col_attrs_hidden : CQL0362: The HIDDEN column attribute must be the first attribute if present
+Error at test/sem_test.sql:XXXX : in col_attrs_fk : CQL0237: strict FK validation requires that some ON UPDATE option be selected for every foreign key
+Error at test/sem_test.sql:XXXX : in enforce_pop_stmt : CQL0365: @enforce_pop used but there is nothing to pop
 semantic errors present; no code gen.

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -55955,3 +55955,96 @@ Error at test/sem_test.sql:XXXX : in col_attrs_hidden : CQL0362: The HIDDEN colu
               | {name y}
               | {type_int}
 
+The statement ending at line XXXX
+
+@ENFORCE_NORMAL FOREIGN KEY ON UPDATE;
+
+  {enforce_normal_stmt}: ok
+  | {int 1}
+
+The statement ending at line XXXX
+
+@ENFORCE_NORMAL FOREIGN KEY ON DELETE;
+
+  {enforce_normal_stmt}: ok
+  | {int 2}
+
+The statement ending at line XXXX
+
+@ENFORCE_PUSH;
+
+  {enforce_push_stmt}: ok
+
+The statement ending at line XXXX
+
+@ENFORCE_STRICT FOREIGN KEY ON UPDATE;
+
+  {enforce_strict_stmt}: ok
+  | {int 1}
+
+The statement ending at line XXXX
+
+CREATE TABLE fk_strict_err_1(
+  id INTEGER REFERENCES foo (id)
+);
+
+Error at test/sem_test.sql:XXXX : in col_attrs_fk : CQL0237: strict FK validation requires that some ON UPDATE option be selected for every foreign key
+
+  {create_table_stmt}: err
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name fk_strict_err_1}
+  | {col_key_list}
+    | {col_def}: err
+      | {col_def_type_attrs}: ok
+        | {col_def_name_type}
+        | | {name id}
+        | | {type_int}: integer
+        | {col_attrs_fk}: err
+          | {fk_target_options}
+            | {fk_target}
+            | | {name foo}
+            | | {name_list}
+            |   | {name id}: id: integer notnull
+            | {int 0}
+
+The statement ending at line XXXX
+
+@ENFORCE_POP;
+
+  {enforce_pop_stmt}: ok
+
+The statement ending at line XXXX
+
+CREATE TABLE fk_strict_err_2(
+  id INTEGER REFERENCES foo (id)
+);
+
+  {create_table_stmt}: fk_strict_err_2: { id: integer foreign_key }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name fk_strict_err_2}
+  | {col_key_list}
+    | {col_def}: id: integer foreign_key
+      | {col_def_type_attrs}: ok
+        | {col_def_name_type}
+        | | {name id}
+        | | {type_int}: integer
+        | {col_attrs_fk}: ok
+          | {fk_target_options}
+            | {fk_target}
+            | | {name foo}
+            | | {name_list}
+            |   | {name id}: id: integer notnull
+            | {int 0}
+
+The statement ending at line XXXX
+
+@ENFORCE_POP;
+
+Error at test/sem_test.sql:XXXX : in enforce_pop_stmt : CQL0365: @enforce_pop used but there is nothing to pop
+
+  {enforce_pop_stmt}: err
+

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -1418,6 +1418,10 @@ CREATE TABLE foo(
   x INTEGER HIDDEN
 );
 
+@ENFORCE_PUSH;
+
+@ENFORCE_POP;
+
 SET file := 'path/I/do/not/like';
 
 SET file := 'long/path/I/do/not/like';

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1316,6 +1316,11 @@ create table foo(
  x integer hidden
 );
 
+
+@enforce_push;
+
+@enforce_pop;
+
 --- keep this at the end because the line numbers will be whack after this so syntax errors will be annoying...
 
 # 1 "long/path/I/do/not/like"


### PR DESCRIPTION
This will let us safely include temporary option changes in shared header files