### PR TITLE
Markdown formatting fixes

### DIFF
--- a/CQL_Guide/ch03.md
+++ b/CQL_Guide/ch03.md
@@ -932,7 +932,7 @@ Each of these has their own macro for `retain` and `release` though all three ac
 
 #### Assigning to an `out` parameter or a global variable
 
-* `out,`inout`parameters, and global variables work just like local variables except that CQL does not call`release` at the end of the procedure
+* `out`, `inout` parameters, and global variables work just like local variables except that CQL does not call `release` at the end of the procedure
 
 ### Function Return Values
 

--- a/CQL_Guide/ch05.md
+++ b/CQL_Guide/ch05.md
@@ -503,13 +503,13 @@ end;
 ```
  Automatic cursors are so much easier to use than explicit storage that explicit storage is rarely seen.  Storing to `out` parameters is a case where explicit is ok, the `out` parameters have to be declared anyway.
 
- #### For Value Cursors
+#### For Value Cursors
 
  A cursor declared in one of these forms:
 
  * `declare C cursor fetch from call foo(args)`
    * `foo` must be a procedure that returns one row with `OUT`
- * `declare C cursor like select 1 id, "x" name;
+ * `declare C cursor like select 1 id, "x" name;`
  * `declare C cursor like X;`
    * where X is the name of a table, a view, another cursor, or a procedure that returns a structured result
 
@@ -548,7 +548,7 @@ With this form, any possible valid cursor values could be set, but many forms of
 
 * `fetch C(a,b) from cursor D(a,b)`
   * the named columns of D are used as the values
-  * in this case it becomes: `fetch C(a,b) from values(D.a, D.b);
+  * in this case it becomes: `fetch C(a,b) from values(D.a, D.b);`
 
 That most recent form does seem like it saves much but recall the first rewrite:
 
@@ -577,7 +577,7 @@ Like can be used in both places, for instance suppose `E` is a cursor that has a
 
  As is mentioned above, the `fetch` form means to load an entire row into the cursor.  This is important because "half loaded" cursors would be semantically problematic.  However there are many cases where you might like to amend the values of an already loaded cursor.  You can do this with the `update` form.
 
- * `update cursor C(a,b,..) from values(1,2,..);
+ * `update cursor C(a,b,..) from values(1,2,..);`
    * the update form is a no-op if the cursor is not already loaded with values (!!)
    * the columns and values are type checked so a valid row is ensured (or no row)
    * all the re-writes above are legal so `update cursor C(like D) from D` is possible, it is in fact the use-case for which this was designed.

--- a/CQL_Guide/generated/guide.html
+++ b/CQL_Guide/generated/guide.html
@@ -6,6 +6,136 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
   <title>The CQL Programming Language</title>
   <style>
+    html {
+      line-height: 1.5;
+      font-family: Georgia, serif;
+      font-size: 20px;
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      word-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 1em;
+      }
+    }
+    @media print {
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
+      font-size: 85%;
+      margin: 0;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      background-color: #1a1a1a;
+      border: none;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
     code{white-space: pre-wrap;}
     span.smallcaps{font-variant: small-caps;}
     span.underline{text-decoration: underline;}
@@ -15,6 +145,7 @@
     pre > code.sourceCode { white-space: pre; position: relative; }
     pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
     pre > code.sourceCode > span:empty { height: 1.2em; }
+    .sourceCode { overflow: visible; }
     code.sourceCode > span { color: inherit; text-decoration: inherit; }
     div.sourceCode { margin: 1em 0; }
     pre.sourceCode { margin: 0; }
@@ -74,6 +205,7 @@
     code span.va { color: #19177c; } /* Variable */
     code span.vs { color: #4070a0; } /* VerbatimString */
     code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
   </style>
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
@@ -613,31 +745,31 @@
 <p>NOTE: CQL was created to help solve problems in the building of Facebook’s Messenger application, but this content is free from references to Messenger. The CQL code generation here is done in the simplest mode with the fewest runtime dependencies allowed for illustration.</p>
 <h3 id="getting-started">Getting Started</h3>
 <p>The “Hello World” program rendered in CQL looks like this:</p>
-<div class="sourceCode" id="cb1"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb1-1"><a href="#cb1-1"></a><span class="kw">create</span> proc hello()</span>
-<span id="cb1-2"><a href="#cb1-2"></a><span class="cf">begin</span></span>
-<span id="cb1-3"><a href="#cb1-3"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;Hello, world\n&quot;</span>);</span>
-<span id="cb1-4"><a href="#cb1-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb1"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc hello()</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;Hello, world\n&quot;</span>);</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This very nearly works exactly as written but we’ll need a little bit of glue to wire it all up. Let’s talk about that glue.</p>
 <p>First, to build this example we’ll use cql in its simplest mode. You may need to build the <code>cql</code> executable first. From a source distribution you can run <code>make</code> in the <code>cql</code> directory to do the job. You can get the binary from the <code>out</code> directory after the build. Arrange for <code>cql</code> to be on your PATH.</p>
 <p>With that done you should have the power to do this:</p>
-<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1"></a><span class="ex">cql</span> --in hello.sql --cg hello.h hello.c</span></code></pre></div>
+<div class="sourceCode" id="cb2"><pre class="sourceCode sh"><code class="sourceCode bash"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="ex">cql</span> <span class="at">--in</span> hello.sql <span class="at">--cg</span> hello.h hello.c</span></code></pre></div>
 <p>This will produce the C output files <code>hello.c</code> and <code>hello.h</code> which can be readily compiled.</p>
 <p>However, hello.c will not have a <code>main</code> – rather it will have a function like this:</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb3-1"><a href="#cb3-1"></a><span class="dt">void</span> hello(<span class="dt">void</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> hello<span class="op">(</span><span class="dt">void</span><span class="op">);</span></span></code></pre></div>
 <p>The declaration of this function can be found in <code>hello.h</code>.</p>
 <p>That <code>hello</code> function is not quite adequate to do get a running program, which brings us to the next step in getting things running. Typically you have some kind of client program that will execute the procedures you create in CQL. Let’s create a simple one in a file we’ll creatively name <code>main.c</code>.</p>
 <p>A very simple CQL main might look like this:</p>
-<div class="sourceCode" id="cb4"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb4-1"><a href="#cb4-1"></a><span class="pp">#include </span><span class="im">&lt;stdlib.h&gt;</span></span>
-<span id="cb4-2"><a href="#cb4-2"></a><span class="pp">#include </span><span class="im">&quot;hello.h&quot;</span></span>
-<span id="cb4-3"><a href="#cb4-3"></a><span class="dt">int</span> main(<span class="dt">int</span> argc, <span class="dt">char</span> **argv)</span>
-<span id="cb4-4"><a href="#cb4-4"></a>{</span>
-<span id="cb4-5"><a href="#cb4-5"></a>   hello();</span>
-<span id="cb4-6"><a href="#cb4-6"></a>   <span class="cf">return</span> <span class="dv">0</span>;</span>
-<span id="cb4-7"><a href="#cb4-7"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;stdlib.h&gt;</span></span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&quot;hello.h&quot;</span></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">(</span><span class="dt">int</span> argc<span class="op">,</span> <span class="dt">char</span> <span class="op">**</span>argv<span class="op">)</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>   hello<span class="op">();</span></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a>   <span class="cf">return</span> <span class="dv">0</span><span class="op">;</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p>Now we should be able to get do the following:</p>
-<div class="sourceCode" id="cb5"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1"></a>$ <span class="fu">cc</span> -o hello main.c hello.c</span>
-<span id="cb5-2"><a href="#cb5-2"></a>$ <span class="ex">./hello</span></span>
-<span id="cb5-3"><a href="#cb5-3"></a><span class="ex">Hello</span>, world</span></code></pre></div>
+<div class="sourceCode" id="cb5"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cc <span class="at">-o</span> hello main.c hello.c</span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> ./hello</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a><span class="ex">Hello,</span> world</span></code></pre></div>
 <p>NOTE: hello.c will attempt to <code>#include "cqlrt.h"</code> the declarations for CQL runtime functions. You must make arrangements for the compiler to be able to find <code>cqlrt.h</code> either by adding it to an <code>INCLUDE</code> path or by adding some -I options to help the compiler find the source. For now you could keep <code>cqlrt.h</code> in the same directory as the examples and avoid that complication.</p>
 <h3 id="why-did-this-work">Why did this work?</h3>
 <p>A number of things are going on even in this simple program that are worth discussing:</p>
@@ -660,24 +792,24 @@
 <p>All of these facts put together mean that the normal simple linkage rules result in an executable that prints the string “Hello, world” and then a newline.</p>
 <h3 id="variables-and-arithmetic">Variables and Arithmetic</h3>
 <p>Borrowing once again from examples in “The C Programming Language”, it’s possible to do significant control flow in CQL without reference to databases. The following program illustrates a variety of concepts:</p>
-<div class="sourceCode" id="cb6"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb6-1"><a href="#cb6-1"></a><span class="co">-- print a conversion table  for temperatures from 0 to 300</span></span>
-<span id="cb6-2"><a href="#cb6-2"></a><span class="kw">create</span> proc conversions()</span>
-<span id="cb6-3"><a href="#cb6-3"></a><span class="cf">begin</span></span>
-<span id="cb6-4"><a href="#cb6-4"></a>  <span class="kw">declare</span> fahr, celsius <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb6-5"><a href="#cb6-5"></a>  <span class="kw">declare</span> <span class="fu">lower</span>, <span class="fu">upper</span>, step <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb6-6"><a href="#cb6-6"></a></span>
-<span id="cb6-7"><a href="#cb6-7"></a>  <span class="kw">set</span> <span class="fu">lower</span> <span class="op">:=</span> <span class="dv">0</span>;   <span class="co">/* lower limit of range */</span></span>
-<span id="cb6-8"><a href="#cb6-8"></a>  <span class="kw">set</span> <span class="fu">upper</span> <span class="op">:=</span> <span class="dv">300</span>; <span class="co">/* upper limit of range */</span></span>
-<span id="cb6-9"><a href="#cb6-9"></a>  <span class="kw">set</span> step <span class="op">:=</span> <span class="dv">20</span>;   <span class="co">/* step size */</span></span>
-<span id="cb6-10"><a href="#cb6-10"></a></span>
-<span id="cb6-11"><a href="#cb6-11"></a>  <span class="kw">set</span> fahr <span class="op">:=</span> <span class="fu">lower</span>;</span>
-<span id="cb6-12"><a href="#cb6-12"></a>  <span class="cf">while</span> fahr <span class="op">&lt;=</span> <span class="fu">upper</span></span>
-<span id="cb6-13"><a href="#cb6-13"></a>  <span class="cf">begin</span></span>
-<span id="cb6-14"><a href="#cb6-14"></a>    <span class="kw">set</span> celsius <span class="op">:=</span> <span class="dv">5</span> <span class="op">*</span> (fahr <span class="op">-</span> <span class="dv">32</span>) <span class="op">/</span> <span class="dv">9</span>;</span>
-<span id="cb6-15"><a href="#cb6-15"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%d\t%d\n&quot;</span>, fahr, celsius);</span>
-<span id="cb6-16"><a href="#cb6-16"></a>    <span class="kw">set</span> fahr <span class="op">:=</span> fahr <span class="op">+</span> step;</span>
-<span id="cb6-17"><a href="#cb6-17"></a>  <span class="cf">end</span>;</span>
-<span id="cb6-18"><a href="#cb6-18"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb6"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- print a conversion table  for temperatures from 0 to 300</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc conversions()</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> fahr, celsius <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> <span class="fu">lower</span>, <span class="fu">upper</span>, step <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> <span class="fu">lower</span> <span class="op">:=</span> <span class="dv">0</span>;   <span class="co">/* lower limit of range */</span></span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> <span class="fu">upper</span> <span class="op">:=</span> <span class="dv">300</span>; <span class="co">/* upper limit of range */</span></span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> step <span class="op">:=</span> <span class="dv">20</span>;   <span class="co">/* step size */</span></span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> fahr <span class="op">:=</span> <span class="fu">lower</span>;</span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> fahr <span class="op">&lt;=</span> <span class="fu">upper</span></span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">set</span> celsius <span class="op">:=</span> <span class="dv">5</span> <span class="op">*</span> (fahr <span class="op">-</span> <span class="dv">32</span>) <span class="op">/</span> <span class="dv">9</span>;</span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%d\t%d\n&quot;</span>, fahr, celsius);</span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">set</span> fahr <span class="op">:=</span> fahr <span class="op">+</span> step;</span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>You may notice that both the SQL style <code>--</code> line prefix comments and the C style <code>/* */</code> forms are acceptable comment forms. Indeed, it’s actually quite normal to pass CQL source through the C pre-processor before giving it to the CQL compiler, thereby gaining <code>#define</code> and <code>#include</code> as well as other pre-processing options like token pasting in addition to the other comment forms. More on this later.</p>
 <p>Like C, in CQL all variables must be declared before they are used. They remain in scope until the end of the procedure in which they are declared, or they are global scoped if they are declared outside of any procedure. The declarations announce the names and types of the local variables. Importantly, variables stay in scope for the whole procedure even if they are declared within a nested <code>begin</code> and <code>end</code> block.</p>
 <p>The most basic types are the scalar or “unitary” types (as they are referred to in the compiler)</p>
@@ -737,21 +869,21 @@
 <p>The size of the reference types is machine dependent, whatever the local pointer size is. The non-reference types use machine independent declarations like <code>int32_t</code> to get exactly the desired sizes in a portable fashion.</p>
 <p>All reference types are initialized to <code>NULL</code> when they are declared.</p>
 <p>The programs execution begins with three assignments:</p>
-<div class="sourceCode" id="cb7"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb7-1"><a href="#cb7-1"></a>  <span class="kw">set</span> <span class="fu">lower</span> <span class="op">:=</span> <span class="dv">0</span>; </span>
-<span id="cb7-2"><a href="#cb7-2"></a>  <span class="kw">set</span> <span class="fu">upper</span> <span class="op">:=</span> <span class="dv">300</span>;</span>
-<span id="cb7-3"><a href="#cb7-3"></a>  <span class="kw">set</span> step <span class="op">:=</span> <span class="dv">20</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb7"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> <span class="fu">lower</span> <span class="op">:=</span> <span class="dv">0</span>; </span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> <span class="fu">upper</span> <span class="op">:=</span> <span class="dv">300</span>;</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> step <span class="op">:=</span> <span class="dv">20</span>;</span></code></pre></div>
 <p>This initializes the variables just like in the isomorphic C code. Statements are seperated by semicolons, just like in C.</p>
 <p>The table is then printed using a <code>while</code> loop</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb8-1"><a href="#cb8-1"></a>  <span class="cf">while</span> fahr <span class="op">&lt;=</span> <span class="fu">upper</span></span>
-<span id="cb8-2"><a href="#cb8-2"></a>  <span class="cf">begin</span></span>
-<span id="cb8-3"><a href="#cb8-3"></a>    <span class="op">..</span>.</span>
-<span id="cb8-4"><a href="#cb8-4"></a>  <span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb8"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> fahr <span class="op">&lt;=</span> <span class="fu">upper</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">..</span>.</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span></code></pre></div>
 <p>This has the usual meaning, with the statements in the <code>begin/end</code> block being executed repeatedly until the condition becomes false.</p>
 <p>The body of a <code>begin/end</code> block such as the one in the <code>while</code> statement can contain one or more statements.</p>
 <p>The typical computation of Celsius temperature ensues with this code:</p>
-<div class="sourceCode" id="cb9"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb9-1"><a href="#cb9-1"></a>  <span class="kw">set</span> celsius <span class="op">:=</span> <span class="dv">5</span> <span class="op">*</span> (fahr <span class="op">-</span> <span class="dv">32</span>) <span class="op">/</span> <span class="dv">9</span>;</span>
-<span id="cb9-2"><a href="#cb9-2"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%d\t%d\n&quot;</span>, fahr, celsius);</span>
-<span id="cb9-3"><a href="#cb9-3"></a>  <span class="kw">set</span> fahr <span class="op">:=</span> fahr <span class="op">+</span> step;</span></code></pre></div>
+<div class="sourceCode" id="cb9"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> celsius <span class="op">:=</span> <span class="dv">5</span> <span class="op">*</span> (fahr <span class="op">-</span> <span class="dv">32</span>) <span class="op">/</span> <span class="dv">9</span>;</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%d\t%d\n&quot;</span>, fahr, celsius);</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> fahr <span class="op">:=</span> fahr <span class="op">+</span> step;</span></code></pre></div>
 <p>This computes the celsuis and then prints it out, moving on to the next entry in the table.</p>
 <p>Importantly, the CQL compiler uses the normal SQLite order of operations, which is NOT the C order of operatations. As a result, the compiler may need to add parentheses in the C output to get the correct order; or it may remove some parentheses because they are not needed in the C order even though they were in the SQL order.</p>
 <p>The <code>printf</code> call operates as before, with the <code>fahr</code> and <code>celsius</code> variables being passed on to the C runtime library for formatting, unchanged.</p>
@@ -769,7 +901,7 @@
 </ul>
 <h3 id="preprocessing-features">Preprocessing Features</h3>
 <p>CQL does not include its own pre-processor but it is designed to consume the output the C pre-processor. To do this, you can either write the output of the pre-processor to a temporary file and read it into CQL as usual or you can set up a pipeline something like this:</p>
-<div class="sourceCode" id="cb10"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1"></a><span class="fu">cc</span> -x c -E your_program.sql <span class="kw">|</span> <span class="ex">cql</span> --cg your_program.h your_program.c</span></code></pre></div>
+<div class="sourceCode" id="cb10"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="fu">cc</span> <span class="at">-x</span> c <span class="at">-E</span> your_program.sql <span class="kw">|</span> <span class="ex">cql</span> <span class="at">--cg</span> your_program.h your_program.c</span></code></pre></div>
 <p>The above causes the C compiler to invoke only the pre-processor <code>-E</code> and to treat the input as though it were C code <code>-x c</code> even though it is in a <code>.sql</code> file. Later examples will assume that you have configured CQL to be used with the C pre-processor as above.</p>
 <h2 id="chapter-2-using-data">Chapter 2: Using Data</h2>
 <!---
@@ -781,80 +913,80 @@
 <p>The point of using CQL is to facilitate access to a SQLite database so we’ll switch gears to a slightly more complicated setup. We’ll still keep things fairly simple but let’s start to use some database features. Note: it is not the intent of this tutorial to also be a primer for the SQLite programming language which is so ably documented on https://sqlite.org/. Please refer to that site for details on the meaning of the SQL statements used here if you are new to SQL.</p>
 <h3 id="a-sample-program">A Sample Program</h3>
 <p>Suppose we have the following program:</p>
-<div class="sourceCode" id="cb11"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb11-1"><a href="#cb11-1"></a><span class="kw">create</span> <span class="kw">table</span> my_data(t text <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb11-2"><a href="#cb11-2"></a></span>
-<span id="cb11-3"><a href="#cb11-3"></a><span class="kw">create</span> proc hello()</span>
-<span id="cb11-4"><a href="#cb11-4"></a><span class="cf">begin</span></span>
-<span id="cb11-5"><a href="#cb11-5"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data(t)  <span class="kw">values</span>(<span class="ot">&quot;Hello, world\n&quot;</span>);</span>
-<span id="cb11-6"><a href="#cb11-6"></a>  <span class="kw">declare</span> t text <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb11-7"><a href="#cb11-7"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data);</span>
-<span id="cb11-8"><a href="#cb11-8"></a>  <span class="kw">call</span> printf(<span class="st">&#39;%s&#39;</span>, t);</span>
-<span id="cb11-9"><a href="#cb11-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb11"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> my_data(t text <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb11-3"><a href="#cb11-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc hello()</span>
+<span id="cb11-4"><a href="#cb11-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb11-5"><a href="#cb11-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data(t)  <span class="kw">values</span>(<span class="ot">&quot;Hello, world\n&quot;</span>);</span>
+<span id="cb11-6"><a href="#cb11-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> t text <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb11-7"><a href="#cb11-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data);</span>
+<span id="cb11-8"><a href="#cb11-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="st">&#39;%s&#39;</span>, t);</span>
+<span id="cb11-9"><a href="#cb11-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>That looks like an interesting little baby program and it appears as though it would once again print that most famous of salutations, “Hello, world”.</p>
 <p>Well, it doesn’t. At least, not yet. Let’s walk through the various things that are going to go wrong as this will teach us everything we need to know about activating CQL from some environment of your choice.</p>
 <h3 id="providing-a-suitable-database">Providing a Suitable Database</h3>
 <p>CQL is just a compiler, it doesn’t know how the code it creates will be provisioned any more than say clang does. It creates functions with predictable signatures so that they can be called from C just as easily as the SQLite API itself, and using the same currency. Our new version of <code>hello</code> now requires a database handle because it performs database operations. Also there are now opportunities for the database operations to fail, and so <code>hello</code> now provides a return code.</p>
 <p>A new minimal <code>main</code> program might look something like this:</p>
-<div class="sourceCode" id="cb12"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb12-1"><a href="#cb12-1"></a><span class="pp">#include </span><span class="im">&lt;stdlib.h&gt;</span></span>
-<span id="cb12-2"><a href="#cb12-2"></a><span class="pp">#include </span><span class="im">&lt;sqlite3.h&gt;</span></span>
-<span id="cb12-3"><a href="#cb12-3"></a></span>
-<span id="cb12-4"><a href="#cb12-4"></a><span class="dt">int</span> main(<span class="dt">int</span> argc, <span class="dt">char</span> **argv)</span>
-<span id="cb12-5"><a href="#cb12-5"></a>{</span>
-<span id="cb12-6"><a href="#cb12-6"></a>  sqlite3 *db;</span>
-<span id="cb12-7"><a href="#cb12-7"></a>  <span class="dt">int</span> rc = sqlite3_open(<span class="st">&quot;:memory:&quot;</span>, &amp;db);</span>
-<span id="cb12-8"><a href="#cb12-8"></a>  <span class="cf">if</span> (rc != SQLITE_OK) {</span>
-<span id="cb12-9"><a href="#cb12-9"></a>    exit(<span class="dv">1</span>); <span class="co">/* not exactly world class error handling but that isn&#39;t the point */</span></span>
-<span id="cb12-10"><a href="#cb12-10"></a>  }</span>
-<span id="cb12-11"><a href="#cb12-11"></a>  rc = hello(db);</span>
-<span id="cb12-12"><a href="#cb12-12"></a>  <span class="cf">if</span> (rc != SQLITE_OK) {</span>
-<span id="cb12-13"><a href="#cb12-13"></a>    exit(<span class="dv">2</span>);</span>
-<span id="cb12-14"><a href="#cb12-14"></a>  }</span>
-<span id="cb12-15"><a href="#cb12-15"></a></span>
-<span id="cb12-16"><a href="#cb12-16"></a>  sqlite3_close(db);</span>
-<span id="cb12-17"><a href="#cb12-17"></a>}</span></code></pre></div>
+<div class="sourceCode" id="cb12"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;stdlib.h&gt;</span></span>
+<span id="cb12-2"><a href="#cb12-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#include </span><span class="im">&lt;sqlite3.h&gt;</span></span>
+<span id="cb12-3"><a href="#cb12-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-4"><a href="#cb12-4" aria-hidden="true" tabindex="-1"></a><span class="dt">int</span> main<span class="op">(</span><span class="dt">int</span> argc<span class="op">,</span> <span class="dt">char</span> <span class="op">**</span>argv<span class="op">)</span></span>
+<span id="cb12-5"><a href="#cb12-5" aria-hidden="true" tabindex="-1"></a><span class="op">{</span></span>
+<span id="cb12-6"><a href="#cb12-6" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>db<span class="op">;</span></span>
+<span id="cb12-7"><a href="#cb12-7" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> rc <span class="op">=</span> sqlite3_open<span class="op">(</span><span class="st">&quot;:memory:&quot;</span><span class="op">,</span> <span class="op">&amp;</span>db<span class="op">);</span></span>
+<span id="cb12-8"><a href="#cb12-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>rc <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb12-9"><a href="#cb12-9" aria-hidden="true" tabindex="-1"></a>    exit<span class="op">(</span><span class="dv">1</span><span class="op">);</span> <span class="co">/* not exactly world class error handling but that isn&#39;t the point */</span></span>
+<span id="cb12-10"><a href="#cb12-10" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb12-11"><a href="#cb12-11" aria-hidden="true" tabindex="-1"></a>  rc <span class="op">=</span> hello<span class="op">(</span>db<span class="op">);</span></span>
+<span id="cb12-12"><a href="#cb12-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> <span class="op">(</span>rc <span class="op">!=</span> SQLITE_OK<span class="op">)</span> <span class="op">{</span></span>
+<span id="cb12-13"><a href="#cb12-13" aria-hidden="true" tabindex="-1"></a>    exit<span class="op">(</span><span class="dv">2</span><span class="op">);</span></span>
+<span id="cb12-14"><a href="#cb12-14" aria-hidden="true" tabindex="-1"></a>  <span class="op">}</span></span>
+<span id="cb12-15"><a href="#cb12-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb12-16"><a href="#cb12-16" aria-hidden="true" tabindex="-1"></a>  sqlite3_close<span class="op">(</span>db<span class="op">);</span></span>
+<span id="cb12-17"><a href="#cb12-17" aria-hidden="true" tabindex="-1"></a><span class="op">}</span></span></code></pre></div>
 <p>If we re-run CQL and look in the <code>hello.h</code> output file we’ll see that the declaration of the <code>hello</code> function is now:</p>
-<div class="sourceCode" id="cb13"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb13-1"><a href="#cb13-1"></a>  cql_code hello(sqlite3 *_db_);</span></code></pre></div>
+<div class="sourceCode" id="cb13"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>  cql_code hello<span class="op">(</span>sqlite3 <span class="op">*</span>_db_<span class="op">);</span></span></code></pre></div>
 <p>indicating that the database is used and a SQLite return code is provided. We’re nearly there. If you attempt to build the program as before there will be several link-time errors due to missing functions. Typically these are resolved by providing the SQLite library to the command line and also adding the CQL runtime. The new command line looks something like this:</p>
-<div class="sourceCode" id="cb14"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1"></a>$ <span class="fu">cc</span> -o hello main.c hello.c cqlrt.c -lsqlite3</span>
-<span id="cb14-2"><a href="#cb14-2"></a>$ <span class="ex">./hello</span></span>
-<span id="cb14-3"><a href="#cb14-3"></a><span class="ex">Hello</span>, world</span></code></pre></div>
+<div class="sourceCode" id="cb14"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cc <span class="at">-o</span> hello main.c hello.c cqlrt.c <span class="at">-lsqlite3</span></span>
+<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> ./hello</span>
+<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a><span class="ex">Hello,</span> world</span></code></pre></div>
 <p>The cql runtime can be anywhere you want it to be, and of course the usual C seperate compilation methods can be applied. More on that later.</p>
 <p>But actually, that program doesn’t quite work yet. If you run it, you’ll get an error result code, not the message “Hello, world”.</p>
 <p>Let’s talk about the final missing bit.</p>
 <h3 id="declaring-schema">Declaring Schema</h3>
 <p>In CQL a loose piece of Data Definition Language (henceforth DDL) does not actually create or drop anything. In most CQL programs, the normal situation is that “something” has already created the database and put some data in it. You need to tell the CQL compiler about the schema so that it knows what the tables are and what to expect to find in those tables. This is because typically you’re reconnecting to some sort of existing database. So, in CQL, loose DDL simply <em>declares</em> schema, it does not create it. To create schema you have to put the DDL into a procedure you can run. If you do that, then the DDL still serves a declaration, but also the schema will be created when the procedure is executed.</p>
 <p>We need to change our program a tiny bit.</p>
-<div class="sourceCode" id="cb15"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb15-1"><a href="#cb15-1"></a><span class="kw">create</span> proc hello()</span>
-<span id="cb15-2"><a href="#cb15-2"></a><span class="cf">begin</span></span>
-<span id="cb15-3"><a href="#cb15-3"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(t text <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb15-4"><a href="#cb15-4"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data(t) <span class="kw">values</span>(<span class="ot">&quot;Hello, world\n&quot;</span>);</span>
-<span id="cb15-5"><a href="#cb15-5"></a>  <span class="kw">declare</span> t text <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb15-6"><a href="#cb15-6"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data);</span>
-<span id="cb15-7"><a href="#cb15-7"></a>  <span class="kw">call</span> printf(<span class="st">&#39;%s&#39;</span>, t);</span>
-<span id="cb15-8"><a href="#cb15-8"></a>  <span class="kw">drop</span> <span class="kw">table</span> my_data;</span>
-<span id="cb15-9"><a href="#cb15-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb15"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc hello()</span>
+<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(t text <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data(t) <span class="kw">values</span>(<span class="ot">&quot;Hello, world\n&quot;</span>);</span>
+<span id="cb15-5"><a href="#cb15-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> t text <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb15-6"><a href="#cb15-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data);</span>
+<span id="cb15-7"><a href="#cb15-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="st">&#39;%s&#39;</span>, t);</span>
+<span id="cb15-8"><a href="#cb15-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">drop</span> <span class="kw">table</span> my_data;</span>
+<span id="cb15-9"><a href="#cb15-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>If we rebuild the program, it will now behave as expected.</p>
 <h3 id="explaining-the-new-hello-world">Explaining The New Hello World</h3>
 <p>Let’s go over every important line of the new program, starting from main.</p>
-<div class="sourceCode" id="cb16"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb16-1"><a href="#cb16-1"></a>  <span class="dt">int</span> rc = sqlite3_open(<span class="st">&quot;:memory:&quot;</span>, &amp;db);</span></code></pre></div>
+<div class="sourceCode" id="cb16"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a>  <span class="dt">int</span> rc <span class="op">=</span> sqlite3_open<span class="op">(</span><span class="st">&quot;:memory:&quot;</span><span class="op">,</span> <span class="op">&amp;</span>db<span class="op">);</span></span></code></pre></div>
 <p>This statement gives us an empty private in-memory only database to work with. This is the simplest case and it’s still very useful. The <code>sqlite_open</code> and <code>sqlite_open_v2</code> functions can be used to create a variety of databases per the SQLite documentation.</p>
 <p>We’ll need such a database to use our procedure, and we use it in the call here:</p>
-<div class="sourceCode" id="cb17"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb17-1"><a href="#cb17-1"></a>  rc = hello(db);</span></code></pre></div>
+<div class="sourceCode" id="cb17"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>  rc <span class="op">=</span> hello<span class="op">(</span>db<span class="op">);</span></span></code></pre></div>
 <p>This provides a valid db handle to our procedure. Note that the procedure doesn’t know what database it is supposed to operate on, it expects to be handed a suitable database on a silver platter. In fact any given proc could be used with various databases at various times. Just like SQLite, CQL does not enforce any particular database setup; it does what you tell it to.</p>
 <p>When <code>hello</code> runs we begin with</p>
-<div class="sourceCode" id="cb18"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb18-1"><a href="#cb18-1"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(t text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb18"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(t text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
 <p>This will create the <code>my_data</code> table with a single column <code>t</code>, of type <code>text not null</code>. That will work because we know we’re going to be called with a fresh/empty database. More typically you might do <code>create table if not exists ...</code> or otherwise have a general attach/create phase or something like that. We’ll dispense with that here.</p>
 <p>Next we’ll run the insert statement:</p>
-<div class="sourceCode" id="cb19"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb19-1"><a href="#cb19-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data(t) <span class="kw">values</span>(<span class="ot">&quot;Hello, world\n&quot;</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data(t) <span class="kw">values</span>(<span class="ot">&quot;Hello, world\n&quot;</span>);</span></code></pre></div>
 <p>This will add a single row to the table. Note that we have again used double quotes, meaning this is a C string literal. This is highly convenient given the escape sequences. Normally SQLite text has the newlines directly embedded in it; that practice isn’t very compiler friendly, hence the alternative.</p>
 <p>Next we declare a local variable to hold our data.</p>
-<div class="sourceCode" id="cb20"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb20-1"><a href="#cb20-1"></a>  <span class="kw">declare</span> t text <span class="kw">not</span> <span class="kw">null</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb20"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> t text <span class="kw">not</span> <span class="kw">null</span>;</span></code></pre></div>
 <p>This is a simple string reference, it will be initialized to <code>NULL</code> by default. That’s actually important; even though the variable is <code>NOT NULL</code> there is no reasonable default value for it other than <code>NULL</code>. The <code>NOT NULL</code> declaration will guard against <code>NULL</code> assignments but it will not prevent reference types from beginning with <code>NULL</code> as their value. Junk would be worse and some random initialized value would create unnecessary cost. This mirrors the choice the C language makes with its <code>_Nonnull</code> extensions.</p>
 <p>At this point we can read back our data.</p>
-<div class="sourceCode" id="cb21"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb21-1"><a href="#cb21-1"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data);</span></code></pre></div>
+<div class="sourceCode" id="cb21"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data);</span></code></pre></div>
 <p>This form of database reading has very limited usability but it does work for this case and it is illustrative. The presence of <code>(select ...)</code> indicates to the CQL compiler that parenthesized expression should be given to SQLite for evaluation according to the SQLite rules. The expression is statically checked at compile time to ensure that it has exactly one result column. In this case the <code>*</code> is just column <code>t</code>, and actually it would have be clearer to use <code>t</code> directly here but then there wouldn’t have a reason to talk about <code>*</code> and multiple columns. At run time, the <code>select</code> query must return exactly one row or an error code will be returned. It’s not uncommmon to see <code>(select ... limit 1)</code> to force the issue. But that still leaves the possibility of zero rows, which would be an error. We’ll talk about more flexible ways to read from the database later.</p>
 <p>At this point it seems wise to bring up the unusual expression evaluation properties of CQL. CQL is by necessity a two-headed beast. On the one side there is a rich expression evaluation language for working with local variables. Those expressions are compiled into C logic that emulates the behavior of SQLite on the data. It provides complex expression constructs such <code>IN</code> and <code>CASE</code> but it is ultimately evaluated by C execution. Alternately, anything that is inside of a piece of SQL is necessarily evaluated by SQLite itself. To make this clearer let’s change the example a little bit before we move on.</p>
-<div class="sourceCode" id="cb22"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb22-1"><a href="#cb22-1"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="ot">&quot;__&quot;</span><span class="op">||</span>t<span class="op">||</span><span class="st">&#39; &#39;</span><span class="op">||</span><span class="fl">1.234</span> <span class="kw">from</span> my_data);</span></code></pre></div>
+<div class="sourceCode" id="cb22"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> t <span class="op">:=</span> (<span class="kw">select</span> <span class="ot">&quot;__&quot;</span><span class="op">||</span>t<span class="op">||</span><span class="st">&#39; &#39;</span><span class="op">||</span><span class="fl">1.234</span> <span class="kw">from</span> my_data);</span></code></pre></div>
 <p>This is a somewhat silly example but it illustrates some important things:</p>
 <ul>
 <li>even though SQLite doesn’t support double quotes that’s no problem because CQL will convert the expression into single quotes with the correct escape values as a matter of course during compilation</li>
@@ -864,128 +996,128 @@
 <li>in fact the conversions are so subtle as to be impossible to emulate in loose C code with any economy, so, like a few other operators, <code>||</code> is only supported in the SQLite context</li>
 </ul>
 <p>Returning now to our code as written, we see something very familiar:</p>
-<div class="sourceCode" id="cb23"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb23-1"><a href="#cb23-1"></a>  <span class="kw">call</span> printf(<span class="st">&#39;%s&#39;</span>, t);</span></code></pre></div>
+<div class="sourceCode" id="cb23"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="st">&#39;%s&#39;</span>, t);</span></code></pre></div>
 <p>Note we’ve used the single quote syntax here for no good reason other than illustration. There are no escape sequences here so either form would the job. Importantly, the string literal will not create a string object as before but the text variable <code>t</code> is of course a string reference. Before it can be used in a call to an un-declared function it must be converted into a temporary C string. This might require allocation in general, that allocation is automatically managed. Note that by default CQL assumes that calls to unknown C functions should be emitted as written. In this way you can use <code>printf</code> even though CQL knows nothing about it.</p>
 <p>Lastly we have:</p>
-<div class="sourceCode" id="cb24"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb24-1"><a href="#cb24-1"></a>  <span class="kw">drop</span> <span class="kw">table</span> my_data;</span></code></pre></div>
+<div class="sourceCode" id="cb24"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">drop</span> <span class="kw">table</span> my_data;</span></code></pre></div>
 <p>This is not strictly necessary because the database is in memory anyway and the program is about to exit but there it is for illustration.</p>
 <p>Now the Data Manipulation Langauge (i.e. insert and select here; and henceforth DML) and the DDL might fail for various reasons. If that happens the proc will <code>goto</code> a cleanup handler and return the failed return code instead of running the rest of the code. Any temporary memory allocations will be freed and any pending SQLite statements will be finalized. More on that later when we discuss error handling.</p>
 <p>With that we have a much more complicated program that prints “Hello, world”</p>
 <h3 id="introducing-cursors">Introducing Cursors</h3>
 <p>In order to read data with reasonable flexibility, we need a more powerful construction. Let’s change our example again and start using some database features.</p>
-<div class="sourceCode" id="cb25"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb25-1"><a href="#cb25-1"></a><span class="kw">create</span> proc hello()</span>
-<span id="cb25-2"><a href="#cb25-2"></a><span class="cf">begin</span></span>
-<span id="cb25-3"><a href="#cb25-3"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(</span>
-<span id="cb25-4"><a href="#cb25-4"></a>    pos <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">primary</span> <span class="kw">key</span>,</span>
-<span id="cb25-5"><a href="#cb25-5"></a>    txt text <span class="kw">not</span> <span class="kw">null</span></span>
-<span id="cb25-6"><a href="#cb25-6"></a>  );</span>
-<span id="cb25-7"><a href="#cb25-7"></a></span>
-<span id="cb25-8"><a href="#cb25-8"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">2</span>, <span class="st">&#39;World&#39;</span>);</span>
-<span id="cb25-9"><a href="#cb25-9"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">0</span>, <span class="st">&#39;Hello&#39;</span>);</span>
-<span id="cb25-10"><a href="#cb25-10"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">1</span>, <span class="st">&#39;There&#39;</span>);</span>
-<span id="cb25-11"><a href="#cb25-11"></a></span>
-<span id="cb25-12"><a href="#cb25-12"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data <span class="kw">order</span> <span class="kw">by</span> pos;</span>
-<span id="cb25-13"><a href="#cb25-13"></a></span>
-<span id="cb25-14"><a href="#cb25-14"></a>  <span class="cf">loop</span> fetch C</span>
-<span id="cb25-15"><a href="#cb25-15"></a>  <span class="cf">begin</span></span>
-<span id="cb25-16"><a href="#cb25-16"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%d: %s\n&quot;</span>, C.pos, C.txt);</span>
-<span id="cb25-17"><a href="#cb25-17"></a>  <span class="cf">end</span>;</span>
-<span id="cb25-18"><a href="#cb25-18"></a>  <span class="kw">close</span> C;</span>
-<span id="cb25-19"><a href="#cb25-19"></a></span>
-<span id="cb25-20"><a href="#cb25-20"></a>  <span class="kw">drop</span> <span class="kw">table</span> my_data;</span>
-<span id="cb25-21"><a href="#cb25-21"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc hello()</span>
+<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(</span>
+<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    pos <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">primary</span> <span class="kw">key</span>,</span>
+<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>    txt text <span class="kw">not</span> <span class="kw">null</span></span>
+<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">2</span>, <span class="st">&#39;World&#39;</span>);</span>
+<span id="cb25-9"><a href="#cb25-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">0</span>, <span class="st">&#39;Hello&#39;</span>);</span>
+<span id="cb25-10"><a href="#cb25-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">1</span>, <span class="st">&#39;There&#39;</span>);</span>
+<span id="cb25-11"><a href="#cb25-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-12"><a href="#cb25-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data <span class="kw">order</span> <span class="kw">by</span> pos;</span>
+<span id="cb25-13"><a href="#cb25-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-14"><a href="#cb25-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">loop</span> fetch C</span>
+<span id="cb25-15"><a href="#cb25-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb25-16"><a href="#cb25-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%d: %s\n&quot;</span>, C.pos, C.txt);</span>
+<span id="cb25-17"><a href="#cb25-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb25-18"><a href="#cb25-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">close</span> C;</span>
+<span id="cb25-19"><a href="#cb25-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb25-20"><a href="#cb25-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">drop</span> <span class="kw">table</span> my_data;</span>
+<span id="cb25-21"><a href="#cb25-21" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Reviewing the essential parts of the above.</p>
-<div class="sourceCode" id="cb26"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb26-1"><a href="#cb26-1"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(</span>
-<span id="cb26-2"><a href="#cb26-2"></a>    pos <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">primary</span> <span class="kw">key</span>,</span>
-<span id="cb26-3"><a href="#cb26-3"></a>    txt text <span class="kw">not</span> <span class="kw">null</span></span>
-<span id="cb26-4"><a href="#cb26-4"></a>  );</span></code></pre></div>
+<div class="sourceCode" id="cb26"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb26-1"><a href="#cb26-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">create</span> <span class="kw">table</span> my_data(</span>
+<span id="cb26-2"><a href="#cb26-2" aria-hidden="true" tabindex="-1"></a>    pos <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">primary</span> <span class="kw">key</span>,</span>
+<span id="cb26-3"><a href="#cb26-3" aria-hidden="true" tabindex="-1"></a>    txt text <span class="kw">not</span> <span class="kw">null</span></span>
+<span id="cb26-4"><a href="#cb26-4" aria-hidden="true" tabindex="-1"></a>  );</span></code></pre></div>
 <p>The table now includes a position column to give us some ordering. That is the primary key.</p>
-<div class="sourceCode" id="cb27"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb27-1"><a href="#cb27-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">2</span>, <span class="st">&#39;World&#39;</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb27"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb27-1"><a href="#cb27-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> my_data <span class="kw">values</span>(<span class="dv">2</span>, <span class="st">&#39;World&#39;</span>);</span></code></pre></div>
 <p>The insert statements provide both columns, not in the printed order. The insert form where the columns are not specified indicates that all the columns will be present, in order, this is more economical to type. CQL will generate errors at compile time if there are any missing columns or if any of the values are not type compatible with the indicated column.</p>
 <p>The most important change is here:</p>
-<div class="sourceCode" id="cb28"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb28-1"><a href="#cb28-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data <span class="kw">order</span> <span class="kw">by</span> pos;</span></code></pre></div>
+<div class="sourceCode" id="cb28"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb28-1"><a href="#cb28-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_data <span class="kw">order</span> <span class="kw">by</span> pos;</span></code></pre></div>
 <p>We’ve created a non-scalar variable <code>C</code>, a cursor over the indicated result set. The results will be ordered by <code>pos</code>.</p>
-<div class="sourceCode" id="cb29"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb29-1"><a href="#cb29-1"></a>  <span class="cf">loop</span> fetch C</span>
-<span id="cb29-2"><a href="#cb29-2"></a>  <span class="cf">begin</span></span>
-<span id="cb29-3"><a href="#cb29-3"></a>   <span class="op">..</span>.</span>
-<span id="cb29-4"><a href="#cb29-4"></a>  <span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb29"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb29-1"><a href="#cb29-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">loop</span> fetch C</span>
+<span id="cb29-2"><a href="#cb29-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb29-3"><a href="#cb29-3" aria-hidden="true" tabindex="-1"></a>   <span class="op">..</span>.</span>
+<span id="cb29-4"><a href="#cb29-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span></code></pre></div>
 <p>This loop will run until there are no results left (it might not run at all if there are zero rows, that is not an error). The <code>FETCH</code> construct allows you to specify target variables, but if you do not do so, then a synethetic structure is automatically created to capture the projection of the <code>select</code>. In this case the columns are <code>pos</code> and <code>txt</code>. The automatically created storage exactly matches the type of the columns in the select list which could itself be tricky to calculate if the <code>select</code> is complex. In this case the <code>select</code> is quite simple and the columns of the result directly match the schema for <code>my_data</code>. An integer and a string reference. Both not null.</p>
-<div class="sourceCode" id="cb30"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb30-1"><a href="#cb30-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%d: %s\n&quot;</span>, C.pos, C.txt);</span></code></pre></div>
+<div class="sourceCode" id="cb30"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb30-1"><a href="#cb30-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%d: %s\n&quot;</span>, C.pos, C.txt);</span></code></pre></div>
 <p>The storage for the cursor is given the same names as the columns of the projection of the select, in this case the columns were not renamed so <code>pos</code> and <code>txt</code> are the fields in the cursor. Double quotes were used in the format string to get the newline in there easily.</p>
-<div class="sourceCode" id="cb31"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb31-1"><a href="#cb31-1"></a>  <span class="kw">close</span> C;</span></code></pre></div>
+<div class="sourceCode" id="cb31"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb31-1"><a href="#cb31-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">close</span> C;</span></code></pre></div>
 <p>The cursor is automatically released at the end of the procedure but in this case we’d like to release it before the <code>drop table</code> happens so there is an explicit <code>close</code>. This is frequently elided in favor of the automatic cleanup. There is an <code>open</code> cursor statement as well but it doesn’t do anything. It’s there because many systems have that construct and it does balance the <code>close</code>.</p>
 <p>If you compile and run this program you’ll get this output.</p>
-<div class="sourceCode" id="cb32"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb32-1"><a href="#cb32-1"></a>$ <span class="fu">cc</span> -x c -E hello.sql <span class="kw">|</span> <span class="ex">cql</span> --cg hello.h hello.c</span>
-<span id="cb32-2"><a href="#cb32-2"></a>$ <span class="fu">cc</span> -o hello main.c hello.c cqlrt.c -lsqlite3</span>
-<span id="cb32-3"><a href="#cb32-3"></a>$ <span class="ex">./hello</span></span>
-<span id="cb32-4"><a href="#cb32-4"></a><span class="ex">0</span>: Hello</span>
-<span id="cb32-5"><a href="#cb32-5"></a><span class="ex">1</span>: There</span>
-<span id="cb32-6"><a href="#cb32-6"></a><span class="ex">2</span>: World</span></code></pre></div>
+<div class="sourceCode" id="cb32"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb32-1"><a href="#cb32-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cc <span class="at">-x</span> c <span class="at">-E</span> hello.sql <span class="kw">|</span> <span class="ex">cql</span> <span class="at">--cg</span> hello.h hello.c</span>
+<span id="cb32-2"><a href="#cb32-2" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> cc <span class="at">-o</span> hello main.c hello.c cqlrt.c <span class="at">-lsqlite3</span></span>
+<span id="cb32-3"><a href="#cb32-3" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span> ./hello</span>
+<span id="cb32-4"><a href="#cb32-4" aria-hidden="true" tabindex="-1"></a><span class="ex">0:</span> Hello</span>
+<span id="cb32-5"><a href="#cb32-5" aria-hidden="true" tabindex="-1"></a><span class="ex">1:</span> There</span>
+<span id="cb32-6"><a href="#cb32-6" aria-hidden="true" tabindex="-1"></a><span class="ex">2:</span> World</span></code></pre></div>
 <p>So the data was inserted and then sorted.</p>
 <h3 id="going-crazy">Going Crazy</h3>
 <p>We’ve only scratched the surface of what SQLite can do and most DML constructs are supported by CQL. This includes common table expressions, and even recursive versions of the same. But remember, when it comes to DML, the CQL compiler only has to validate the types and figure out what the result shape will be – SQLite always does all the heavy lifting of evaluation. All of this means with remarkably little additional code, the example below from the SQLite documentation can be turned into a CQL stored proc using the constructs we have defined above.</p>
-<div class="sourceCode" id="cb33"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb33-1"><a href="#cb33-1"></a><span class="kw">create</span> proc mandelbrot()</span>
-<span id="cb33-2"><a href="#cb33-2"></a><span class="cf">begin</span></span>
-<span id="cb33-3"><a href="#cb33-3"></a>  <span class="co">-- this is basically one giant select statement</span></span>
-<span id="cb33-4"><a href="#cb33-4"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span></span>
-<span id="cb33-5"><a href="#cb33-5"></a>    <span class="kw">with</span> recursive</span>
-<span id="cb33-6"><a href="#cb33-6"></a>      <span class="co">-- x from -2.0 to +1.2</span></span>
-<span id="cb33-7"><a href="#cb33-7"></a>      xaxis(x) <span class="kw">as</span> (<span class="kw">select</span> <span class="op">-</span><span class="fl">2.0</span> <span class="kw">union</span> <span class="kw">all</span> <span class="kw">select</span> x <span class="op">+</span> <span class="fl">0.05</span> <span class="kw">from</span> xaxis <span class="kw">where</span> x <span class="op">&lt;</span> <span class="fl">1.2</span>),</span>
-<span id="cb33-8"><a href="#cb33-8"></a></span>
-<span id="cb33-9"><a href="#cb33-9"></a>      <span class="co">-- y from -1.0 to +1.0</span></span>
-<span id="cb33-10"><a href="#cb33-10"></a>      yaxis(y) <span class="kw">as</span> (<span class="kw">select</span> <span class="op">-</span><span class="fl">1.0</span> <span class="kw">union</span> <span class="kw">all</span> <span class="kw">select</span> y <span class="op">+</span> <span class="fl">0.1</span> <span class="kw">from</span> yaxis <span class="kw">where</span> y <span class="op">&lt;</span> <span class="fl">1.0</span>),</span>
-<span id="cb33-11"><a href="#cb33-11"></a></span>
-<span id="cb33-12"><a href="#cb33-12"></a>      m(iter, cx, cy, x, y) <span class="kw">as</span> (</span>
-<span id="cb33-13"><a href="#cb33-13"></a>        <span class="co">-- initial seed iteration count 0, at each of the points in the above grid</span></span>
-<span id="cb33-14"><a href="#cb33-14"></a>        <span class="kw">select</span> <span class="dv">0</span> iter, x cx, y cy, <span class="fl">0.0</span> x, <span class="fl">0.0</span> y <span class="kw">from</span> xaxis, yaxis</span>
-<span id="cb33-15"><a href="#cb33-15"></a>        <span class="kw">union</span> <span class="kw">all</span></span>
-<span id="cb33-16"><a href="#cb33-16"></a>        <span class="co">-- the next point is always iter +1, same (x,y) and the next iteration of z^2 + c</span></span>
-<span id="cb33-17"><a href="#cb33-17"></a>        <span class="kw">select</span> iter<span class="op">+</span><span class="dv">1</span> iter, cx, cy, x<span class="op">*</span>x<span class="op">-</span>y<span class="op">*</span>y <span class="op">+</span> cx x, <span class="fl">2.0</span><span class="op">*</span>x<span class="op">*</span>y <span class="op">+</span> cy y <span class="kw">from</span> m</span>
-<span id="cb33-18"><a href="#cb33-18"></a>        <span class="co">-- stop condition, the point has escaped OR iteration count &gt; 28</span></span>
-<span id="cb33-19"><a href="#cb33-19"></a>        <span class="kw">where</span> (x<span class="op">*</span>x <span class="op">+</span> y<span class="op">*</span>y) <span class="op">&lt;</span> <span class="fl">4.0</span> <span class="kw">and</span> iter <span class="op">&lt;</span> <span class="dv">28</span></span>
-<span id="cb33-20"><a href="#cb33-20"></a>      ),</span>
-<span id="cb33-21"><a href="#cb33-21"></a>      m2(iter, cx, cy) <span class="kw">as</span> (</span>
-<span id="cb33-22"><a href="#cb33-22"></a>       <span class="co">-- find the last iteration for any given point to get that count</span></span>
-<span id="cb33-23"><a href="#cb33-23"></a>       <span class="kw">select</span> <span class="fu">max</span>(iter), cx, cy <span class="kw">from</span> m <span class="kw">group</span> <span class="kw">by</span> cx, cy</span>
-<span id="cb33-24"><a href="#cb33-24"></a>      ),</span>
-<span id="cb33-25"><a href="#cb33-25"></a>      a(t) <span class="kw">as</span> (</span>
-<span id="cb33-26"><a href="#cb33-26"></a>        <span class="co">-- convert the iteration count to a printable character, grouping by line</span></span>
-<span id="cb33-27"><a href="#cb33-27"></a>        <span class="kw">select</span> group_concat(<span class="fu">substr</span>(<span class="ot">&quot; .+*#&quot;</span>, <span class="dv">1</span> <span class="op">+</span> <span class="fu">min</span>(iter<span class="op">/</span><span class="dv">7</span>,<span class="dv">4</span>), <span class="dv">1</span>), <span class="st">&#39;&#39;</span>)</span>
-<span id="cb33-28"><a href="#cb33-28"></a>        <span class="kw">from</span> m2 <span class="kw">group</span> <span class="kw">by</span> cy</span>
-<span id="cb33-29"><a href="#cb33-29"></a>      )</span>
-<span id="cb33-30"><a href="#cb33-30"></a>    <span class="co">-- group all the lines together</span></span>
-<span id="cb33-31"><a href="#cb33-31"></a>    <span class="kw">select</span> <span class="fu">rtrim</span>(t) line <span class="kw">from</span> a;</span>
-<span id="cb33-32"><a href="#cb33-32"></a></span>
-<span id="cb33-33"><a href="#cb33-33"></a>  <span class="co">-- slurp out the data</span></span>
-<span id="cb33-34"><a href="#cb33-34"></a>  <span class="cf">loop</span> fetch C</span>
-<span id="cb33-35"><a href="#cb33-35"></a>  <span class="cf">begin</span></span>
-<span id="cb33-36"><a href="#cb33-36"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%s\n&quot;</span>, C.line);</span>
-<span id="cb33-37"><a href="#cb33-37"></a>  <span class="cf">end</span>;</span>
-<span id="cb33-38"><a href="#cb33-38"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb33"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb33-1"><a href="#cb33-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc mandelbrot()</span>
+<span id="cb33-2"><a href="#cb33-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb33-3"><a href="#cb33-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- this is basically one giant select statement</span></span>
+<span id="cb33-4"><a href="#cb33-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span></span>
+<span id="cb33-5"><a href="#cb33-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">with</span> recursive</span>
+<span id="cb33-6"><a href="#cb33-6" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- x from -2.0 to +1.2</span></span>
+<span id="cb33-7"><a href="#cb33-7" aria-hidden="true" tabindex="-1"></a>      xaxis(x) <span class="kw">as</span> (<span class="kw">select</span> <span class="op">-</span><span class="fl">2.0</span> <span class="kw">union</span> <span class="kw">all</span> <span class="kw">select</span> x <span class="op">+</span> <span class="fl">0.05</span> <span class="kw">from</span> xaxis <span class="kw">where</span> x <span class="op">&lt;</span> <span class="fl">1.2</span>),</span>
+<span id="cb33-8"><a href="#cb33-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-9"><a href="#cb33-9" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- y from -1.0 to +1.0</span></span>
+<span id="cb33-10"><a href="#cb33-10" aria-hidden="true" tabindex="-1"></a>      yaxis(y) <span class="kw">as</span> (<span class="kw">select</span> <span class="op">-</span><span class="fl">1.0</span> <span class="kw">union</span> <span class="kw">all</span> <span class="kw">select</span> y <span class="op">+</span> <span class="fl">0.1</span> <span class="kw">from</span> yaxis <span class="kw">where</span> y <span class="op">&lt;</span> <span class="fl">1.0</span>),</span>
+<span id="cb33-11"><a href="#cb33-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-12"><a href="#cb33-12" aria-hidden="true" tabindex="-1"></a>      m(iter, cx, cy, x, y) <span class="kw">as</span> (</span>
+<span id="cb33-13"><a href="#cb33-13" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- initial seed iteration count 0, at each of the points in the above grid</span></span>
+<span id="cb33-14"><a href="#cb33-14" aria-hidden="true" tabindex="-1"></a>        <span class="kw">select</span> <span class="dv">0</span> iter, x cx, y cy, <span class="fl">0.0</span> x, <span class="fl">0.0</span> y <span class="kw">from</span> xaxis, yaxis</span>
+<span id="cb33-15"><a href="#cb33-15" aria-hidden="true" tabindex="-1"></a>        <span class="kw">union</span> <span class="kw">all</span></span>
+<span id="cb33-16"><a href="#cb33-16" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- the next point is always iter +1, same (x,y) and the next iteration of z^2 + c</span></span>
+<span id="cb33-17"><a href="#cb33-17" aria-hidden="true" tabindex="-1"></a>        <span class="kw">select</span> iter<span class="op">+</span><span class="dv">1</span> iter, cx, cy, x<span class="op">*</span>x<span class="op">-</span>y<span class="op">*</span>y <span class="op">+</span> cx x, <span class="fl">2.0</span><span class="op">*</span>x<span class="op">*</span>y <span class="op">+</span> cy y <span class="kw">from</span> m</span>
+<span id="cb33-18"><a href="#cb33-18" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- stop condition, the point has escaped OR iteration count &gt; 28</span></span>
+<span id="cb33-19"><a href="#cb33-19" aria-hidden="true" tabindex="-1"></a>        <span class="kw">where</span> (x<span class="op">*</span>x <span class="op">+</span> y<span class="op">*</span>y) <span class="op">&lt;</span> <span class="fl">4.0</span> <span class="kw">and</span> iter <span class="op">&lt;</span> <span class="dv">28</span></span>
+<span id="cb33-20"><a href="#cb33-20" aria-hidden="true" tabindex="-1"></a>      ),</span>
+<span id="cb33-21"><a href="#cb33-21" aria-hidden="true" tabindex="-1"></a>      m2(iter, cx, cy) <span class="kw">as</span> (</span>
+<span id="cb33-22"><a href="#cb33-22" aria-hidden="true" tabindex="-1"></a>       <span class="co">-- find the last iteration for any given point to get that count</span></span>
+<span id="cb33-23"><a href="#cb33-23" aria-hidden="true" tabindex="-1"></a>       <span class="kw">select</span> <span class="fu">max</span>(iter), cx, cy <span class="kw">from</span> m <span class="kw">group</span> <span class="kw">by</span> cx, cy</span>
+<span id="cb33-24"><a href="#cb33-24" aria-hidden="true" tabindex="-1"></a>      ),</span>
+<span id="cb33-25"><a href="#cb33-25" aria-hidden="true" tabindex="-1"></a>      a(t) <span class="kw">as</span> (</span>
+<span id="cb33-26"><a href="#cb33-26" aria-hidden="true" tabindex="-1"></a>        <span class="co">-- convert the iteration count to a printable character, grouping by line</span></span>
+<span id="cb33-27"><a href="#cb33-27" aria-hidden="true" tabindex="-1"></a>        <span class="kw">select</span> group_concat(<span class="fu">substr</span>(<span class="ot">&quot; .+*#&quot;</span>, <span class="dv">1</span> <span class="op">+</span> <span class="fu">min</span>(iter<span class="op">/</span><span class="dv">7</span>,<span class="dv">4</span>), <span class="dv">1</span>), <span class="st">&#39;&#39;</span>)</span>
+<span id="cb33-28"><a href="#cb33-28" aria-hidden="true" tabindex="-1"></a>        <span class="kw">from</span> m2 <span class="kw">group</span> <span class="kw">by</span> cy</span>
+<span id="cb33-29"><a href="#cb33-29" aria-hidden="true" tabindex="-1"></a>      )</span>
+<span id="cb33-30"><a href="#cb33-30" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- group all the lines together</span></span>
+<span id="cb33-31"><a href="#cb33-31" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> <span class="fu">rtrim</span>(t) line <span class="kw">from</span> a;</span>
+<span id="cb33-32"><a href="#cb33-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb33-33"><a href="#cb33-33" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- slurp out the data</span></span>
+<span id="cb33-34"><a href="#cb33-34" aria-hidden="true" tabindex="-1"></a>  <span class="cf">loop</span> fetch C</span>
+<span id="cb33-35"><a href="#cb33-35" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb33-36"><a href="#cb33-36" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%s\n&quot;</span>, C.line);</span>
+<span id="cb33-37"><a href="#cb33-37" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb33-38"><a href="#cb33-38" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This code uses all kinds of SQLite features to produce this text:</p>
-<div class="sourceCode" id="cb34"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb34-1"><a href="#cb34-1"></a>$</span>
-<span id="cb34-2"><a href="#cb34-2"></a>                                    <span class="ex">....</span>#</span>
-<span id="cb34-3"><a href="#cb34-3"></a>                                   <span class="ex">..</span>#*..</span>
-<span id="cb34-4"><a href="#cb34-4"></a>                                 <span class="ex">..+</span>####+.</span>
-<span id="cb34-5"><a href="#cb34-5"></a>                            <span class="ex">.......+</span>####....   +</span>
-<span id="cb34-6"><a href="#cb34-6"></a>                           <span class="ex">..</span>##+*##########+.++++</span>
-<span id="cb34-7"><a href="#cb34-7"></a>                          <span class="ex">.+.</span>##################+.</span>
-<span id="cb34-8"><a href="#cb34-8"></a>              <span class="ex">.............+</span>###################+.+</span>
-<span id="cb34-9"><a href="#cb34-9"></a>              <span class="ex">..++..</span>#.....*#####################+.</span>
-<span id="cb34-10"><a href="#cb34-10"></a>             <span class="ex">...+</span>#######++#######################.</span>
-<span id="cb34-11"><a href="#cb34-11"></a>          <span class="ex">....+*</span>################################.</span>
-<span id="cb34-12"><a href="#cb34-12"></a> <span class="co">#############################################...</span></span>
-<span id="cb34-13"><a href="#cb34-13"></a>          <span class="ex">....+*</span>################################.</span>
-<span id="cb34-14"><a href="#cb34-14"></a>             <span class="ex">...+</span>#######++#######################.</span>
-<span id="cb34-15"><a href="#cb34-15"></a>              <span class="ex">..++..</span>#.....*#####################+.</span>
-<span id="cb34-16"><a href="#cb34-16"></a>              <span class="ex">.............+</span>###################+.+</span>
-<span id="cb34-17"><a href="#cb34-17"></a>                          <span class="ex">.+.</span>##################+.</span>
-<span id="cb34-18"><a href="#cb34-18"></a>                           <span class="ex">..</span>##+*##########+.++++</span>
-<span id="cb34-19"><a href="#cb34-19"></a>                            <span class="ex">.......+</span>####....   +</span>
-<span id="cb34-20"><a href="#cb34-20"></a>                                 <span class="ex">..+</span>####+.</span>
-<span id="cb34-21"><a href="#cb34-21"></a>                                   <span class="ex">..</span>#*..</span>
-<span id="cb34-22"><a href="#cb34-22"></a>                                    <span class="ex">....</span>#</span>
-<span id="cb34-23"><a href="#cb34-23"></a>                                    <span class="ex">+.</span></span></code></pre></div>
+<div class="sourceCode" id="cb34"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb34-1"><a href="#cb34-1" aria-hidden="true" tabindex="-1"></a><span class="ex">$</span></span>
+<span id="cb34-2"><a href="#cb34-2" aria-hidden="true" tabindex="-1"></a>                                    <span class="ex">....#</span></span>
+<span id="cb34-3"><a href="#cb34-3" aria-hidden="true" tabindex="-1"></a>                                   <span class="ex">..#*..</span></span>
+<span id="cb34-4"><a href="#cb34-4" aria-hidden="true" tabindex="-1"></a>                                 <span class="ex">..+####+.</span></span>
+<span id="cb34-5"><a href="#cb34-5" aria-hidden="true" tabindex="-1"></a>                            <span class="ex">.......+####....</span>   +</span>
+<span id="cb34-6"><a href="#cb34-6" aria-hidden="true" tabindex="-1"></a>                           <span class="ex">..##+*##########+.++++</span></span>
+<span id="cb34-7"><a href="#cb34-7" aria-hidden="true" tabindex="-1"></a>                          <span class="bu">.</span>+.##################+.</span>
+<span id="cb34-8"><a href="#cb34-8" aria-hidden="true" tabindex="-1"></a>              <span class="ex">.............+###################+.+</span></span>
+<span id="cb34-9"><a href="#cb34-9" aria-hidden="true" tabindex="-1"></a>              <span class="ex">..++..#.....*#####################+.</span></span>
+<span id="cb34-10"><a href="#cb34-10" aria-hidden="true" tabindex="-1"></a>             <span class="ex">...+#######++#######################.</span></span>
+<span id="cb34-11"><a href="#cb34-11" aria-hidden="true" tabindex="-1"></a>          <span class="ex">....+*################################.</span></span>
+<span id="cb34-12"><a href="#cb34-12" aria-hidden="true" tabindex="-1"></a> <span class="co">#############################################...</span></span>
+<span id="cb34-13"><a href="#cb34-13" aria-hidden="true" tabindex="-1"></a>          <span class="ex">....+*################################.</span></span>
+<span id="cb34-14"><a href="#cb34-14" aria-hidden="true" tabindex="-1"></a>             <span class="ex">...+#######++#######################.</span></span>
+<span id="cb34-15"><a href="#cb34-15" aria-hidden="true" tabindex="-1"></a>              <span class="ex">..++..#.....*#####################+.</span></span>
+<span id="cb34-16"><a href="#cb34-16" aria-hidden="true" tabindex="-1"></a>              <span class="ex">.............+###################+.+</span></span>
+<span id="cb34-17"><a href="#cb34-17" aria-hidden="true" tabindex="-1"></a>                          <span class="bu">.</span>+.##################+.</span>
+<span id="cb34-18"><a href="#cb34-18" aria-hidden="true" tabindex="-1"></a>                           <span class="ex">..##+*##########+.++++</span></span>
+<span id="cb34-19"><a href="#cb34-19" aria-hidden="true" tabindex="-1"></a>                            <span class="ex">.......+####....</span>   +</span>
+<span id="cb34-20"><a href="#cb34-20" aria-hidden="true" tabindex="-1"></a>                                 <span class="ex">..+####+.</span></span>
+<span id="cb34-21"><a href="#cb34-21" aria-hidden="true" tabindex="-1"></a>                                   <span class="ex">..#*..</span></span>
+<span id="cb34-22"><a href="#cb34-22" aria-hidden="true" tabindex="-1"></a>                                    <span class="ex">....#</span></span>
+<span id="cb34-23"><a href="#cb34-23" aria-hidden="true" tabindex="-1"></a>                                    <span class="ex">+.</span></span></code></pre></div>
 <p>Which probably doesn’t come up very often but it does illustrate several things:</p>
 <ul>
 <li><code>WITH RECURSIVE</code> actually provides a full lambda calculus so arbitrary computation is possible</li>
@@ -1033,26 +1165,26 @@ CONCAT:        ||</code></pre>
 <p>NOTE: the above is NOT the C binding order (!!!) The Sqlite binding order is used in the language and parens are added in the C output as needed to force that order. CQL’s rewriting emits minimal parens in all outputs. Different parens are often needed for SQL output.</p>
 <h3 id="variables-columns-basic-types-and-nullability">Variables, Columns, Basic Types and Nullability</h3>
 <p>CQL needs type information for both variables in the code and columns in the database. Like SQL, CQL allows variables to hold a NULL value and just as in SQL the absence of <code>NOT NULL</code> implies that <code>NULL</code> is a legal value. Consider these examples:</p>
-<div class="sourceCode" id="cb37"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb37-1"><a href="#cb37-1"></a><span class="co">-- real code should use better names than this :)</span></span>
-<span id="cb37-2"><a href="#cb37-2"></a><span class="kw">create</span> <span class="kw">table</span> all_the_nullables(</span>
-<span id="cb37-3"><a href="#cb37-3"></a>  i1 <span class="dt">integer</span>,</span>
-<span id="cb37-4"><a href="#cb37-4"></a>  b1 bool,</span>
-<span id="cb37-5"><a href="#cb37-5"></a>  l1 <span class="dt">long</span>,</span>
-<span id="cb37-6"><a href="#cb37-6"></a>  r1 <span class="dt">real</span>,</span>
-<span id="cb37-7"><a href="#cb37-7"></a>  t1 text,</span>
-<span id="cb37-8"><a href="#cb37-8"></a>  bl1 <span class="dt">blob</span></span>
-<span id="cb37-9"><a href="#cb37-9"></a>);</span>
-<span id="cb37-10"><a href="#cb37-10"></a></span>
-<span id="cb37-11"><a href="#cb37-11"></a><span class="kw">declare</span> i2 <span class="dt">integer</span>;</span>
-<span id="cb37-12"><a href="#cb37-12"></a><span class="kw">declare</span> b2 bool;</span>
-<span id="cb37-13"><a href="#cb37-13"></a><span class="kw">declare</span> l2 <span class="dt">long</span>;</span>
-<span id="cb37-14"><a href="#cb37-14"></a><span class="kw">declare</span> r2 <span class="dt">real</span>;</span>
-<span id="cb37-15"><a href="#cb37-15"></a><span class="kw">declare</span> t2 text;</span>
-<span id="cb37-16"><a href="#cb37-16"></a><span class="kw">declare</span> bl2 <span class="dt">blob</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb37"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb37-1"><a href="#cb37-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- real code should use better names than this :)</span></span>
+<span id="cb37-2"><a href="#cb37-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> all_the_nullables(</span>
+<span id="cb37-3"><a href="#cb37-3" aria-hidden="true" tabindex="-1"></a>  i1 <span class="dt">integer</span>,</span>
+<span id="cb37-4"><a href="#cb37-4" aria-hidden="true" tabindex="-1"></a>  b1 bool,</span>
+<span id="cb37-5"><a href="#cb37-5" aria-hidden="true" tabindex="-1"></a>  l1 <span class="dt">long</span>,</span>
+<span id="cb37-6"><a href="#cb37-6" aria-hidden="true" tabindex="-1"></a>  r1 <span class="dt">real</span>,</span>
+<span id="cb37-7"><a href="#cb37-7" aria-hidden="true" tabindex="-1"></a>  t1 text,</span>
+<span id="cb37-8"><a href="#cb37-8" aria-hidden="true" tabindex="-1"></a>  bl1 <span class="dt">blob</span></span>
+<span id="cb37-9"><a href="#cb37-9" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb37-10"><a href="#cb37-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb37-11"><a href="#cb37-11" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> i2 <span class="dt">integer</span>;</span>
+<span id="cb37-12"><a href="#cb37-12" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> b2 bool;</span>
+<span id="cb37-13"><a href="#cb37-13" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> l2 <span class="dt">long</span>;</span>
+<span id="cb37-14"><a href="#cb37-14" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> r2 <span class="dt">real</span>;</span>
+<span id="cb37-15"><a href="#cb37-15" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> t2 text;</span>
+<span id="cb37-16"><a href="#cb37-16" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> bl2 <span class="dt">blob</span>;</span></code></pre></div>
 <p>ALL of <code>i1</code>, <code>i2</code>, <code>b1</code>, <code>b2</code>, <code>l1</code>, <code>l2</code>, <code>r1</code>, <code>r2</code>, <code>t1</code>, <code>t2</code>, and <code>bl1</code>, <code>bl2</code> are nullable. In some sense variables and columns declared nullable (by virtual of the missing <code>NOT NULL</code>) are the root sources of nullability in the SQL language. That and the <code>NULL</code> literal. Though there are other sources as we will see.</p>
 <p><code>NOT NULL</code> could be added to any of these, e.g.</p>
-<div class="sourceCode" id="cb38"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb38-1"><a href="#cb38-1"></a><span class="co">-- real code should use better names than this :)</span></span>
-<span id="cb38-2"><a href="#cb38-2"></a><span class="kw">declare</span> i_nn <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb38"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb38-1"><a href="#cb38-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- real code should use better names than this :)</span></span>
+<span id="cb38-2"><a href="#cb38-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> i_nn <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span></code></pre></div>
 <p>In the context of computing the types of expressions, CQL is statically typed and so it must make a decision about the type of any expression based on the type information at hand at compile time. As a result it handles the static type of an expression conservatively. If the result might be null then the expression is of a nullable type and the compiled code will include an affordance for the possibility of a null value at runtime.</p>
 <p>The generated code for nullable types is considerably less efficient and so it should be avoided if that is reasonably possible.</p>
 <p>CQL also has the special built-in variable <code>@RC</code> which refers to the most recent result code returned by a SQLite operation, e.g. 0 == <code>SQLITE_OK</code>, 1 == <code>SQLITE_ERROR</code>. <code>@RC</code> is of type <code>integer not null</code>. Note: there are many hidden SQLite operations such as statement finalization so <code>@RC</code> might change where there is no visible SQL operation. The most common use of <code>@RC</code> is to capture the error code in the first statement of a <code>catch</code> block.</p>
@@ -1197,23 +1329,23 @@ declare thing_type type thing;</code></pre>
 <p>Enumerations always get “not null” in addition to their base type. Enumerations also have a unique “kind” associated, specfically the above enum has type <code>integer&lt;thing&gt; not null</code>. The rules for type kind are described below.</p>
 <h3 id="type-kinds">Type Kinds</h3>
 <p>Any CQL type can be tagged with a “kind” for instance <code>real</code> can become <code>real&lt;meters&gt;</code>, <code>integer</code> can become <code>integer&lt;job_id&gt;</code>. The idea here is that the additional tag, the “kind” can help prevent type mistakes in arguments and in columns and procedure calls. For instance:</p>
-<div class="sourceCode" id="cb54"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb54-1"><a href="#cb54-1"></a><span class="kw">create</span> <span class="kw">table</span> things(</span>
-<span id="cb54-2"><a href="#cb54-2"></a>  <span class="kw">size</span> <span class="dt">real</span><span class="op">&lt;</span>meters<span class="op">&gt;</span>,</span>
-<span id="cb54-3"><a href="#cb54-3"></a>  duration <span class="dt">real</span><span class="op">&lt;</span>seconds<span class="op">&gt;</span></span>
-<span id="cb54-4"><a href="#cb54-4"></a>);</span>
-<span id="cb54-5"><a href="#cb54-5"></a></span>
-<span id="cb54-6"><a href="#cb54-6"></a><span class="kw">create</span> proc do_something(size_ <span class="dt">real</span><span class="op">&lt;</span>meters<span class="op">&gt;</span>, duration_ <span class="dt">real</span><span class="op">&lt;</span>seconds<span class="op">&gt;</span>)</span>
-<span id="cb54-7"><a href="#cb54-7"></a><span class="cf">begin</span></span>
-<span id="cb54-8"><a href="#cb54-8"></a>  <span class="kw">insert</span> <span class="kw">into</span> things(<span class="kw">size</span>, duration) <span class="kw">values</span>(size_, duration_);</span>
-<span id="cb54-9"><a href="#cb54-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb54"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb54-1"><a href="#cb54-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> things(</span>
+<span id="cb54-2"><a href="#cb54-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">size</span> <span class="dt">real</span><span class="op">&lt;</span>meters<span class="op">&gt;</span>,</span>
+<span id="cb54-3"><a href="#cb54-3" aria-hidden="true" tabindex="-1"></a>  duration <span class="dt">real</span><span class="op">&lt;</span>seconds<span class="op">&gt;</span></span>
+<span id="cb54-4"><a href="#cb54-4" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb54-5"><a href="#cb54-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb54-6"><a href="#cb54-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc do_something(size_ <span class="dt">real</span><span class="op">&lt;</span>meters<span class="op">&gt;</span>, duration_ <span class="dt">real</span><span class="op">&lt;</span>seconds<span class="op">&gt;</span>)</span>
+<span id="cb54-7"><a href="#cb54-7" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb54-8"><a href="#cb54-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> things(<span class="kw">size</span>, duration) <span class="kw">values</span>(size_, duration_);</span>
+<span id="cb54-9"><a href="#cb54-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>In this situation you couldn’t accidentally switch the columns in <code>do_something</code> even though both are <code>real</code>, and indeed SQLite will only see the type <code>real</code> for both. If you have your own variables typed <code>real&lt;size&gt;</code> and <code>read&lt;duration&gt;</code> you can’t accidentally do:</p>
-<div class="sourceCode" id="cb55"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb55-1"><a href="#cb55-1"></a>  <span class="kw">call</span> do_something(duration, <span class="kw">size</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb55"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb55-1"><a href="#cb55-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> do_something(duration, <span class="kw">size</span>);</span></code></pre></div>
 <p>Even though both are real. The type kind won’t match.</p>
 <p>Importantly, an expression with no type kind is compatible with any type kind (or none). Hence all of the below are legal.</p>
-<div class="sourceCode" id="cb56"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb56-1"><a href="#cb56-1"></a><span class="kw">declare</span> generic <span class="dt">real</span>;</span>
-<span id="cb56-2"><a href="#cb56-2"></a><span class="kw">set</span> generic <span class="op">:=</span> <span class="kw">size</span>;        <span class="co">-- no kind may accept &lt;meters&gt;</span></span>
-<span id="cb56-3"><a href="#cb56-3"></a><span class="kw">set</span> generic <span class="op">:=</span> duration;    <span class="co">-- no kind may accept &lt;seconds&gt;</span></span>
-<span id="cb56-4"><a href="#cb56-4"></a><span class="kw">set</span> duration <span class="op">:=</span> generic;    <span class="co">-- no kind may be stored in &lt;seconds&gt;</span></span></code></pre></div>
+<div class="sourceCode" id="cb56"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb56-1"><a href="#cb56-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> generic <span class="dt">real</span>;</span>
+<span id="cb56-2"><a href="#cb56-2" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> generic <span class="op">:=</span> <span class="kw">size</span>;        <span class="co">-- no kind may accept &lt;meters&gt;</span></span>
+<span id="cb56-3"><a href="#cb56-3" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> generic <span class="op">:=</span> duration;    <span class="co">-- no kind may accept &lt;seconds&gt;</span></span>
+<span id="cb56-4"><a href="#cb56-4" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> duration <span class="op">:=</span> generic;    <span class="co">-- no kind may be stored in &lt;seconds&gt;</span></span></code></pre></div>
 <p>Only mixing types where both have a kind, and the kind is different generates errors. This choice allows you to write procedures that (for instance) log any <code>integer</code> or any <code>real</code>, or that return an <code>integer</code> out of a collection or some such.</p>
 <p>These rules are applied to comparisons, assignments, column updates, everywhere types are checked for compatibility.</p>
 <p>To get the most value out of these constructs, the authors recommend that type kinds be used universally except when the extra compatibility described above is needed (like low level helper functions).</p>
@@ -1243,22 +1375,22 @@ declare thing_type type thing;</code></pre>
 <p>These functions are nullable or non-nullable based on their arguments. If the <code>IFNULL</code> or <code>COALESCE</code> call has at least one non-nullable argument then the result is non-nullable.</p>
 <h4 id="the-ifnull_crash-and-ifnull_throw-functions">The ifnull_crash and ifnull_throw functions</h4>
 <p>Sometimes <code>ifnull</code> is not possible, e.g. if the operand is an object or blob type. Other times it’s just not convenient. The “attesting” forms gives you a type conversion to not null with a runtime check. They cannot be used in SQLite contexts because the functions are not known to SQLite. But in loose expressions you can write this important pattern:</p>
-<div class="sourceCode" id="cb57"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb57-1"><a href="#cb57-1"></a><span class="kw">create</span> proc foo(x <span class="dt">object</span>)</span>
-<span id="cb57-2"><a href="#cb57-2"></a><span class="cf">begin</span></span>
-<span id="cb57-3"><a href="#cb57-3"></a>  <span class="cf">if</span> x <span class="kw">is</span> <span class="kw">not</span> <span class="kw">null</span> <span class="cf">then</span></span>
-<span id="cb57-4"><a href="#cb57-4"></a>     <span class="kw">declare</span> xo <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb57-5"><a href="#cb57-5"></a>     <span class="kw">set</span> xo <span class="op">:=</span> ifnull_crash(x); <span class="co">-- this is like an assert</span></span>
-<span id="cb57-6"><a href="#cb57-6"></a>     <span class="co">-- use xo where a non-null object is needed</span></span>
-<span id="cb57-7"><a href="#cb57-7"></a>  <span class="cf">end</span>;</span>
-<span id="cb57-8"><a href="#cb57-8"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb57"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb57-1"><a href="#cb57-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(x <span class="dt">object</span>)</span>
+<span id="cb57-2"><a href="#cb57-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb57-3"><a href="#cb57-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> x <span class="kw">is</span> <span class="kw">not</span> <span class="kw">null</span> <span class="cf">then</span></span>
+<span id="cb57-4"><a href="#cb57-4" aria-hidden="true" tabindex="-1"></a>     <span class="kw">declare</span> xo <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb57-5"><a href="#cb57-5" aria-hidden="true" tabindex="-1"></a>     <span class="kw">set</span> xo <span class="op">:=</span> ifnull_crash(x); <span class="co">-- this is like an assert</span></span>
+<span id="cb57-6"><a href="#cb57-6" aria-hidden="true" tabindex="-1"></a>     <span class="co">-- use xo where a non-null object is needed</span></span>
+<span id="cb57-7"><a href="#cb57-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb57-8"><a href="#cb57-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>If you can’t assert that the object is not null but rather you want to test it then you can use <code>ifnull_throw</code>. This form is shown below:</p>
-<div class="sourceCode" id="cb58"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb58-1"><a href="#cb58-1"></a><span class="kw">create</span> proc foo(x <span class="dt">object</span>)</span>
-<span id="cb58-2"><a href="#cb58-2"></a><span class="cf">begin</span></span>
-<span id="cb58-3"><a href="#cb58-3"></a>  <span class="kw">declare</span> xo <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb58-4"><a href="#cb58-4"></a>  <span class="kw">set</span> xo <span class="op">:=</span> ifnull_throw(x);</span>
-<span id="cb58-5"><a href="#cb58-5"></a>  <span class="co">-- use xo where a non-null object is needed</span></span>
-<span id="cb58-6"><a href="#cb58-6"></a>  <span class="cf">end</span>;</span>
-<span id="cb58-7"><a href="#cb58-7"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb58"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb58-1"><a href="#cb58-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(x <span class="dt">object</span>)</span>
+<span id="cb58-2"><a href="#cb58-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb58-3"><a href="#cb58-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> xo <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb58-4"><a href="#cb58-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> xo <span class="op">:=</span> ifnull_throw(x);</span>
+<span id="cb58-5"><a href="#cb58-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- use xo where a non-null object is needed</span></span>
+<span id="cb58-6"><a href="#cb58-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb58-7"><a href="#cb58-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>It is equivalent to adding this inline in the expression</p>
 <pre><code>  if x is null then throw end if;</code></pre>
 <p>The compiler then considers ‘x’ to be not null having tested it at run time.</p>
@@ -1270,22 +1402,22 @@ declare thing_type type thing;</code></pre>
 <h4 id="union-and-union-all">UNION and UNION ALL</h4>
 <p>These appear only in the context of <code>SELECT</code> statements. The arms of a compound select may include <code>FROM</code>, <code>WHERE</code>, <code>GROUP BY</code>, <code>HAVING</code>, and <code>WINDOW</code>. If <code>ORDER BY</code> or <code>LIMIT ... OFFSET</code> are present, these apply to the entire UNION.</p>
 <p>example:</p>
-<div class="sourceCode" id="cb60"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb60-1"><a href="#cb60-1"></a><span class="kw">select</span> A.x x <span class="kw">from</span> A <span class="kw">inner</span> <span class="kw">join</span> B <span class="kw">using</span>(z)</span>
-<span id="cb60-2"><a href="#cb60-2"></a><span class="kw">union</span> <span class="kw">all</span></span>
-<span id="cb60-3"><a href="#cb60-3"></a><span class="kw">select</span> C.x x <span class="kw">from</span> C</span>
-<span id="cb60-4"><a href="#cb60-4"></a><span class="kw">where</span> x <span class="op">=</span> <span class="dv">1</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb60"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb60-1"><a href="#cb60-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> A.x x <span class="kw">from</span> A <span class="kw">inner</span> <span class="kw">join</span> B <span class="kw">using</span>(z)</span>
+<span id="cb60-2"><a href="#cb60-2" aria-hidden="true" tabindex="-1"></a><span class="kw">union</span> <span class="kw">all</span></span>
+<span id="cb60-3"><a href="#cb60-3" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> C.x x <span class="kw">from</span> C</span>
+<span id="cb60-4"><a href="#cb60-4" aria-hidden="true" tabindex="-1"></a><span class="kw">where</span> x <span class="op">=</span> <span class="dv">1</span>;</span></code></pre></div>
 <p>The <code>WHERE</code> applies only to the second select in the union. And each <code>SELECT</code> is evaluated before the the <code>UNION ALL</code></p>
-<div class="sourceCode" id="cb61"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb61-1"><a href="#cb61-1"></a><span class="kw">select</span> A.x x <span class="kw">from</span> A <span class="kw">inner</span> <span class="kw">join</span> B <span class="kw">using</span>(z)</span>
-<span id="cb61-2"><a href="#cb61-2"></a><span class="kw">where</span> x <span class="op">=</span> <span class="dv">3</span></span>
-<span id="cb61-3"><a href="#cb61-3"></a><span class="kw">union</span> <span class="kw">all</span></span>
-<span id="cb61-4"><a href="#cb61-4"></a><span class="kw">select</span> C.x x <span class="kw">from</span> C</span>
-<span id="cb61-5"><a href="#cb61-5"></a><span class="kw">where</span> x <span class="op">=</span> <span class="dv">1</span></span>
-<span id="cb61-6"><a href="#cb61-6"></a><span class="kw">order</span> <span class="kw">by</span> x;</span></code></pre></div>
+<div class="sourceCode" id="cb61"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb61-1"><a href="#cb61-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> A.x x <span class="kw">from</span> A <span class="kw">inner</span> <span class="kw">join</span> B <span class="kw">using</span>(z)</span>
+<span id="cb61-2"><a href="#cb61-2" aria-hidden="true" tabindex="-1"></a><span class="kw">where</span> x <span class="op">=</span> <span class="dv">3</span></span>
+<span id="cb61-3"><a href="#cb61-3" aria-hidden="true" tabindex="-1"></a><span class="kw">union</span> <span class="kw">all</span></span>
+<span id="cb61-4"><a href="#cb61-4" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> C.x x <span class="kw">from</span> C</span>
+<span id="cb61-5"><a href="#cb61-5" aria-hidden="true" tabindex="-1"></a><span class="kw">where</span> x <span class="op">=</span> <span class="dv">1</span></span>
+<span id="cb61-6"><a href="#cb61-6" aria-hidden="true" tabindex="-1"></a><span class="kw">order</span> <span class="kw">by</span> x;</span></code></pre></div>
 <p>The <code>ORDER BY</code> applies to the result of the union, so any results from the 2nd branch will sort before any results from the first branch (because <code>x</code> is constrained in both).</p>
 <h4 id="assignment">Assignment</h4>
 <p>Assignment only occurs in the <code>UPDATE</code> statement or in the <code>SET</code> statement. In both cases the left side is a simple target and the right side is a general expression. The expression is evaluated before the assignment.</p>
 <p>example:</p>
-<div class="sourceCode" id="cb62"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb62-1"><a href="#cb62-1"></a><span class="kw">SET</span> x <span class="op">:=</span> <span class="dv">1</span> <span class="op">+</span> <span class="dv">3</span> <span class="kw">AND</span> <span class="dv">4</span>;  <span class="co">-- + before AND then :=</span></span></code></pre></div>
+<div class="sourceCode" id="cb62"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb62-1"><a href="#cb62-1" aria-hidden="true" tabindex="-1"></a><span class="kw">SET</span> x <span class="op">:=</span> <span class="dv">1</span> <span class="op">+</span> <span class="dv">3</span> <span class="kw">AND</span> <span class="dv">4</span>;  <span class="co">-- + before AND then :=</span></span></code></pre></div>
 <h4 id="logical-or">Logical OR</h4>
 <p>The logical <code>OR</code> operator does shortcut evaluation, much like the C <code>||</code> operator (not to be confused with SQL’s concatenation operator with the same lexeme).</p>
 <p>The truth table for logical <code>OR</code> is as follows:</p>
@@ -1406,8 +1538,8 @@ declare thing_type type thing;</code></pre>
 </table>
 <h4 id="between-and-not-between">BETWEEN and NOT BETWEEN</h4>
 <p>These are a ternary type operation. The general forms are:</p>
-<div class="sourceCode" id="cb63"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb63-1"><a href="#cb63-1"></a>  expr1 <span class="kw">BETWEEN</span> expr2 <span class="kw">AND</span> expr3</span>
-<span id="cb63-2"><a href="#cb63-2"></a>  expr1 <span class="kw">NOT</span> <span class="kw">BETWEEN</span> expr2 <span class="kw">AND</span> expr3</span></code></pre></div>
+<div class="sourceCode" id="cb63"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb63-1"><a href="#cb63-1" aria-hidden="true" tabindex="-1"></a>  expr1 <span class="kw">BETWEEN</span> expr2 <span class="kw">AND</span> expr3</span>
+<span id="cb63-2"><a href="#cb63-2" aria-hidden="true" tabindex="-1"></a>  expr1 <span class="kw">NOT</span> <span class="kw">BETWEEN</span> expr2 <span class="kw">AND</span> expr3</span></code></pre></div>
 <p>Note that there is an inherent ambiguity in the language because <code>expr2</code> or <code>expr3</code> could be logical expressions that include <code>AND</code>. CQL resolves this ambiguity by insisting that <code>expr2</code> and <code>expr3</code> be “math expressions” in the grammar.</p>
 <p>“Math expressions” consist of:</p>
 <ul>
@@ -1423,13 +1555,13 @@ declare thing_type type thing;</code></pre>
 <li>any parenthesized expression</li>
 </ul>
 <p>Hence:</p>
-<div class="sourceCode" id="cb64"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb64-1"><a href="#cb64-1"></a><span class="co">-- oh hell no (syntax error)</span></span>
-<span id="cb64-2"><a href="#cb64-2"></a>a <span class="kw">between</span> <span class="dv">1</span> <span class="kw">and</span> <span class="dv">2</span> <span class="kw">and</span> <span class="dv">3</span>;</span>
-<span id="cb64-3"><a href="#cb64-3"></a></span>
-<span id="cb64-4"><a href="#cb64-4"></a><span class="co">-- all ok</span></span>
-<span id="cb64-5"><a href="#cb64-5"></a>a <span class="kw">between</span> (<span class="dv">1</span> <span class="kw">and</span> <span class="dv">2</span>) <span class="kw">and</span> <span class="dv">3</span>;</span>
-<span id="cb64-6"><a href="#cb64-6"></a>a <span class="kw">between</span> <span class="dv">1</span> <span class="kw">and</span> (<span class="dv">2</span> <span class="kw">and</span> <span class="dv">3</span>);</span>
-<span id="cb64-7"><a href="#cb64-7"></a>a <span class="kw">between</span> <span class="dv">1</span> <span class="op">+</span> <span class="dv">2</span> <span class="kw">and</span> <span class="dv">12</span> <span class="op">/</span> <span class="dv">2</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb64"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb64-1"><a href="#cb64-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- oh hell no (syntax error)</span></span>
+<span id="cb64-2"><a href="#cb64-2" aria-hidden="true" tabindex="-1"></a>a <span class="kw">between</span> <span class="dv">1</span> <span class="kw">and</span> <span class="dv">2</span> <span class="kw">and</span> <span class="dv">3</span>;</span>
+<span id="cb64-3"><a href="#cb64-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb64-4"><a href="#cb64-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- all ok</span></span>
+<span id="cb64-5"><a href="#cb64-5" aria-hidden="true" tabindex="-1"></a>a <span class="kw">between</span> (<span class="dv">1</span> <span class="kw">and</span> <span class="dv">2</span>) <span class="kw">and</span> <span class="dv">3</span>;</span>
+<span id="cb64-6"><a href="#cb64-6" aria-hidden="true" tabindex="-1"></a>a <span class="kw">between</span> <span class="dv">1</span> <span class="kw">and</span> (<span class="dv">2</span> <span class="kw">and</span> <span class="dv">3</span>);</span>
+<span id="cb64-7"><a href="#cb64-7" aria-hidden="true" tabindex="-1"></a>a <span class="kw">between</span> <span class="dv">1</span> <span class="op">+</span> <span class="dv">2</span> <span class="kw">and</span> <span class="dv">12</span> <span class="op">/</span> <span class="dv">2</span>;</span></code></pre></div>
 <p>These considerations force the grammar to contain special rules for expressions after <code>BETWEEN</code>.</p>
 <h4 id="logical-not">Logical NOT</h4>
 <p>The one operand of logical not must be a numeric. <code>NOT 'x'</code> is illegal.</p>
@@ -1443,9 +1575,9 @@ declare thing_type type thing;</code></pre>
 <li>objects compare equal based on their address, not their content (i.e. reference equality)</li>
 <li><code>MATCH</code> and <code>GLOB</code> only valid in SQL contexts, <code>LIKE</code> can be used in any context (a helper method to do <code>LIKE</code> in C is provided by SQLite, but not the others)</li>
 </ul>
-<div class="sourceCode" id="cb65"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb65-1"><a href="#cb65-1"></a> <span class="kw">NULL</span> <span class="kw">IS</span> <span class="kw">NULL</span>  <span class="co">-- this is true</span></span>
-<span id="cb65-2"><a href="#cb65-2"></a>(<span class="kw">NULL</span> <span class="op">==</span> <span class="kw">NULL</span>) <span class="kw">IS</span> <span class="kw">NULL</span>  <span class="co">-- this is also true because NULL == NULL is not 1, it&#39;s NULL.</span></span>
-<span id="cb65-3"><a href="#cb65-3"></a>(<span class="kw">NULL</span> <span class="op">!=</span> <span class="kw">NULL</span>) <span class="kw">IS</span> <span class="kw">NULL</span>  <span class="co">-- this is also true because NULL != NULL is not 0, it&#39;s also NULL.</span></span></code></pre></div>
+<div class="sourceCode" id="cb65"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb65-1"><a href="#cb65-1" aria-hidden="true" tabindex="-1"></a> <span class="kw">NULL</span> <span class="kw">IS</span> <span class="kw">NULL</span>  <span class="co">-- this is true</span></span>
+<span id="cb65-2"><a href="#cb65-2" aria-hidden="true" tabindex="-1"></a>(<span class="kw">NULL</span> <span class="op">==</span> <span class="kw">NULL</span>) <span class="kw">IS</span> <span class="kw">NULL</span>  <span class="co">-- this is also true because NULL == NULL is not 1, it&#39;s NULL.</span></span>
+<span id="cb65-3"><a href="#cb65-3" aria-hidden="true" tabindex="-1"></a>(<span class="kw">NULL</span> <span class="op">!=</span> <span class="kw">NULL</span>) <span class="kw">IS</span> <span class="kw">NULL</span>  <span class="co">-- this is also true because NULL != NULL is not 0, it&#39;s also NULL.</span></span></code></pre></div>
 <h4 id="ordering-comparisons">Ordering comparisons &lt;, &gt;, &lt;=, &gt;=</h4>
 <p>These operators do the usual order comparison of their two operands.</p>
 <ul>
@@ -1457,9 +1589,9 @@ declare thing_type type thing;</code></pre>
 <p>NOTE: CQL uses <code>strcmp</code> for string comparison. In SQL expressions the comparison happens in whatever way SQLite has been configured. Typically general purpose string comparison should be done with helper functions that deal with collation and other considerations. This is a very complex topic and CQL is largely silent on it.</p>
 <h4 id="bitwise-operators">Bitwise operators &lt;&lt;, &gt;&gt;, &amp;, |</h4>
 <p>These are the bit-manipulation operations. Their binding strength is VERY different than C so beware. And notably the <code>&amp;</code> operator has the same binding strength as the <code>|</code> operator so they bind left to right, this is utterly unlike most systems. Many parenthesis are likely to be needed to get the usual “or of ands” patterns codified correctly. Likewise the shift operators <code>&lt;&lt;</code> and <code>&gt;&gt;</code> are the same strength as <code>&amp;</code> and <code>|</code> which is very atypical. Consider:</p>
-<div class="sourceCode" id="cb66"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb66-1"><a href="#cb66-1"></a>x &amp; <span class="dv">1</span> <span class="op">&lt;&lt;</span> <span class="dv">7</span>;    <span class="co">-- probably doesn&#39;t mean what you think (this is not ambigous, it&#39;s well defined, but unlike C)</span></span>
-<span id="cb66-2"><a href="#cb66-2"></a>(x &amp; <span class="dv">1</span>) <span class="op">&lt;&lt;</span> <span class="dv">7</span>;   <span class="co">-- means the same as the above</span></span>
-<span id="cb66-3"><a href="#cb66-3"></a>x &amp; (<span class="dv">1</span> <span class="op">&lt;&lt;</span> <span class="dv">7</span>)   <span class="co">-- probably what you intended</span></span></code></pre></div>
+<div class="sourceCode" id="cb66"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb66-1"><a href="#cb66-1" aria-hidden="true" tabindex="-1"></a>x &amp; <span class="dv">1</span> <span class="op">&lt;&lt;</span> <span class="dv">7</span>;    <span class="co">-- probably doesn&#39;t mean what you think (this is not ambigous, it&#39;s well defined, but unlike C)</span></span>
+<span id="cb66-2"><a href="#cb66-2" aria-hidden="true" tabindex="-1"></a>(x &amp; <span class="dv">1</span>) <span class="op">&lt;&lt;</span> <span class="dv">7</span>;   <span class="co">-- means the same as the above</span></span>
+<span id="cb66-3"><a href="#cb66-3" aria-hidden="true" tabindex="-1"></a>x &amp; (<span class="dv">1</span> <span class="op">&lt;&lt;</span> <span class="dv">7</span>)   <span class="co">-- probably what you intended</span></span></code></pre></div>
 <p>Note that these operators only work on integer and long integer data. If any operand is <code>NULL</code> the result is `NULL.</p>
 <h4 id="addition-and-subtraction--">Addition and Subtraction +, -</h4>
 <p>These operators do the typical math. Note that there are no unsigned numerics so it’s always signed math that is happening here.</p>
@@ -1485,62 +1617,62 @@ declare thing_type type thing;</code></pre>
 </ul>
 <h3 id="case-expressions">CASE Expressions</h3>
 <p>The <code>case</code> expression has two major forms and provides a great deal of flexibility in an expression. You can kind of think of it as the C <code>?:</code> operator on steroids.</p>
-<div class="sourceCode" id="cb67"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb67-1"><a href="#cb67-1"></a><span class="kw">set</span> x <span class="op">:=</span> <span class="st">&#39;y&#39;</span>;</span>
-<span id="cb67-2"><a href="#cb67-2"></a><span class="kw">select</span> <span class="cf">case</span> x</span>
-<span id="cb67-3"><a href="#cb67-3"></a>  <span class="cf">when</span> <span class="st">&#39;y&#39;</span> <span class="cf">then</span> <span class="dv">1</span></span>
-<span id="cb67-4"><a href="#cb67-4"></a>  <span class="cf">when</span> <span class="st">&#39;z&#39;</span> <span class="cf">then</span> <span class="dv">2</span></span>
-<span id="cb67-5"><a href="#cb67-5"></a>  <span class="cf">else</span> <span class="dv">3</span></span>
-<span id="cb67-6"><a href="#cb67-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb67"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb67-1"><a href="#cb67-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> x <span class="op">:=</span> <span class="st">&#39;y&#39;</span>;</span>
+<span id="cb67-2"><a href="#cb67-2" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="cf">case</span> x</span>
+<span id="cb67-3"><a href="#cb67-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">when</span> <span class="st">&#39;y&#39;</span> <span class="cf">then</span> <span class="dv">1</span></span>
+<span id="cb67-4"><a href="#cb67-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">when</span> <span class="st">&#39;z&#39;</span> <span class="cf">then</span> <span class="dv">2</span></span>
+<span id="cb67-5"><a href="#cb67-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="dv">3</span></span>
+<span id="cb67-6"><a href="#cb67-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>In this form the expression in the case <code>x</code> here is evaluated exactly once and then compared against each <code>when</code> clause, they must be type compatible with the expression. The <code>then</code> expression that corresponds is evaluated and becomes the result, or the <code>else</code> expression if present and no <code>when</code> matches. If there is no else and no match the result is <code>null</code>.</p>
 <p>If that’s not general enough, there is an alternate form:</p>
-<div class="sourceCode" id="cb68"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb68-1"><a href="#cb68-1"></a><span class="kw">set</span> y <span class="op">:=</span> <span class="st">&#39;yy&#39;</span>;</span>
-<span id="cb68-2"><a href="#cb68-2"></a><span class="kw">set</span> z <span class="op">:=</span> <span class="st">&#39;z&#39;</span>;</span>
-<span id="cb68-3"><a href="#cb68-3"></a><span class="kw">select</span> <span class="cf">case</span></span>
-<span id="cb68-4"><a href="#cb68-4"></a>  <span class="cf">when</span> y <span class="op">=</span> <span class="st">&#39;y&#39;</span> <span class="cf">then</span> <span class="dv">1</span></span>
-<span id="cb68-5"><a href="#cb68-5"></a>  <span class="cf">when</span> z <span class="op">=</span> <span class="st">&#39;z&#39;</span> <span class="cf">then</span> <span class="dv">2</span></span>
-<span id="cb68-6"><a href="#cb68-6"></a>  <span class="cf">else</span> <span class="dv">3</span></span>
-<span id="cb68-7"><a href="#cb68-7"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb68"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb68-1"><a href="#cb68-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> y <span class="op">:=</span> <span class="st">&#39;yy&#39;</span>;</span>
+<span id="cb68-2"><a href="#cb68-2" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> z <span class="op">:=</span> <span class="st">&#39;z&#39;</span>;</span>
+<span id="cb68-3"><a href="#cb68-3" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="cf">case</span></span>
+<span id="cb68-4"><a href="#cb68-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">when</span> y <span class="op">=</span> <span class="st">&#39;y&#39;</span> <span class="cf">then</span> <span class="dv">1</span></span>
+<span id="cb68-5"><a href="#cb68-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">when</span> z <span class="op">=</span> <span class="st">&#39;z&#39;</span> <span class="cf">then</span> <span class="dv">2</span></span>
+<span id="cb68-6"><a href="#cb68-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="dv">3</span></span>
+<span id="cb68-7"><a href="#cb68-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The second form, where there is no value before the first <code>when</code> keyword, each <code>when</code> expression is a separate independent boolean expression. The first one that evaluates to true causes the corresponding <code>then</code> to be evaluated and that becomes the result. If there are no matches the result is the <code>else</code> expression, or <code>null</code> if there is no <code>else</code>.</p>
 <p>The result types must be compatible and the best type to hold the answer is selected with the usual promotion rules.</p>
 <h4 id="select-expressions">SELECT expressions</h4>
 <p>Single values can be extracted from SQLite using an inline <code>select</code> expression. For instance:</p>
-<div class="sourceCode" id="cb69"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb69-1"><a href="#cb69-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb69"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb69-1"><a href="#cb69-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span>);</span></code></pre></div>
 <p>The select statement in question must extract exactly one column and the type of the expression becomes the type of the column. This form can appear anywhere an expression can be appear, though it is most commonly used in assignments. Something like this would also be valid:</p>
-<div class="sourceCode" id="cb70"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb70-1"><a href="#cb70-1"></a><span class="cf">if</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span>) <span class="op">==</span> <span class="dv">3</span> <span class="cf">then</span></span>
-<span id="cb70-2"><a href="#cb70-2"></a>  <span class="op">..</span>.</span>
-<span id="cb70-3"><a href="#cb70-3"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb70"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb70-1"><a href="#cb70-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span>) <span class="op">==</span> <span class="dv">3</span> <span class="cf">then</span></span>
+<span id="cb70-2"><a href="#cb70-2" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb70-3"><a href="#cb70-3" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>The select statement can of course be arbitrarily complex.</p>
 <p>Note, if the select statement returns no rows this will result in the normal error flow. In that case, the error code will be SQLITE_DONE, which is treated like an error because in this context SQLITE_ROW is expected as a result of the select. This is not a typical error code can be quite surprising to callers. If you’re seeing this failure mode it usually means the code had no affordance for the case where there were no rows and probably that situation should have been handled. This is an easy mistake to make, so to avoid it, CQL also supports these more tolerant forms:</p>
-<div class="sourceCode" id="cb71"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb71-1"><a href="#cb71-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span> <span class="cf">if</span> <span class="kw">nothing</span> <span class="op">-</span><span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb71"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb71-1"><a href="#cb71-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span> <span class="cf">if</span> <span class="kw">nothing</span> <span class="op">-</span><span class="dv">1</span>);</span></code></pre></div>
 <p>And even more generally if the schema allows for null vales and those are not desired:</p>
-<div class="sourceCode" id="cb72"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb72-1"><a href="#cb72-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span> <span class="cf">if</span> <span class="kw">nothing</span> <span class="kw">or</span> <span class="kw">null</span> <span class="op">-</span><span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb72"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb72-1"><a href="#cb72-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> x <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span> <span class="cf">if</span> <span class="kw">nothing</span> <span class="kw">or</span> <span class="kw">null</span> <span class="op">-</span><span class="dv">1</span>);</span></code></pre></div>
 <p>Both of these are much safer to use as only genuine errors (e.g. the table was dropped and no longer exists) will result in the error control flow.</p>
 <p>Again note that:</p>
-<div class="sourceCode" id="cb73"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb73-1"><a href="#cb73-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> ifnull(x,<span class="op">-</span><span class="dv">1</span>) <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb73"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb73-1"><a href="#cb73-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> ifnull(x,<span class="op">-</span><span class="dv">1</span>) <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span>);</span></code></pre></div>
 <p>Would not avoid the SQLITE_DONE error code, because no rows returned is not at all the same as a null value returned.</p>
 <p>The <code>if nothing or null</code> form above is equivalent to the following, but it is more economical, and probably clearer:</p>
-<div class="sourceCode" id="cb74"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb74-1"><a href="#cb74-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> ifnull(x,<span class="op">-</span><span class="dv">1</span>) <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span> <span class="cf">if</span> <span class="kw">nothing</span> <span class="op">-</span><span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb74"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb74-1"><a href="#cb74-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> x_ <span class="op">:=</span> (<span class="kw">select</span> ifnull(x,<span class="op">-</span><span class="dv">1</span>) <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> <span class="dv">1</span> <span class="cf">if</span> <span class="kw">nothing</span> <span class="op">-</span><span class="dv">1</span>);</span></code></pre></div>
 <p>To compute the type of the overall expression, the rules are almost the same as normal binary operators. In particular: * if the default expression is present it must be type compatible with the select result * the result type is the smallest type that holds both the select value and the default expression (see normal promotion rules above) * object types are not allowed (SQLite cannot return an object) * in <code>(select ...)</code> the result type is not null if and only if the select result type is not null (see select statement, many cases) * in <code>(select ... if nothing)</code> the result type is not null if and only if both the select result and the default expression types are not null (normal binary rules) * in <code>(select ... if nothing or null)</code> the result type is not null if and only if the default expression type is not null</p>
 <p>Finally, the form <code>(select ... if nothing throw)</code> is allowed; this form is exactly the same as normal <code>(select ...)</code> but makes the explicit that the error control flow will happen if there is no row. Consequently this form is allowed even if <code>@enforce_strict select if nothing</code> is in force.</p>
 <h3 id="marking-data-as-sensitive">Marking Data as Sensitive</h3>
 <p>CQL supports the notion of ‘sensitive’ data in a first class way. You can think of it as very much like nullability; It largely begins by tagging data columns with <code>@sensitive</code></p>
 <p>Rather than go through the whole calculus, it’s easier to understand by a series of examples. So let’s start with a table with some sensitive data.</p>
-<div class="sourceCode" id="cb75"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb75-1"><a href="#cb75-1"></a><span class="kw">create</span> <span class="kw">table</span> with_sensitive(</span>
-<span id="cb75-2"><a href="#cb75-2"></a> <span class="kw">id</span> <span class="dt">integer</span>,</span>
-<span id="cb75-3"><a href="#cb75-3"></a> name text @sensitive,</span>
-<span id="cb75-4"><a href="#cb75-4"></a> sens <span class="dt">integer</span> @sensitive</span>
-<span id="cb75-5"><a href="#cb75-5"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb75"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb75-1"><a href="#cb75-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_sensitive(</span>
+<span id="cb75-2"><a href="#cb75-2" aria-hidden="true" tabindex="-1"></a> <span class="kw">id</span> <span class="dt">integer</span>,</span>
+<span id="cb75-3"><a href="#cb75-3" aria-hidden="true" tabindex="-1"></a> name text @sensitive,</span>
+<span id="cb75-4"><a href="#cb75-4" aria-hidden="true" tabindex="-1"></a> sens <span class="dt">integer</span> @sensitive</span>
+<span id="cb75-5"><a href="#cb75-5" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>The most obvious thing you might do at this point is create a stored proc that would read data out of that table. Maybe something like this:</p>
-<div class="sourceCode" id="cb76"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb76-1"><a href="#cb76-1"></a><span class="kw">create</span> proc get_sensitive()</span>
-<span id="cb76-2"><a href="#cb76-2"></a><span class="cf">begin</span></span>
-<span id="cb76-3"><a href="#cb76-3"></a>  <span class="kw">select</span> <span class="kw">id</span> <span class="kw">as</span> not_sensitive_1,</span>
-<span id="cb76-4"><a href="#cb76-4"></a>        sens <span class="op">+</span> <span class="dv">1</span> sensitive_1,</span>
-<span id="cb76-5"><a href="#cb76-5"></a>        name <span class="kw">as</span> sensitive_2,</span>
-<span id="cb76-6"><a href="#cb76-6"></a>        <span class="st">&#39;x&#39;</span> <span class="kw">as</span> not_sensitive_2,</span>
-<span id="cb76-7"><a href="#cb76-7"></a>        <span class="op">-</span>sens <span class="kw">as</span> sensitive_3,</span>
-<span id="cb76-8"><a href="#cb76-8"></a>        sens <span class="kw">between</span> <span class="dv">1</span> <span class="kw">and</span> <span class="dv">3</span> <span class="kw">as</span> sensitive_4</span>
-<span id="cb76-9"><a href="#cb76-9"></a>  <span class="kw">from</span> with_sensitive;</span>
-<span id="cb76-10"><a href="#cb76-10"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb76"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb76-1"><a href="#cb76-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc get_sensitive()</span>
+<span id="cb76-2"><a href="#cb76-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb76-3"><a href="#cb76-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="kw">id</span> <span class="kw">as</span> not_sensitive_1,</span>
+<span id="cb76-4"><a href="#cb76-4" aria-hidden="true" tabindex="-1"></a>        sens <span class="op">+</span> <span class="dv">1</span> sensitive_1,</span>
+<span id="cb76-5"><a href="#cb76-5" aria-hidden="true" tabindex="-1"></a>        name <span class="kw">as</span> sensitive_2,</span>
+<span id="cb76-6"><a href="#cb76-6" aria-hidden="true" tabindex="-1"></a>        <span class="st">&#39;x&#39;</span> <span class="kw">as</span> not_sensitive_2,</span>
+<span id="cb76-7"><a href="#cb76-7" aria-hidden="true" tabindex="-1"></a>        <span class="op">-</span>sens <span class="kw">as</span> sensitive_3,</span>
+<span id="cb76-8"><a href="#cb76-8" aria-hidden="true" tabindex="-1"></a>        sens <span class="kw">between</span> <span class="dv">1</span> <span class="kw">and</span> <span class="dv">3</span> <span class="kw">as</span> sensitive_4</span>
+<span id="cb76-9"><a href="#cb76-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">from</span> with_sensitive;</span>
+<span id="cb76-10"><a href="#cb76-10" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>So looking at that procedure we can see that it’s reading sensitive data, the result will have some sensitive columns in it.</p>
 <ul>
 <li>the “id” is not sensitive (at least not in this example)</li>
@@ -1553,58 +1685,58 @@ declare thing_type type thing;</code></pre>
 <p>Generally sensitivity is “radioactive” anything it touches becomes sensitive. This is very important because even a simple looking expression like <code>lgbtqia IS NOT NULL</code> must lead to a sensitive result or the whole process would be largely useless. It has to be basically impossible to wash away sensitivity.</p>
 <p>These rules apply to normal expressions as well as expressions in the context of SQL. Accordingly:</p>
 <p>Sensitive variables can be declared:</p>
-<div class="sourceCode" id="cb77"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb77-1"><a href="#cb77-1"></a><span class="kw">declare</span> sens <span class="dt">integer</span> @sensitive;</span></code></pre></div>
+<div class="sourceCode" id="cb77"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb77-1"><a href="#cb77-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> sens <span class="dt">integer</span> @sensitive;</span></code></pre></div>
 <p>Simple operations on the variables are sensitive</p>
-<div class="sourceCode" id="cb78"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb78-1"><a href="#cb78-1"></a><span class="co">-- this is sensitive (and the same would be true for any other math)</span></span>
-<span id="cb78-2"><a href="#cb78-2"></a>sens <span class="op">+</span> <span class="dv">1</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb78"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb78-1"><a href="#cb78-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- this is sensitive (and the same would be true for any other math)</span></span>
+<span id="cb78-2"><a href="#cb78-2" aria-hidden="true" tabindex="-1"></a>sens <span class="op">+</span> <span class="dv">1</span>;</span></code></pre></div>
 <p>The <code>IN</code> expression gives you sensitive results if anything about it is sensitive</p>
-<div class="sourceCode" id="cb79"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb79-1"><a href="#cb79-1"></a><span class="co">-- all of these are sensitive</span></span>
-<span id="cb79-2"><a href="#cb79-2"></a>sens <span class="kw">in</span> (<span class="dv">1</span>, <span class="dv">2</span>);</span>
-<span id="cb79-3"><a href="#cb79-3"></a><span class="dv">1</span> <span class="kw">in</span> (<span class="dv">1</span>, sens);</span>
-<span id="cb79-4"><a href="#cb79-4"></a>(<span class="kw">select</span> <span class="kw">id</span> <span class="kw">in</span> (<span class="kw">select</span> sens <span class="kw">from</span> with_sensitive));</span></code></pre></div>
+<div class="sourceCode" id="cb79"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb79-1"><a href="#cb79-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- all of these are sensitive</span></span>
+<span id="cb79-2"><a href="#cb79-2" aria-hidden="true" tabindex="-1"></a>sens <span class="kw">in</span> (<span class="dv">1</span>, <span class="dv">2</span>);</span>
+<span id="cb79-3"><a href="#cb79-3" aria-hidden="true" tabindex="-1"></a><span class="dv">1</span> <span class="kw">in</span> (<span class="dv">1</span>, sens);</span>
+<span id="cb79-4"><a href="#cb79-4" aria-hidden="true" tabindex="-1"></a>(<span class="kw">select</span> <span class="kw">id</span> <span class="kw">in</span> (<span class="kw">select</span> sens <span class="kw">from</span> with_sensitive));</span></code></pre></div>
 <p>Similarly sensitive constructs in <code>CASE</code> expressions result in a sensitive output</p>
-<div class="sourceCode" id="cb80"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb80-1"><a href="#cb80-1"></a><span class="co">-- not sensitive</span></span>
-<span id="cb80-2"><a href="#cb80-2"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
-<span id="cb80-3"><a href="#cb80-3"></a></span>
-<span id="cb80-4"><a href="#cb80-4"></a><span class="co">-- all of these are sensitive</span></span>
-<span id="cb80-5"><a href="#cb80-5"></a><span class="cf">case</span> sens <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
-<span id="cb80-6"><a href="#cb80-6"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> sens <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
-<span id="cb80-7"><a href="#cb80-7"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> sens <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
-<span id="cb80-8"><a href="#cb80-8"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> sens <span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb80"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb80-1"><a href="#cb80-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- not sensitive</span></span>
+<span id="cb80-2"><a href="#cb80-2" aria-hidden="true" tabindex="-1"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
+<span id="cb80-3"><a href="#cb80-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb80-4"><a href="#cb80-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- all of these are sensitive</span></span>
+<span id="cb80-5"><a href="#cb80-5" aria-hidden="true" tabindex="-1"></a><span class="cf">case</span> sens <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
+<span id="cb80-6"><a href="#cb80-6" aria-hidden="true" tabindex="-1"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> sens <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
+<span id="cb80-7"><a href="#cb80-7" aria-hidden="true" tabindex="-1"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> sens <span class="cf">else</span> <span class="dv">3</span> <span class="cf">end</span>;</span>
+<span id="cb80-8"><a href="#cb80-8" aria-hidden="true" tabindex="-1"></a><span class="cf">case</span> <span class="dv">0</span> <span class="cf">when</span> <span class="dv">1</span> <span class="cf">then</span> <span class="dv">2</span> <span class="cf">else</span> sens <span class="cf">end</span>;</span></code></pre></div>
 <p>Cast operations preserve sensitivity</p>
-<div class="sourceCode" id="cb81"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb81-1"><a href="#cb81-1"></a><span class="co">-- sensitive result</span></span>
-<span id="cb81-2"><a href="#cb81-2"></a><span class="kw">select</span> <span class="fu">cast</span>(sens <span class="kw">as</span> <span class="dt">INT</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb81"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb81-1"><a href="#cb81-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- sensitive result</span></span>
+<span id="cb81-2"><a href="#cb81-2" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">cast</span>(sens <span class="kw">as</span> <span class="dt">INT</span>);</span></code></pre></div>
 <p>Aggregate functions likewise preserve sensitivity</p>
-<div class="sourceCode" id="cb82"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb82-1"><a href="#cb82-1"></a><span class="co">-- all of these are sensitive</span></span>
-<span id="cb82-2"><a href="#cb82-2"></a><span class="kw">select</span> <span class="fu">AVG</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
-<span id="cb82-3"><a href="#cb82-3"></a><span class="kw">select</span> <span class="fu">MIN</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
-<span id="cb82-4"><a href="#cb82-4"></a><span class="kw">select</span> <span class="fu">MAX</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
-<span id="cb82-5"><a href="#cb82-5"></a><span class="kw">select</span> <span class="fu">SUM</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
-<span id="cb82-6"><a href="#cb82-6"></a><span class="kw">select</span> <span class="fu">COUNT</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span></code></pre></div>
+<div class="sourceCode" id="cb82"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb82-1"><a href="#cb82-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- all of these are sensitive</span></span>
+<span id="cb82-2"><a href="#cb82-2" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">AVG</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
+<span id="cb82-3"><a href="#cb82-3" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">MIN</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
+<span id="cb82-4"><a href="#cb82-4" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">MAX</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
+<span id="cb82-5"><a href="#cb82-5" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">SUM</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span>
+<span id="cb82-6"><a href="#cb82-6" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">COUNT</span>(T1.sens) <span class="kw">from</span> with_sensitive T1;</span></code></pre></div>
 <p>There are many operators that get similar treatment such as <code>COALESCE</code>, <code>IFNULL</code>, <code>IS</code> and <code>IS NOT</code>.</p>
 <p>Things get more interesting when we come to the <code>EXISTS</code> operator:</p>
-<div class="sourceCode" id="cb83"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb83-1"><a href="#cb83-1"></a><span class="co">-- sensitive if and only if any selected column is sensitive</span></span>
-<span id="cb83-2"><a href="#cb83-2"></a><span class="kw">exists</span>(<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> with_sensitive)</span>
-<span id="cb83-3"><a href="#cb83-3"></a></span>
-<span id="cb83-4"><a href="#cb83-4"></a><span class="co">-- sensitive because &quot;info&quot; is sensitive</span></span>
-<span id="cb83-5"><a href="#cb83-5"></a><span class="kw">exists</span>(<span class="kw">select</span> info <span class="kw">from</span> with_sensitive)</span>
-<span id="cb83-6"><a href="#cb83-6"></a></span>
-<span id="cb83-7"><a href="#cb83-7"></a><span class="co">-- not sensitive because &quot;id&quot; is not sensitive</span></span>
-<span id="cb83-8"><a href="#cb83-8"></a><span class="kw">exists</span>(<span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> with_sensitive)</span></code></pre></div>
+<div class="sourceCode" id="cb83"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb83-1"><a href="#cb83-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- sensitive if and only if any selected column is sensitive</span></span>
+<span id="cb83-2"><a href="#cb83-2" aria-hidden="true" tabindex="-1"></a><span class="kw">exists</span>(<span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> with_sensitive)</span>
+<span id="cb83-3"><a href="#cb83-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb83-4"><a href="#cb83-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- sensitive because &quot;info&quot; is sensitive</span></span>
+<span id="cb83-5"><a href="#cb83-5" aria-hidden="true" tabindex="-1"></a><span class="kw">exists</span>(<span class="kw">select</span> info <span class="kw">from</span> with_sensitive)</span>
+<span id="cb83-6"><a href="#cb83-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb83-7"><a href="#cb83-7" aria-hidden="true" tabindex="-1"></a><span class="co">-- not sensitive because &quot;id&quot; is not sensitive</span></span>
+<span id="cb83-8"><a href="#cb83-8" aria-hidden="true" tabindex="-1"></a><span class="kw">exists</span>(<span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> with_sensitive)</span></code></pre></div>
 <p>If this is making you nervous, it probably should, we need a little more protection because of the way EXISTS is typically used. The predicates matter, consider the following:</p>
-<div class="sourceCode" id="cb84"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb84-1"><a href="#cb84-1"></a><span class="co">-- id is now sensitive because the predicate of the where clause was sensitive</span></span>
-<span id="cb84-2"><a href="#cb84-2"></a><span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> with_sensitive <span class="kw">where</span> sens <span class="op">=</span> <span class="dv">1</span>;</span>
-<span id="cb84-3"><a href="#cb84-3"></a></span>
-<span id="cb84-4"><a href="#cb84-4"></a><span class="co">-- this expression is now sensitive because id is sensitive in this context</span></span>
-<span id="cb84-5"><a href="#cb84-5"></a><span class="kw">exists</span>(<span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> with_sensitive <span class="kw">where</span> sens <span class="op">=</span> <span class="dv">1</span>)</span></code></pre></div>
+<div class="sourceCode" id="cb84"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb84-1"><a href="#cb84-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- id is now sensitive because the predicate of the where clause was sensitive</span></span>
+<span id="cb84-2"><a href="#cb84-2" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> with_sensitive <span class="kw">where</span> sens <span class="op">=</span> <span class="dv">1</span>;</span>
+<span id="cb84-3"><a href="#cb84-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb84-4"><a href="#cb84-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- this expression is now sensitive because id is sensitive in this context</span></span>
+<span id="cb84-5"><a href="#cb84-5" aria-hidden="true" tabindex="-1"></a><span class="kw">exists</span>(<span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> with_sensitive <span class="kw">where</span> sens <span class="op">=</span> <span class="dv">1</span>)</span></code></pre></div>
 <p>In general: if the predicate of a <code>WHERE</code> or <code>HAVING</code> clause is sensitive then all columns in the result become sensitive.</p>
 <p>Similarly when performing joins, if the column specified in the <code>USING</code> clause is sensitive or the predicate of the <code>ON</code> clause is sensitive then the result of the join is considered to be all sensitive columns (even if the columns were not sensitive in the schema).</p>
 <p>Likewise a sensitive expression in <code>LIMIT</code> or <code>OFFSET</code> will result in 100% sensitive columns as these can be used in a <code>WHERE</code>-ish way. There is no reasonble defense against using <code>LIMIT</code> and testing for the presence or absence of a row as a way to wash away sensitivity so that is a weakness, but the rules that are present are likely to be very helpful.</p>
-<div class="sourceCode" id="cb85"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb85-1"><a href="#cb85-1"></a><span class="co">-- join with ON</span></span>
-<span id="cb85-2"><a href="#cb85-2"></a><span class="kw">select</span> T1.<span class="kw">id</span> <span class="kw">from</span> with_sensitive T1 <span class="kw">inner</span> <span class="kw">join</span> with_sensitive T2 <span class="kw">on</span> T1.sens <span class="op">=</span> T2.sens</span>
-<span id="cb85-3"><a href="#cb85-3"></a></span>
-<span id="cb85-4"><a href="#cb85-4"></a><span class="co">-- join with USING</span></span>
-<span id="cb85-5"><a href="#cb85-5"></a><span class="kw">select</span> T1.<span class="kw">id</span> <span class="kw">from</span> with_sensitive T1 <span class="kw">inner</span> <span class="kw">join</span> with_sensitive T2 <span class="kw">using</span>(sens);</span></code></pre></div>
+<div class="sourceCode" id="cb85"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb85-1"><a href="#cb85-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- join with ON</span></span>
+<span id="cb85-2"><a href="#cb85-2" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> T1.<span class="kw">id</span> <span class="kw">from</span> with_sensitive T1 <span class="kw">inner</span> <span class="kw">join</span> with_sensitive T2 <span class="kw">on</span> T1.sens <span class="op">=</span> T2.sens</span>
+<span id="cb85-3"><a href="#cb85-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb85-4"><a href="#cb85-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- join with USING</span></span>
+<span id="cb85-5"><a href="#cb85-5" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> T1.<span class="kw">id</span> <span class="kw">from</span> with_sensitive T1 <span class="kw">inner</span> <span class="kw">join</span> with_sensitive T2 <span class="kw">using</span>(sens);</span></code></pre></div>
 <p>All of these expression and join propagations are designed to make it impossible to simply wash-away sensitivity with a little bit of math.</p>
 <p>Now we come to enforcement, which boils down to what assignments or “assignment-like” operations we allow.</p>
 <p>If we have these:</p>
@@ -1656,7 +1788,7 @@ set not_sens := sens;</code></pre>
 </ul>
 <h4 id="assigning-to-an-out-parameter-or-a-global-variable">Assigning to an <code>out</code> parameter or a global variable</h4>
 <ul>
-<li><code>out,</code>inout<code>parameters, and global variables work just like local variables except that CQL does not call</code>release` at the end of the procedure</li>
+<li><code>out</code>, <code>inout</code> parameters, and global variables work just like local variables except that CQL does not call <code>release</code> at the end of the procedure</li>
 </ul>
 <h3 id="function-return-values">Function Return Values</h3>
 <p>Stored procedures do not return values, they only have <code>out</code> arguments and those are well defined as above. Functions however are also supported and they can have either <code>get</code> or <code>create</code> semantics</p>
@@ -1756,13 +1888,13 @@ cql_cleanup:
 <p>All kinds of control flow happens in the context of some procedure, though we’ve already introduced examples of procedures let’s now go over some of the additional aspects we have not yet illustrated.</p>
 <h3 id="out-parameters">Out Parameters</h3>
 <p>Consider this procedure:</p>
-<div class="sourceCode" id="cb93"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb93-1"><a href="#cb93-1"></a><span class="kw">create</span> <span class="kw">procedure</span> echo (<span class="kw">in</span> arg1 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">out</span> arg2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb93-2"><a href="#cb93-2"></a><span class="cf">begin</span> </span>
-<span id="cb93-3"><a href="#cb93-3"></a>  <span class="kw">set</span> arg2 <span class="op">:=</span> arg1; </span>
-<span id="cb93-4"><a href="#cb93-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb93"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb93-1"><a href="#cb93-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> echo (<span class="kw">in</span> arg1 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">out</span> arg2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb93-2"><a href="#cb93-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span> </span>
+<span id="cb93-3"><a href="#cb93-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> arg2 <span class="op">:=</span> arg1; </span>
+<span id="cb93-4"><a href="#cb93-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Here <code>arg2</code> has been declared <code>out</code>. CQL out parameters are very similar to “by reference” arguments in other langauges and indeed they compile into a simple pointer reference in the generated C code. One notable difference is that, in CQL, <code>out</code> parameters for reference types and nullable types are always set to NULL by default. This is another way that an otherwise non-null reference variable can end up with a null in it.</p>
 <p>Looking at the one line in the body of this procedure:</p>
-<div class="sourceCode" id="cb94"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb94-1"><a href="#cb94-1"></a>  <span class="kw">set</span> arg2 <span class="op">:=</span> arg1; </span></code></pre></div>
+<div class="sourceCode" id="cb94"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb94-1"><a href="#cb94-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> arg2 <span class="op">:=</span> arg1; </span></code></pre></div>
 <p>The input argument <code>arg1</code> is unconditionally stored in the output. Note that the <code>in</code> keyword is entirely optional and does nothing other than perhaps add some clarity. CQL also supports <code>inout</code> arguments which are expected to contain non-garbage values on entry. If the procedure is called from CQL, the compiler will arrange for this to be true.</p>
 <ul>
 <li><code>in</code> arguments contain a valid value</li>
@@ -1785,120 +1917,120 @@ cql_cleanup:
 <p>The let’s go over the most essential bits of control flow.</p>
 <h3 id="the-if-statement">The IF statement</h3>
 <p>The CQL <code>IF</code> statement has no syntatic ambiguities at the expense of being somewhat more verbose than many other languages. In CQL the <code>ELSE IF</code> portion is baked into the <code>IF</code> statement, so what you see below is logically a single statement.</p>
-<div class="sourceCode" id="cb96"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb96-1"><a href="#cb96-1"></a><span class="kw">create</span> proc checker(foo <span class="dt">integer</span>, <span class="kw">out</span> result <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb96-2"><a href="#cb96-2"></a><span class="cf">begin</span></span>
-<span id="cb96-3"><a href="#cb96-3"></a>  <span class="cf">if</span> foo <span class="op">=</span> <span class="dv">1</span> <span class="cf">then</span></span>
-<span id="cb96-4"><a href="#cb96-4"></a>   <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">1</span>;</span>
-<span id="cb96-5"><a href="#cb96-5"></a>  <span class="cf">else</span> <span class="cf">if</span> foo <span class="op">=</span> <span class="dv">2</span> <span class="cf">then</span></span>
-<span id="cb96-6"><a href="#cb96-6"></a>   <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">3</span>; </span>
-<span id="cb96-7"><a href="#cb96-7"></a>  <span class="cf">else</span></span>
-<span id="cb96-8"><a href="#cb96-8"></a>   <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">5</span>;</span>
-<span id="cb96-9"><a href="#cb96-9"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb96-10"><a href="#cb96-10"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb96"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb96-1"><a href="#cb96-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc checker(foo <span class="dt">integer</span>, <span class="kw">out</span> result <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb96-2"><a href="#cb96-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb96-3"><a href="#cb96-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> foo <span class="op">=</span> <span class="dv">1</span> <span class="cf">then</span></span>
+<span id="cb96-4"><a href="#cb96-4" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">1</span>;</span>
+<span id="cb96-5"><a href="#cb96-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> <span class="cf">if</span> foo <span class="op">=</span> <span class="dv">2</span> <span class="cf">then</span></span>
+<span id="cb96-6"><a href="#cb96-6" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">3</span>; </span>
+<span id="cb96-7"><a href="#cb96-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span></span>
+<span id="cb96-8"><a href="#cb96-8" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">5</span>;</span>
+<span id="cb96-9"><a href="#cb96-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb96-10"><a href="#cb96-10" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <h3 id="the-while-statement">The WHILE statement</h3>
 <p>What follows is a simple procedure that counts down its input argument.</p>
-<div class="sourceCode" id="cb97"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb97-1"><a href="#cb97-1"></a><span class="kw">create</span> proc looper(x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb97-2"><a href="#cb97-2"></a><span class="cf">begin</span></span>
-<span id="cb97-3"><a href="#cb97-3"></a>  <span class="cf">while</span> x <span class="op">&gt;</span> <span class="dv">0</span></span>
-<span id="cb97-4"><a href="#cb97-4"></a>  <span class="cf">begin</span></span>
-<span id="cb97-5"><a href="#cb97-5"></a>   <span class="kw">call</span> printf(<span class="st">&#39;%d</span><span class="ch">\n</span><span class="st">&#39;</span>, x);</span>
-<span id="cb97-6"><a href="#cb97-6"></a>   <span class="kw">set</span> x <span class="op">:=</span> x <span class="op">-</span> <span class="dv">1</span>;</span>
-<span id="cb97-7"><a href="#cb97-7"></a>  <span class="cf">end</span>;</span>
-<span id="cb97-8"><a href="#cb97-8"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb97"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb97-1"><a href="#cb97-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc looper(x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb97-2"><a href="#cb97-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb97-3"><a href="#cb97-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> x <span class="op">&gt;</span> <span class="dv">0</span></span>
+<span id="cb97-4"><a href="#cb97-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb97-5"><a href="#cb97-5" aria-hidden="true" tabindex="-1"></a>   <span class="kw">call</span> printf(<span class="st">&#39;%d</span><span class="ch">\n</span><span class="st">&#39;</span>, x);</span>
+<span id="cb97-6"><a href="#cb97-6" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> x <span class="op">:=</span> x <span class="op">-</span> <span class="dv">1</span>;</span>
+<span id="cb97-7"><a href="#cb97-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb97-8"><a href="#cb97-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The <code>WHILE</code> loop has additional keywords that can be used within it to better control the loop. A more general loop might look like this:</p>
-<div class="sourceCode" id="cb98"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb98-1"><a href="#cb98-1"></a><span class="kw">create</span> proc looper(x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb98-2"><a href="#cb98-2"></a><span class="cf">begin</span></span>
-<span id="cb98-3"><a href="#cb98-3"></a>  <span class="cf">while</span> <span class="dv">1</span></span>
-<span id="cb98-4"><a href="#cb98-4"></a>  <span class="cf">begin</span></span>
-<span id="cb98-5"><a href="#cb98-5"></a>   <span class="kw">set</span> x <span class="op">:=</span> x <span class="op">-</span> <span class="dv">1</span>;</span>
-<span id="cb98-6"><a href="#cb98-6"></a>   <span class="cf">if</span> x <span class="op">&lt;</span> <span class="dv">0</span> <span class="cf">then</span></span>
-<span id="cb98-7"><a href="#cb98-7"></a>     leave;</span>
-<span id="cb98-8"><a href="#cb98-8"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">100</span> <span class="op">=</span> <span class="dv">0</span> <span class="cf">then</span></span>
-<span id="cb98-9"><a href="#cb98-9"></a>     <span class="kw">continue</span>;</span>
-<span id="cb98-10"><a href="#cb98-10"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">10</span> <span class="op">=</span> <span class="dv">0</span></span>
-<span id="cb98-11"><a href="#cb98-11"></a>     <span class="kw">call</span> printf(<span class="st">&#39;%d</span><span class="ch">\n</span><span class="st">&#39;</span>, x);</span>
-<span id="cb98-12"><a href="#cb98-12"></a>   <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb98-13"><a href="#cb98-13"></a>  <span class="cf">end</span>;</span>
-<span id="cb98-14"><a href="#cb98-14"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb98"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb98-1"><a href="#cb98-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc looper(x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb98-2"><a href="#cb98-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb98-3"><a href="#cb98-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> <span class="dv">1</span></span>
+<span id="cb98-4"><a href="#cb98-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb98-5"><a href="#cb98-5" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> x <span class="op">:=</span> x <span class="op">-</span> <span class="dv">1</span>;</span>
+<span id="cb98-6"><a href="#cb98-6" aria-hidden="true" tabindex="-1"></a>   <span class="cf">if</span> x <span class="op">&lt;</span> <span class="dv">0</span> <span class="cf">then</span></span>
+<span id="cb98-7"><a href="#cb98-7" aria-hidden="true" tabindex="-1"></a>     leave;</span>
+<span id="cb98-8"><a href="#cb98-8" aria-hidden="true" tabindex="-1"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">100</span> <span class="op">=</span> <span class="dv">0</span> <span class="cf">then</span></span>
+<span id="cb98-9"><a href="#cb98-9" aria-hidden="true" tabindex="-1"></a>     <span class="kw">continue</span>;</span>
+<span id="cb98-10"><a href="#cb98-10" aria-hidden="true" tabindex="-1"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">10</span> <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb98-11"><a href="#cb98-11" aria-hidden="true" tabindex="-1"></a>     <span class="kw">call</span> printf(<span class="st">&#39;%d</span><span class="ch">\n</span><span class="st">&#39;</span>, x);</span>
+<span id="cb98-12"><a href="#cb98-12" aria-hidden="true" tabindex="-1"></a>   <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb98-13"><a href="#cb98-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb98-14"><a href="#cb98-14" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Let’s go over this peculiar loop:</p>
-<div class="sourceCode" id="cb99"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb99-1"><a href="#cb99-1"></a>  <span class="cf">while</span> <span class="dv">1</span></span>
-<span id="cb99-2"><a href="#cb99-2"></a>  <span class="cf">begin</span></span>
-<span id="cb99-3"><a href="#cb99-3"></a>    <span class="op">..</span>.</span>
-<span id="cb99-4"><a href="#cb99-4"></a>  <span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb99"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb99-1"><a href="#cb99-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> <span class="dv">1</span></span>
+<span id="cb99-2"><a href="#cb99-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb99-3"><a href="#cb99-3" aria-hidden="true" tabindex="-1"></a>    <span class="op">..</span>.</span>
+<span id="cb99-4"><a href="#cb99-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span></code></pre></div>
 <p>This is an immediate sign that there will be an unusual exit condition. The loop will never end without one because <code>1</code> will never be false.</p>
-<div class="sourceCode" id="cb100"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb100-1"><a href="#cb100-1"></a>   <span class="cf">if</span> x <span class="op">&lt;</span> <span class="dv">0</span> <span class="cf">then</span></span>
-<span id="cb100-2"><a href="#cb100-2"></a>     leave;</span></code></pre></div>
+<div class="sourceCode" id="cb100"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb100-1"><a href="#cb100-1" aria-hidden="true" tabindex="-1"></a>   <span class="cf">if</span> x <span class="op">&lt;</span> <span class="dv">0</span> <span class="cf">then</span></span>
+<span id="cb100-2"><a href="#cb100-2" aria-hidden="true" tabindex="-1"></a>     leave;</span></code></pre></div>
 <p>Now here we’ve encoded our exit condition a bit strangely we might have done the equivalent job with a normal conditionn in the predicate part of the <code>while</code> statement but for illustration anyway, when x becomes negative <code>leave</code> will cause us to exit the loop. This is like <code>break</code> in C.</p>
-<div class="sourceCode" id="cb101"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb101-1"><a href="#cb101-1"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">100</span> <span class="op">=</span> <span class="dv">0</span> <span class="cf">then</span></span>
-<span id="cb101-2"><a href="#cb101-2"></a>     <span class="kw">continue</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb101"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb101-1"><a href="#cb101-1" aria-hidden="true" tabindex="-1"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">100</span> <span class="op">=</span> <span class="dv">0</span> <span class="cf">then</span></span>
+<span id="cb101-2"><a href="#cb101-2" aria-hidden="true" tabindex="-1"></a>     <span class="kw">continue</span>;</span></code></pre></div>
 <p>This bit says that on every 100th iteration we go back to the start of the loop. So the next bit will not run, which is the printing.</p>
-<div class="sourceCode" id="cb102"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb102-1"><a href="#cb102-1"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">10</span> <span class="op">=</span> <span class="dv">0</span></span>
-<span id="cb102-2"><a href="#cb102-2"></a>     <span class="kw">call</span> printf(<span class="st">&#39;%d</span><span class="ch">\n</span><span class="st">&#39;</span>, x);</span>
-<span id="cb102-3"><a href="#cb102-3"></a>   <span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb102"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb102-1"><a href="#cb102-1" aria-hidden="true" tabindex="-1"></a>   <span class="cf">else</span> <span class="cf">if</span> x % <span class="dv">10</span> <span class="op">=</span> <span class="dv">0</span></span>
+<span id="cb102-2"><a href="#cb102-2" aria-hidden="true" tabindex="-1"></a>     <span class="kw">call</span> printf(<span class="st">&#39;%d</span><span class="ch">\n</span><span class="st">&#39;</span>, x);</span>
+<span id="cb102-3"><a href="#cb102-3" aria-hidden="true" tabindex="-1"></a>   <span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>Finishing up the control flow, on every 10th iteration we print the value of the loop variable.</p>
 <h3 id="the-try-catch-and-throw-statements">The TRY, CATCH, and THROW Statements</h3>
 <p>This example illustrates catching an error from some DML, and recovering rather than letting the error cascade up.<br />
 This is the common “upsert” pattern (insert or update)</p>
-<div class="sourceCode" id="cb103"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb103-1"><a href="#cb103-1"></a><span class="kw">create</span> <span class="kw">procedure</span> upsert_foo(id_ <span class="dt">integer</span>, t_ text)</span>
-<span id="cb103-2"><a href="#cb103-2"></a><span class="cf">begin</span></span>
-<span id="cb103-3"><a href="#cb103-3"></a>  <span class="cf">begin</span> try</span>
-<span id="cb103-4"><a href="#cb103-4"></a>    <span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>, t) <span class="kw">values</span>(id_, t_)</span>
-<span id="cb103-5"><a href="#cb103-5"></a>  <span class="cf">end</span> try; </span>
-<span id="cb103-6"><a href="#cb103-6"></a>  <span class="cf">begin</span> catch </span>
-<span id="cb103-7"><a href="#cb103-7"></a>    <span class="cf">begin</span> try</span>
-<span id="cb103-8"><a href="#cb103-8"></a>      <span class="kw">update</span> foo <span class="kw">set</span> t <span class="op">=</span> t_ <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb103-9"><a href="#cb103-9"></a>    <span class="cf">end</span> try;</span>
-<span id="cb103-10"><a href="#cb103-10"></a>    <span class="cf">begin</span> catch</span>
-<span id="cb103-11"><a href="#cb103-11"></a>      printf(<span class="ot">&quot;Error!\n&quot;</span>);</span>
-<span id="cb103-12"><a href="#cb103-12"></a>      throw;</span>
-<span id="cb103-13"><a href="#cb103-13"></a>    <span class="cf">end</span> catch;</span>
-<span id="cb103-14"><a href="#cb103-14"></a>  <span class="cf">end</span> catch; </span>
-<span id="cb103-15"><a href="#cb103-15"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb103"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb103-1"><a href="#cb103-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> upsert_foo(id_ <span class="dt">integer</span>, t_ text)</span>
+<span id="cb103-2"><a href="#cb103-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb103-3"><a href="#cb103-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span> try</span>
+<span id="cb103-4"><a href="#cb103-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>, t) <span class="kw">values</span>(id_, t_)</span>
+<span id="cb103-5"><a href="#cb103-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> try; </span>
+<span id="cb103-6"><a href="#cb103-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span> catch </span>
+<span id="cb103-7"><a href="#cb103-7" aria-hidden="true" tabindex="-1"></a>    <span class="cf">begin</span> try</span>
+<span id="cb103-8"><a href="#cb103-8" aria-hidden="true" tabindex="-1"></a>      <span class="kw">update</span> foo <span class="kw">set</span> t <span class="op">=</span> t_ <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb103-9"><a href="#cb103-9" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span> try;</span>
+<span id="cb103-10"><a href="#cb103-10" aria-hidden="true" tabindex="-1"></a>    <span class="cf">begin</span> catch</span>
+<span id="cb103-11"><a href="#cb103-11" aria-hidden="true" tabindex="-1"></a>      printf(<span class="ot">&quot;Error!\n&quot;</span>);</span>
+<span id="cb103-12"><a href="#cb103-12" aria-hidden="true" tabindex="-1"></a>      throw;</span>
+<span id="cb103-13"><a href="#cb103-13" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span> catch;</span>
+<span id="cb103-14"><a href="#cb103-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> catch; </span>
+<span id="cb103-15"><a href="#cb103-15" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Once again, let’s go over this section by section:</p>
-<div class="sourceCode" id="cb104"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb104-1"><a href="#cb104-1"></a>  <span class="cf">begin</span> try</span>
-<span id="cb104-2"><a href="#cb104-2"></a>    <span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>, t) <span class="kw">values</span>(id_, t_)</span>
-<span id="cb104-3"><a href="#cb104-3"></a>  <span class="cf">end</span> try; </span></code></pre></div>
+<div class="sourceCode" id="cb104"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb104-1"><a href="#cb104-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span> try</span>
+<span id="cb104-2"><a href="#cb104-2" aria-hidden="true" tabindex="-1"></a>    <span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>, t) <span class="kw">values</span>(id_, t_)</span>
+<span id="cb104-3"><a href="#cb104-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> try; </span></code></pre></div>
 <p>Normally if the <code>insert</code> statement fails, the procedure will exit with a failure result code. Here, instead, we prepare to catch that error.</p>
-<div class="sourceCode" id="cb105"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb105-1"><a href="#cb105-1"></a>  <span class="cf">begin</span> catch </span>
-<span id="cb105-2"><a href="#cb105-2"></a>    <span class="cf">begin</span> try</span>
-<span id="cb105-3"><a href="#cb105-3"></a>      <span class="kw">update</span> foo <span class="kw">set</span> t <span class="op">=</span> t_ <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb105-4"><a href="#cb105-4"></a>    <span class="cf">end</span> try;</span></code></pre></div>
+<div class="sourceCode" id="cb105"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb105-1"><a href="#cb105-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span> catch </span>
+<span id="cb105-2"><a href="#cb105-2" aria-hidden="true" tabindex="-1"></a>    <span class="cf">begin</span> try</span>
+<span id="cb105-3"><a href="#cb105-3" aria-hidden="true" tabindex="-1"></a>      <span class="kw">update</span> foo <span class="kw">set</span> t <span class="op">=</span> t_ <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb105-4"><a href="#cb105-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span> try;</span></code></pre></div>
 <p>Now, having failed to insert, presumably because a row with the provided <code>id</code> already exists, we try to update that row instead. However that might also fail, so we wrap it in another try. If the update fails, then there is a final catch block:</p>
-<div class="sourceCode" id="cb106"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb106-1"><a href="#cb106-1"></a>    <span class="cf">begin</span> catch</span>
-<span id="cb106-2"><a href="#cb106-2"></a>      printf(<span class="ot">&quot;Error!\n&quot;</span>);</span>
-<span id="cb106-3"><a href="#cb106-3"></a>      throw;</span>
-<span id="cb106-4"><a href="#cb106-4"></a>    <span class="cf">end</span> catch;</span></code></pre></div>
+<div class="sourceCode" id="cb106"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb106-1"><a href="#cb106-1" aria-hidden="true" tabindex="-1"></a>    <span class="cf">begin</span> catch</span>
+<span id="cb106-2"><a href="#cb106-2" aria-hidden="true" tabindex="-1"></a>      printf(<span class="ot">&quot;Error!\n&quot;</span>);</span>
+<span id="cb106-3"><a href="#cb106-3" aria-hidden="true" tabindex="-1"></a>      throw;</span>
+<span id="cb106-4"><a href="#cb106-4" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span> catch;</span></code></pre></div>
 <p>Here we print a diagnostic message and then use the <code>throw</code> keyword to rethrow the previous failure. Throw will create a failure in the current block using the most recent result code from SQLite if it is an error, or else the general <code>SQLITE_ERROR</code> result code if there is no such error. In this case the failure code for the <code>update</code> statement will become the result code of the current procedure.</p>
 <p>This leaves only the closing markers:</p>
-<div class="sourceCode" id="cb107"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb107-1"><a href="#cb107-1"></a>  <span class="cf">end</span> catch; </span>
-<span id="cb107-2"><a href="#cb107-2"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb107"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb107-1"><a href="#cb107-1" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> catch; </span>
+<span id="cb107-2"><a href="#cb107-2" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>If control flow reaches the normal end of the procedure it will return <code>SQLITE_OK</code>.</p>
 <h3 id="procedures-as-functions-motivation-and-example">Procedures as Functions: Motivation and Example</h3>
 <p>The calling convention for CQL stored procedures often (usually) requires that the procedure returns a result code from SQLite.<br />
 This makes it impossible to write a procedure that returns a result like a function, the result position is already used for the error code. You can get around this problem by using <code>out</code> arguments as your return codes. So for instance, this version of the Fibonacci function is possible.</p>
-<div class="sourceCode" id="cb108"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb108-1"><a href="#cb108-1"></a><span class="co">-- this works, but it is awkward</span></span>
-<span id="cb108-2"><a href="#cb108-2"></a><span class="kw">create</span> <span class="kw">procedure</span> fib (<span class="kw">in</span> arg <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">out</span> result <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>) </span>
-<span id="cb108-3"><a href="#cb108-3"></a><span class="cf">begin</span></span>
-<span id="cb108-4"><a href="#cb108-4"></a>  <span class="cf">if</span> (arg <span class="op">&lt;=</span> <span class="dv">2</span>) <span class="cf">then</span></span>
-<span id="cb108-5"><a href="#cb108-5"></a>    <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">1</span>;</span>
-<span id="cb108-6"><a href="#cb108-6"></a>  <span class="cf">else</span> </span>
-<span id="cb108-7"><a href="#cb108-7"></a>    <span class="kw">declare</span> t <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>; </span>
-<span id="cb108-8"><a href="#cb108-8"></a>    <span class="kw">call</span> fib(arg <span class="op">-</span> <span class="dv">1</span>,  result); </span>
-<span id="cb108-9"><a href="#cb108-9"></a>    <span class="kw">call</span> fib(arg <span class="op">-</span> <span class="dv">2</span>,  t); </span>
-<span id="cb108-10"><a href="#cb108-10"></a>    <span class="kw">set</span> result <span class="op">:=</span> t <span class="op">+</span> result;</span>
-<span id="cb108-11"><a href="#cb108-11"></a>  <span class="cf">end</span> <span class="cf">if</span>; </span>
-<span id="cb108-12"><a href="#cb108-12"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb108"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb108-1"><a href="#cb108-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- this works, but it is awkward</span></span>
+<span id="cb108-2"><a href="#cb108-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> fib (<span class="kw">in</span> arg <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">out</span> result <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>) </span>
+<span id="cb108-3"><a href="#cb108-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb108-4"><a href="#cb108-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (arg <span class="op">&lt;=</span> <span class="dv">2</span>) <span class="cf">then</span></span>
+<span id="cb108-5"><a href="#cb108-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">1</span>;</span>
+<span id="cb108-6"><a href="#cb108-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> </span>
+<span id="cb108-7"><a href="#cb108-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">declare</span> t <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>; </span>
+<span id="cb108-8"><a href="#cb108-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> fib(arg <span class="op">-</span> <span class="dv">1</span>,  result); </span>
+<span id="cb108-9"><a href="#cb108-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> fib(arg <span class="op">-</span> <span class="dv">2</span>,  t); </span>
+<span id="cb108-10"><a href="#cb108-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">set</span> result <span class="op">:=</span> t <span class="op">+</span> result;</span>
+<span id="cb108-11"><a href="#cb108-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>; </span>
+<span id="cb108-12"><a href="#cb108-12" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The above works, but the notation is very awkward.</p>
 <p>CQL has a “procedures as functions” feature that tries to make this more pleasant by making it possible to use function call notation on a procedure whose last argument is an <code>out</code> variable. You simply call the procedure like it was a function and omit the last argument in the call. A temporary variable is automatically created to hold the result and that temporary becomes the logical return of the function. For semantic analysis, the result type of the function becomes the type of the <code>out</code> argument.</p>
-<div class="sourceCode" id="cb109"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb109-1"><a href="#cb109-1"></a><span class="co">-- rewritten with function call syntax</span></span>
-<span id="cb109-2"><a href="#cb109-2"></a><span class="kw">create</span> <span class="kw">procedure</span> fib (<span class="kw">in</span> arg <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">out</span> result <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>) </span>
-<span id="cb109-3"><a href="#cb109-3"></a><span class="cf">begin</span></span>
-<span id="cb109-4"><a href="#cb109-4"></a>  <span class="cf">if</span> (arg <span class="op">&lt;=</span> <span class="dv">2</span>) <span class="cf">then</span></span>
-<span id="cb109-5"><a href="#cb109-5"></a>    <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">1</span>;</span>
-<span id="cb109-6"><a href="#cb109-6"></a>  <span class="cf">else</span> </span>
-<span id="cb109-7"><a href="#cb109-7"></a>    <span class="kw">set</span> result <span class="op">:=</span> fib(arg <span class="op">-</span> <span class="dv">1</span>) <span class="op">+</span> fib(arg <span class="op">-</span> <span class="dv">2</span>);</span>
-<span id="cb109-8"><a href="#cb109-8"></a>  <span class="cf">end</span> <span class="cf">if</span>; </span>
-<span id="cb109-9"><a href="#cb109-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb109"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb109-1"><a href="#cb109-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- rewritten with function call syntax</span></span>
+<span id="cb109-2"><a href="#cb109-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> fib (<span class="kw">in</span> arg <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">out</span> result <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>) </span>
+<span id="cb109-3"><a href="#cb109-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb109-4"><a href="#cb109-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (arg <span class="op">&lt;=</span> <span class="dv">2</span>) <span class="cf">then</span></span>
+<span id="cb109-5"><a href="#cb109-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">set</span> result <span class="op">:=</span> <span class="dv">1</span>;</span>
+<span id="cb109-6"><a href="#cb109-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span> </span>
+<span id="cb109-7"><a href="#cb109-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">set</span> result <span class="op">:=</span> fib(arg <span class="op">-</span> <span class="dv">1</span>) <span class="op">+</span> fib(arg <span class="op">-</span> <span class="dv">2</span>);</span>
+<span id="cb109-8"><a href="#cb109-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>; </span>
+<span id="cb109-9"><a href="#cb109-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This form is allowed when:</p>
 <ul>
 <li>all but the last argument of the procedure was specified</li>
@@ -1919,44 +2051,44 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 <p>First there are three types of cursors, as we will see below.</p>
 <h3 id="statement-cursors">Statement Cursors</h3>
 <p>A statement cursor is based on a SQL <code>SELECT</code> statement. A full example might look like this:</p>
-<div class="sourceCode" id="cb110"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb110-1"><a href="#cb110-1"></a><span class="co">-- elsewhere</span></span>
-<span id="cb110-2"><a href="#cb110-2"></a><span class="kw">create</span> <span class="kw">table</span> xy_table(x <span class="dt">integer</span>, y <span class="dt">integer</span>);</span>
-<span id="cb110-3"><a href="#cb110-3"></a></span>
-<span id="cb110-4"><a href="#cb110-4"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> x, y <span class="kw">from</span> xy_table;</span></code></pre></div>
+<div class="sourceCode" id="cb110"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb110-1"><a href="#cb110-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- elsewhere</span></span>
+<span id="cb110-2"><a href="#cb110-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> xy_table(x <span class="dt">integer</span>, y <span class="dt">integer</span>);</span>
+<span id="cb110-3"><a href="#cb110-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb110-4"><a href="#cb110-4" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> x, y <span class="kw">from</span> xy_table;</span></code></pre></div>
 <p>When compiled, this will result in creating a SQLite statement object (type <code>sqlite_stmt*</code>) and storing it in a variable called <code>C</code>. This statement can then be used later in various ways.</p>
 <p>Here’s perhaps the simplest way to use a cursor:</p>
-<div class="sourceCode" id="cb111"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb111-1"><a href="#cb111-1"></a><span class="kw">declare</span> x, y  <span class="dt">integer</span>;</span>
-<span id="cb111-2"><a href="#cb111-2"></a>fetch C <span class="kw">into</span> x, y;</span></code></pre></div>
+<div class="sourceCode" id="cb111"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb111-1"><a href="#cb111-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> x, y  <span class="dt">integer</span>;</span>
+<span id="cb111-2"><a href="#cb111-2" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">into</span> x, y;</span></code></pre></div>
 <p>This will have the effect of reading one row from the results of the query into the local variables <code>x</code> and <code>y</code>.</p>
 <p>These variables might then be used to create some output such as</p>
-<div class="sourceCode" id="cb112"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb112-1"><a href="#cb112-1"></a><span class="co">/* note use of double quotes so that \n is legal */</span></span>
-<span id="cb112-2"><a href="#cb112-2"></a><span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(x, <span class="dv">0</span>), ifnull(y,<span class="dv">0</span>));</span></code></pre></div>
+<div class="sourceCode" id="cb112"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb112-1"><a href="#cb112-1" aria-hidden="true" tabindex="-1"></a><span class="co">/* note use of double quotes so that \n is legal */</span></span>
+<span id="cb112-2"><a href="#cb112-2" aria-hidden="true" tabindex="-1"></a><span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(x, <span class="dv">0</span>), ifnull(y,<span class="dv">0</span>));</span></code></pre></div>
 <p>Or any other use.</p>
 <p>More generally, there may or may not be a fetched value. The cursor variable <code>C</code> can be used by itself as a virtual boolean indicating the presence of a row. So a more complete example might be</p>
-<div class="sourceCode" id="cb113"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb113-1"><a href="#cb113-1"></a><span class="cf">if</span> C <span class="cf">then</span></span>
-<span id="cb113-2"><a href="#cb113-2"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(x, <span class="dv">0</span>), ifnull(y,<span class="dv">0</span>));</span>
-<span id="cb113-3"><a href="#cb113-3"></a><span class="cf">else</span></span>
-<span id="cb113-4"><a href="#cb113-4"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;nada\n&quot;</span>);</span>
-<span id="cb113-5"><a href="#cb113-5"></a><span class="cf">end</span> <span class="cf">if</span></span></code></pre></div>
+<div class="sourceCode" id="cb113"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb113-1"><a href="#cb113-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> C <span class="cf">then</span></span>
+<span id="cb113-2"><a href="#cb113-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(x, <span class="dv">0</span>), ifnull(y,<span class="dv">0</span>));</span>
+<span id="cb113-3"><a href="#cb113-3" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span></span>
+<span id="cb113-4"><a href="#cb113-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;nada\n&quot;</span>);</span>
+<span id="cb113-5"><a href="#cb113-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span></span></code></pre></div>
 <p>And even more generally</p>
-<div class="sourceCode" id="cb114"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb114-1"><a href="#cb114-1"></a><span class="cf">loop</span> fetch C <span class="kw">into</span> x, y</span>
-<span id="cb114-2"><a href="#cb114-2"></a><span class="cf">begin</span></span>
-<span id="cb114-3"><a href="#cb114-3"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(x, <span class="dv">0</span>), ifnull(y,<span class="dv">0</span>));</span>
-<span id="cb114-4"><a href="#cb114-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb114"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb114-1"><a href="#cb114-1" aria-hidden="true" tabindex="-1"></a><span class="cf">loop</span> fetch C <span class="kw">into</span> x, y</span>
+<span id="cb114-2"><a href="#cb114-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb114-3"><a href="#cb114-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(x, <span class="dv">0</span>), ifnull(y,<span class="dv">0</span>));</span>
+<span id="cb114-4"><a href="#cb114-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Here we read all the rows out and print them.</p>
 <p>Now if the table <code>xy_table</code> had instead had dozens of columns those declarations would be very verbose and error prone. And frankly annoying, especially if the table definition was changing over time.</p>
 <p>To make this a little easier, there are also so-called ‘automatic’ cursors. These happen implicitly and include all the necessary storage to exactly match the rows in their statement. Using the automatic syntax for the above we might get</p>
-<div class="sourceCode" id="cb115"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb115-1"><a href="#cb115-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> xy_table;</span>
-<span id="cb115-2"><a href="#cb115-2"></a>fetch C;</span>
-<span id="cb115-3"><a href="#cb115-3"></a><span class="cf">if</span> (C) <span class="cf">then</span></span>
-<span id="cb115-4"><a href="#cb115-4"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(C.x, <span class="dv">0</span>), ifnull(C.y,<span class="dv">0</span>));</span>
-<span id="cb115-5"><a href="#cb115-5"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb115"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb115-1"><a href="#cb115-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> xy_table;</span>
+<span id="cb115-2"><a href="#cb115-2" aria-hidden="true" tabindex="-1"></a>fetch C;</span>
+<span id="cb115-3"><a href="#cb115-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> (C) <span class="cf">then</span></span>
+<span id="cb115-4"><a href="#cb115-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(C.x, <span class="dv">0</span>), ifnull(C.y,<span class="dv">0</span>));</span>
+<span id="cb115-5"><a href="#cb115-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>or the equivalent loop form:</p>
-<div class="sourceCode" id="cb116"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb116-1"><a href="#cb116-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> xy_table;</span>
-<span id="cb116-2"><a href="#cb116-2"></a><span class="cf">loop</span> fetch C</span>
-<span id="cb116-3"><a href="#cb116-3"></a><span class="cf">begin</span></span>
-<span id="cb116-4"><a href="#cb116-4"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(C.x, <span class="dv">0</span>), ifnull(C.y,<span class="dv">0</span>));</span>
-<span id="cb116-5"><a href="#cb116-5"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb116"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb116-1"><a href="#cb116-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> xy_table;</span>
+<span id="cb116-2"><a href="#cb116-2" aria-hidden="true" tabindex="-1"></a><span class="cf">loop</span> fetch C</span>
+<span id="cb116-3"><a href="#cb116-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb116-4"><a href="#cb116-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;x:%d y:%d\n&quot;</span>, ifnull(C.x, <span class="dv">0</span>), ifnull(C.y,<span class="dv">0</span>));</span>
+<span id="cb116-5"><a href="#cb116-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>All the necessary local state is automatically created hence “automatic” cursor. This pattern is generally preferred but the loose variables pattern is in some sense more general.</p>
 <p>In all the cases if the number or type of variables do not match the select statement, semantic errors are produced.</p>
 <h3 id="value-cursors">Value Cursors</h3>
@@ -1968,187 +2100,187 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 </ul>
 <p>Let’s first start by how you declare a value cursor. It is by analogy to one of the structure types above.</p>
 <p>So:</p>
-<div class="sourceCode" id="cb117"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb117-1"><a href="#cb117-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> xy_table;</span>
-<span id="cb117-2"><a href="#cb117-2"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="dv">1</span> a, <span class="st">&#39;x&#39;</span> b;</span>
-<span id="cb117-3"><a href="#cb117-3"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_view;</span>
-<span id="cb117-4"><a href="#cb117-4"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_other_cursor;</span>
-<span id="cb117-5"><a href="#cb117-5"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_previously_declared_stored_proc;</span></code></pre></div>
+<div class="sourceCode" id="cb117"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb117-1"><a href="#cb117-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> xy_table;</span>
+<span id="cb117-2"><a href="#cb117-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="dv">1</span> a, <span class="st">&#39;x&#39;</span> b;</span>
+<span id="cb117-3"><a href="#cb117-3" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_view;</span>
+<span id="cb117-4"><a href="#cb117-4" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_other_cursor;</span>
+<span id="cb117-5"><a href="#cb117-5" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_previously_declared_stored_proc;</span></code></pre></div>
 <p>Any of those forms define a valid set of columns. Note that the <code>select</code> example in no way causes the query provided to run. Instead, the select statement is analyzed and the column names and types are computed. The cursor get the same field names and types. Nothing happens at run time. The last example assumes that there is a stored procedure defined somewhere earlier in this translation unit and that procedure returns a result set. The cursor declaration makes a cursor that could receive the result of that procedure. We’ll cover that particular case in more detail below when we deal with the <code>OUT</code> statement.</p>
 <p>Now once we have declared the cursor we can load it with values using <code>fetch</code> in the value form.</p>
 <p>You can load up a cursor from values. The values must be type-compatible of course.</p>
-<div class="sourceCode" id="cb118"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb118-1"><a href="#cb118-1"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>,<span class="dv">2</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb118"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb118-1"><a href="#cb118-1" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>,<span class="dv">2</span>);</span></code></pre></div>
 <p>You can call a procedure that returns a single row:</p>
-<div class="sourceCode" id="cb119"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb119-1"><a href="#cb119-1"></a>fetch C <span class="kw">from</span> <span class="kw">call</span> my_previously_declared_stored_proc();</span></code></pre></div>
+<div class="sourceCode" id="cb119"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb119-1"><a href="#cb119-1" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> <span class="kw">call</span> my_previously_declared_stored_proc();</span></code></pre></div>
 <p>You can fetch a cursor from another cursor:</p>
-<div class="sourceCode" id="cb120"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb120-1"><a href="#cb120-1"></a>fetch C <span class="kw">from</span> D;</span></code></pre></div>
+<div class="sourceCode" id="cb120"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb120-1"><a href="#cb120-1" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> D;</span></code></pre></div>
 <p>In this case D must be an ‘automatic’ cursor but it could be coming from a statement. This lets you copy a row and save it for later. E.g. you could copy the current max-valued row into a value cursor and use it after the loop.</p>
-<div class="sourceCode" id="cb121"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb121-1"><a href="#cb121-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="kw">id</span>, <span class="fu">value</span>, <span class="op">&lt;</span>other_stuff<span class="op">&gt;</span> <span class="kw">from</span> <span class="op">&lt;</span>somewhere<span class="op">&gt;</span> <span class="kw">where</span> <span class="op">&lt;</span>conditions<span class="op">&gt;</span>;</span>
-<span id="cb121-2"><a href="#cb121-2"></a><span class="kw">declare</span> D <span class="kw">cursor</span> <span class="kw">like</span> C;</span>
-<span id="cb121-3"><a href="#cb121-3"></a></span>
-<span id="cb121-4"><a href="#cb121-4"></a>fetch D <span class="kw">from</span> <span class="kw">values</span> (<span class="op">-</span><span class="dv">1</span>, <span class="op">-</span><span class="dv">999</span>);</span>
-<span id="cb121-5"><a href="#cb121-5"></a></span>
-<span id="cb121-6"><a href="#cb121-6"></a><span class="cf">loop</span> fetch C</span>
-<span id="cb121-7"><a href="#cb121-7"></a><span class="cf">begin</span></span>
-<span id="cb121-8"><a href="#cb121-8"></a>  <span class="cf">if</span> (D.<span class="fu">max</span> <span class="op">&lt;</span> C.<span class="fu">max</span>) <span class="cf">then</span></span>
-<span id="cb121-9"><a href="#cb121-9"></a>    fetch D <span class="kw">from</span> C;</span>
-<span id="cb121-10"><a href="#cb121-10"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb121-11"><a href="#cb121-11"></a><span class="cf">end</span>;</span>
-<span id="cb121-12"><a href="#cb121-12"></a></span>
-<span id="cb121-13"><a href="#cb121-13"></a><span class="co">-- this could print &lt;other stuff&gt; too</span></span>
-<span id="cb121-14"><a href="#cb121-14"></a><span class="kw">call</span> printf(<span class="ot">&quot;id:%d value:%d&quot;</span>, D.<span class="kw">id</span>, D.<span class="fu">value</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb121"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb121-1"><a href="#cb121-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="kw">id</span>, <span class="fu">value</span>, <span class="op">&lt;</span>other_stuff<span class="op">&gt;</span> <span class="kw">from</span> <span class="op">&lt;</span>somewhere<span class="op">&gt;</span> <span class="kw">where</span> <span class="op">&lt;</span>conditions<span class="op">&gt;</span>;</span>
+<span id="cb121-2"><a href="#cb121-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> D <span class="kw">cursor</span> <span class="kw">like</span> C;</span>
+<span id="cb121-3"><a href="#cb121-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-4"><a href="#cb121-4" aria-hidden="true" tabindex="-1"></a>fetch D <span class="kw">from</span> <span class="kw">values</span> (<span class="op">-</span><span class="dv">1</span>, <span class="op">-</span><span class="dv">999</span>);</span>
+<span id="cb121-5"><a href="#cb121-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-6"><a href="#cb121-6" aria-hidden="true" tabindex="-1"></a><span class="cf">loop</span> fetch C</span>
+<span id="cb121-7"><a href="#cb121-7" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb121-8"><a href="#cb121-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (D.<span class="fu">max</span> <span class="op">&lt;</span> C.<span class="fu">max</span>) <span class="cf">then</span></span>
+<span id="cb121-9"><a href="#cb121-9" aria-hidden="true" tabindex="-1"></a>    fetch D <span class="kw">from</span> C;</span>
+<span id="cb121-10"><a href="#cb121-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb121-11"><a href="#cb121-11" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span>
+<span id="cb121-12"><a href="#cb121-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb121-13"><a href="#cb121-13" aria-hidden="true" tabindex="-1"></a><span class="co">-- this could print &lt;other stuff&gt; too</span></span>
+<span id="cb121-14"><a href="#cb121-14" aria-hidden="true" tabindex="-1"></a><span class="kw">call</span> printf(<span class="ot">&quot;id:%d value:%d&quot;</span>, D.<span class="kw">id</span>, D.<span class="fu">value</span>);</span></code></pre></div>
 <p>Value cursors are always ‘automatic’ – they have their own storage.</p>
 <p>Value cursors also may or may not be holding a row.</p>
-<div class="sourceCode" id="cb122"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb122-1"><a href="#cb122-1"></a><span class="kw">declare</span> C <span class="kw">like</span> xy_table;</span>
-<span id="cb122-2"><a href="#cb122-2"></a><span class="cf">if</span> <span class="kw">not</span> C <span class="cf">then</span></span>
-<span id="cb122-3"><a href="#cb122-3"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;this will always be true because it starts empty\n&quot;</span>);</span>
-<span id="cb122-4"><a href="#cb122-4"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb122"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb122-1"><a href="#cb122-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">like</span> xy_table;</span>
+<span id="cb122-2"><a href="#cb122-2" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> <span class="kw">not</span> C <span class="cf">then</span></span>
+<span id="cb122-3"><a href="#cb122-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;this will always be true because it starts empty\n&quot;</span>);</span>
+<span id="cb122-4"><a href="#cb122-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>When you call a procedure you may or may not get a row as we’ll see below.</p>
 <h3 id="out-statement">OUT Statement</h3>
 <p>Value cursors were initially designed to create a convenient way for a procedure to return a single row from a complex query without having a crazy number of <code>OUT</code> parameters. It’s easiest to illustrate this with an example.</p>
 <p>The older verbose pattern looks like this:</p>
-<div class="sourceCode" id="cb123"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb123-1"><a href="#cb123-1"></a><span class="kw">create</span> proc get_a_row(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb123-2"><a href="#cb123-2"></a>                      <span class="kw">out</span> got_row bool <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb123-3"><a href="#cb123-3"></a>                      <span class="kw">out</span> w <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb123-4"><a href="#cb123-4"></a>                      <span class="kw">out</span> x <span class="dt">integer</span>,</span>
-<span id="cb123-5"><a href="#cb123-5"></a>                      <span class="kw">out</span> y text <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb123-6"><a href="#cb123-6"></a>                      <span class="kw">out</span> z <span class="dt">real</span>)</span>
-<span id="cb123-7"><a href="#cb123-7"></a><span class="cf">begin</span></span>
-<span id="cb123-8"><a href="#cb123-8"></a>  <span class="kw">declare</span> C <span class="cf">for</span> <span class="kw">select</span> w, x, y, z <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb123-9"><a href="#cb123-9"></a>  fetch C <span class="kw">into</span> w, x, y, z;</span>
-<span id="cb123-10"><a href="#cb123-10"></a>  <span class="kw">set</span> got_row <span class="op">:=</span> C;</span>
-<span id="cb123-11"><a href="#cb123-11"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb123"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb123-1"><a href="#cb123-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc get_a_row(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb123-2"><a href="#cb123-2" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">out</span> got_row bool <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb123-3"><a href="#cb123-3" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">out</span> w <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb123-4"><a href="#cb123-4" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">out</span> x <span class="dt">integer</span>,</span>
+<span id="cb123-5"><a href="#cb123-5" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">out</span> y text <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb123-6"><a href="#cb123-6" aria-hidden="true" tabindex="-1"></a>                      <span class="kw">out</span> z <span class="dt">real</span>)</span>
+<span id="cb123-7"><a href="#cb123-7" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb123-8"><a href="#cb123-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="cf">for</span> <span class="kw">select</span> w, x, y, z <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb123-9"><a href="#cb123-9" aria-hidden="true" tabindex="-1"></a>  fetch C <span class="kw">into</span> w, x, y, z;</span>
+<span id="cb123-10"><a href="#cb123-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> got_row <span class="op">:=</span> C;</span>
+<span id="cb123-11"><a href="#cb123-11" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Now you can imagine this gets very annoying if <code>get_a_row</code> has to produce a couple dozen column values. And of course you have to get the types exactly right. And they might evolve over time. Joy.</p>
 <p>On the receiving side you get to do something just as annoying:</p>
-<div class="sourceCode" id="cb124"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb124-1"><a href="#cb124-1"></a><span class="kw">declare</span> w <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span></span>
-<span id="cb124-2"><a href="#cb124-2"></a><span class="kw">declare</span> x <span class="dt">integer</span>;</span>
-<span id="cb124-3"><a href="#cb124-3"></a><span class="kw">declare</span> y text;</span>
-<span id="cb124-4"><a href="#cb124-4"></a><span class="kw">declare</span> z <span class="dt">real</span>;</span>
-<span id="cb124-5"><a href="#cb124-5"></a><span class="kw">declare</span> got_row bool <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb124-6"><a href="#cb124-6"></a><span class="kw">call</span> get_a_row(<span class="kw">id</span>, got_row, w, x, y, z);</span></code></pre></div>
+<div class="sourceCode" id="cb124"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb124-1"><a href="#cb124-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> w <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span></span>
+<span id="cb124-2"><a href="#cb124-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> x <span class="dt">integer</span>;</span>
+<span id="cb124-3"><a href="#cb124-3" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> y text;</span>
+<span id="cb124-4"><a href="#cb124-4" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> z <span class="dt">real</span>;</span>
+<span id="cb124-5"><a href="#cb124-5" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> got_row bool <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb124-6"><a href="#cb124-6" aria-hidden="true" tabindex="-1"></a><span class="kw">call</span> get_a_row(<span class="kw">id</span>, got_row, w, x, y, z);</span></code></pre></div>
 <p>Using the <code>out</code> statement we get the equivalent functionality with a much simplified pattern. It looks like this:</p>
-<div class="sourceCode" id="cb125"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb125-1"><a href="#cb125-1"></a><span class="kw">create</span> proc get_a_row(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb125-2"><a href="#cb125-2"></a><span class="cf">begin</span></span>
-<span id="cb125-3"><a href="#cb125-3"></a>   <span class="kw">declare</span> C <span class="cf">for</span> <span class="kw">select</span> a, b, c, d <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb125-4"><a href="#cb125-4"></a>   fetch C;</span>
-<span id="cb125-5"><a href="#cb125-5"></a>   <span class="kw">out</span> C;</span>
-<span id="cb125-6"><a href="#cb125-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb125"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb125-1"><a href="#cb125-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc get_a_row(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb125-2"><a href="#cb125-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb125-3"><a href="#cb125-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">declare</span> C <span class="cf">for</span> <span class="kw">select</span> a, b, c, d <span class="kw">from</span> somewhere <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb125-4"><a href="#cb125-4" aria-hidden="true" tabindex="-1"></a>   fetch C;</span>
+<span id="cb125-5"><a href="#cb125-5" aria-hidden="true" tabindex="-1"></a>   <span class="kw">out</span> C;</span>
+<span id="cb125-6"><a href="#cb125-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>To use it you simply do this:</p>
-<div class="sourceCode" id="cb126"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb126-1"><a href="#cb126-1"></a><span class="kw">declare</span> C <span class="kw">like</span> get_a_row;</span>
-<span id="cb126-2"><a href="#cb126-2"></a>fetch C <span class="kw">from</span> <span class="kw">call</span> get_a_row(<span class="kw">id</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb126"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb126-1"><a href="#cb126-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">like</span> get_a_row;</span>
+<span id="cb126-2"><a href="#cb126-2" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> <span class="kw">call</span> get_a_row(<span class="kw">id</span>);</span></code></pre></div>
 <p>In fact originally the above was the only way to load a value cursor, before the calculus was generalized. The original form still works, and does both things in one step:</p>
-<div class="sourceCode" id="cb127"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb127-1"><a href="#cb127-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> fetch <span class="kw">from</span> <span class="kw">call</span> get_a_row(<span class="kw">id</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb127"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb127-1"><a href="#cb127-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> fetch <span class="kw">from</span> <span class="kw">call</span> get_a_row(<span class="kw">id</span>);</span></code></pre></div>
 <p>The <code>OUT</code> statement lets you return a single row economically and lets you then test if there actually was a row and read the columns. It infers all the various column names and types so it is resilient to schema change and generally a lot less error prone than having a large number of <code>out</code> arguments to your procedure.</p>
 <p>Once you have the result in a value cursor you can do the usual cursor operations to move it around or otherwise work with it.</p>
 <p>The use of the <code>LIKE</code> keyword to refer to the types of complex entities spread to other places in CQL as a very useful construct, but it began here with the need to describe a cursor shape economically, by reference.</p>
 <h3 id="out-union-statement">OUT UNION Statement</h3>
 <p>The semantics of the <code>out</code> statement are that it always produces one row of output (a procedure can produce no row if an <code>out</code> never actually ran but the procedure does use <code>out</code>). If an <code>out</code> statement runs more than once the most recent row becomes the result. So the <code>out</code> statement really does mirror having one <code>out</code> variable for each column. This was its intent and procedures that return at most, or exactly, one row are very common. However, in general, one row results do not suffice; you might want to produce a result set from various sources with maybe arbitary compution in there as well. For that you need to be able to emit multiple rows from a computed source. This is exactly what <code>out union</code> provides.</p>
 <p>Here’s a (somewhat contrived) example of the kind of thing you can do with this form:</p>
-<div class="sourceCode" id="cb128"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb128-1"><a href="#cb128-1"></a><span class="kw">create</span> proc foo(n <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb128-2"><a href="#cb128-2"></a><span class="cf">begin</span></span>
-<span id="cb128-3"><a href="#cb128-3"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="dv">1</span> <span class="fu">value</span>;</span>
-<span id="cb128-4"><a href="#cb128-4"></a>  <span class="kw">declare</span> i <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb128-5"><a href="#cb128-5"></a>  <span class="kw">set</span> i <span class="op">:=</span> <span class="dv">0</span>;</span>
-<span id="cb128-6"><a href="#cb128-6"></a>  <span class="cf">while</span> (i <span class="op">&lt;</span> n)</span>
-<span id="cb128-7"><a href="#cb128-7"></a>  <span class="cf">begin</span></span>
-<span id="cb128-8"><a href="#cb128-8"></a>     <span class="co">-- emit one row for every integer</span></span>
-<span id="cb128-9"><a href="#cb128-9"></a>     fetch C <span class="kw">from</span> <span class="kw">values</span>(i);</span>
-<span id="cb128-10"><a href="#cb128-10"></a>     <span class="kw">out</span> <span class="kw">union</span> C;</span>
-<span id="cb128-11"><a href="#cb128-11"></a>  <span class="cf">end</span>;</span>
-<span id="cb128-12"><a href="#cb128-12"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb128"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb128-1"><a href="#cb128-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(n <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb128-2"><a href="#cb128-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb128-3"><a href="#cb128-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="dv">1</span> <span class="fu">value</span>;</span>
+<span id="cb128-4"><a href="#cb128-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> i <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb128-5"><a href="#cb128-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> i <span class="op">:=</span> <span class="dv">0</span>;</span>
+<span id="cb128-6"><a href="#cb128-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> (i <span class="op">&lt;</span> n)</span>
+<span id="cb128-7"><a href="#cb128-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb128-8"><a href="#cb128-8" aria-hidden="true" tabindex="-1"></a>     <span class="co">-- emit one row for every integer</span></span>
+<span id="cb128-9"><a href="#cb128-9" aria-hidden="true" tabindex="-1"></a>     fetch C <span class="kw">from</span> <span class="kw">values</span>(i);</span>
+<span id="cb128-10"><a href="#cb128-10" aria-hidden="true" tabindex="-1"></a>     <span class="kw">out</span> <span class="kw">union</span> C;</span>
+<span id="cb128-11"><a href="#cb128-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb128-12"><a href="#cb128-12" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>In <code>foo</code> above, we make an entire result set out of thin air. It isn’t very interesting but of course any computation would have been possible.</p>
 <p>This pattern is very flexibe as we see below in <code>bar</code> where we’re going to merge two different data streams.</p>
-<div class="sourceCode" id="cb129"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb129-1"><a href="#cb129-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(<span class="kw">id</span> <span class="dt">integer</span>, stuff text, [other things too]);</span>
-<span id="cb129-2"><a href="#cb129-2"></a><span class="kw">create</span> <span class="kw">table</span> t2(<span class="kw">id</span> <span class="dt">integer</span>, stuff text, [other things too]);</span>
-<span id="cb129-3"><a href="#cb129-3"></a></span>
-<span id="cb129-4"><a href="#cb129-4"></a><span class="kw">create</span> proc bar()</span>
-<span id="cb129-5"><a href="#cb129-5"></a><span class="cf">begin</span></span>
-<span id="cb129-6"><a href="#cb129-6"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> t1 <span class="kw">order</span> <span class="kw">by</span> <span class="kw">id</span>;</span>
-<span id="cb129-7"><a href="#cb129-7"></a>  <span class="kw">declare</span> D <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> t2 <span class="kw">order</span> <span class="kw">by</span> <span class="kw">id</span>;</span>
-<span id="cb129-8"><a href="#cb129-8"></a></span>
-<span id="cb129-9"><a href="#cb129-9"></a>  fetch C;</span>
-<span id="cb129-10"><a href="#cb129-10"></a>  fetch D;</span>
-<span id="cb129-11"><a href="#cb129-11"></a></span>
-<span id="cb129-12"><a href="#cb129-12"></a>  <span class="co">-- we&#39;re going to merge these two queries</span></span>
-<span id="cb129-13"><a href="#cb129-13"></a>  <span class="cf">while</span> (C <span class="kw">or</span> D)</span>
-<span id="cb129-14"><a href="#cb129-14"></a>  <span class="cf">begin</span></span>
-<span id="cb129-15"><a href="#cb129-15"></a>    <span class="co">-- if both have a row pick the smaller id</span></span>
-<span id="cb129-16"><a href="#cb129-16"></a>    <span class="cf">if</span> (C <span class="kw">and</span> D) <span class="cf">then</span></span>
-<span id="cb129-17"><a href="#cb129-17"></a>       <span class="cf">if</span> (C.<span class="kw">id</span> <span class="op">&lt;</span> D.<span class="kw">id</span>) <span class="cf">then</span></span>
-<span id="cb129-18"><a href="#cb129-18"></a>         <span class="kw">out</span> <span class="kw">union</span> C;</span>
-<span id="cb129-19"><a href="#cb129-19"></a>         fetch C;</span>
-<span id="cb129-20"><a href="#cb129-20"></a>       <span class="cf">else</span></span>
-<span id="cb129-21"><a href="#cb129-21"></a>         <span class="kw">out</span> <span class="kw">union</span> D;</span>
-<span id="cb129-22"><a href="#cb129-22"></a>         fetch D;</span>
-<span id="cb129-23"><a href="#cb129-23"></a>       <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb129-24"><a href="#cb129-24"></a>    <span class="cf">else</span> <span class="cf">if</span> C <span class="cf">then</span></span>
-<span id="cb129-25"><a href="#cb129-25"></a>      <span class="co">-- only C has a row, emit that</span></span>
-<span id="cb129-26"><a href="#cb129-26"></a>      <span class="kw">out</span> <span class="kw">union</span> C;</span>
-<span id="cb129-27"><a href="#cb129-27"></a>      fetch C;</span>
-<span id="cb129-28"><a href="#cb129-28"></a>    <span class="cf">else</span></span>
-<span id="cb129-29"><a href="#cb129-29"></a>      <span class="co">-- only D has a row, emit that</span></span>
-<span id="cb129-30"><a href="#cb129-30"></a>      <span class="kw">out</span> <span class="kw">union</span> D;</span>
-<span id="cb129-31"><a href="#cb129-31"></a>      fetch D;</span>
-<span id="cb129-32"><a href="#cb129-32"></a>    <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb129-33"><a href="#cb129-33"></a>  <span class="cf">end</span>;</span>
-<span id="cb129-34"><a href="#cb129-34"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb129"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb129-1"><a href="#cb129-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(<span class="kw">id</span> <span class="dt">integer</span>, stuff text, [other things too]);</span>
+<span id="cb129-2"><a href="#cb129-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t2(<span class="kw">id</span> <span class="dt">integer</span>, stuff text, [other things too]);</span>
+<span id="cb129-3"><a href="#cb129-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-4"><a href="#cb129-4" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc bar()</span>
+<span id="cb129-5"><a href="#cb129-5" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb129-6"><a href="#cb129-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> t1 <span class="kw">order</span> <span class="kw">by</span> <span class="kw">id</span>;</span>
+<span id="cb129-7"><a href="#cb129-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> D <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> t2 <span class="kw">order</span> <span class="kw">by</span> <span class="kw">id</span>;</span>
+<span id="cb129-8"><a href="#cb129-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-9"><a href="#cb129-9" aria-hidden="true" tabindex="-1"></a>  fetch C;</span>
+<span id="cb129-10"><a href="#cb129-10" aria-hidden="true" tabindex="-1"></a>  fetch D;</span>
+<span id="cb129-11"><a href="#cb129-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb129-12"><a href="#cb129-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- we&#39;re going to merge these two queries</span></span>
+<span id="cb129-13"><a href="#cb129-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> (C <span class="kw">or</span> D)</span>
+<span id="cb129-14"><a href="#cb129-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb129-15"><a href="#cb129-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- if both have a row pick the smaller id</span></span>
+<span id="cb129-16"><a href="#cb129-16" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (C <span class="kw">and</span> D) <span class="cf">then</span></span>
+<span id="cb129-17"><a href="#cb129-17" aria-hidden="true" tabindex="-1"></a>       <span class="cf">if</span> (C.<span class="kw">id</span> <span class="op">&lt;</span> D.<span class="kw">id</span>) <span class="cf">then</span></span>
+<span id="cb129-18"><a href="#cb129-18" aria-hidden="true" tabindex="-1"></a>         <span class="kw">out</span> <span class="kw">union</span> C;</span>
+<span id="cb129-19"><a href="#cb129-19" aria-hidden="true" tabindex="-1"></a>         fetch C;</span>
+<span id="cb129-20"><a href="#cb129-20" aria-hidden="true" tabindex="-1"></a>       <span class="cf">else</span></span>
+<span id="cb129-21"><a href="#cb129-21" aria-hidden="true" tabindex="-1"></a>         <span class="kw">out</span> <span class="kw">union</span> D;</span>
+<span id="cb129-22"><a href="#cb129-22" aria-hidden="true" tabindex="-1"></a>         fetch D;</span>
+<span id="cb129-23"><a href="#cb129-23" aria-hidden="true" tabindex="-1"></a>       <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb129-24"><a href="#cb129-24" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span> <span class="cf">if</span> C <span class="cf">then</span></span>
+<span id="cb129-25"><a href="#cb129-25" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- only C has a row, emit that</span></span>
+<span id="cb129-26"><a href="#cb129-26" aria-hidden="true" tabindex="-1"></a>      <span class="kw">out</span> <span class="kw">union</span> C;</span>
+<span id="cb129-27"><a href="#cb129-27" aria-hidden="true" tabindex="-1"></a>      fetch C;</span>
+<span id="cb129-28"><a href="#cb129-28" aria-hidden="true" tabindex="-1"></a>    <span class="cf">else</span></span>
+<span id="cb129-29"><a href="#cb129-29" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- only D has a row, emit that</span></span>
+<span id="cb129-30"><a href="#cb129-30" aria-hidden="true" tabindex="-1"></a>      <span class="kw">out</span> <span class="kw">union</span> D;</span>
+<span id="cb129-31"><a href="#cb129-31" aria-hidden="true" tabindex="-1"></a>      fetch D;</span>
+<span id="cb129-32"><a href="#cb129-32" aria-hidden="true" tabindex="-1"></a>    <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb129-33"><a href="#cb129-33" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb129-34"><a href="#cb129-34" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Just like <code>foo</code>, in <code>bar</code>, each time <code>out union</code> runs a new row is accumulated. Now, if you build a procedure that ends with a <code>select</code> statement CQL automatically creates a fetcher function that does exactly the same thing – it loops over the SQLite statement for the select and fetches each row, materializing a result. With <code>out union</code> you take manual control of this process, allowing you to build arbitrary result sets. Note that either of <code>C</code> or <code>D</code> above could have been modified, replaced, skipped, normalized, etc. with any kind of computation. Even entirely synthetic rows can be computed and inserted into the output as we saw in <code>foo</code>.</p>
 <h3 id="result-set-cursors">Result Set Cursors</h3>
 <p>So <code>OUT UNION</code> makes it possible to create arbitrary result sets using a mix of sources and filtering. Unfortunately this result type is not a simple row, nor is it a SQLite statement and so while it can produce ordinary result sets for CQL callers, CQL could not itself consume that result type.</p>
 <p>To address this hole, and thereby make it a lot easier to test these result sets (which really is the most interesting use case for re-consuming a result set) we need an additional cursor type. The syntax is exactly the same as the statement cursor cases described above but, instead of holding a SQLite statement, the cursor holds a result set pointer and the current/max row numbers. Stepping through it simply increments the row number and fetches the next row out of the rowset instead of from SQLite.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb130"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb130-1"><a href="#cb130-1"></a><span class="co">-- reading the above</span></span>
-<span id="cb130-2"><a href="#cb130-2"></a><span class="kw">create</span> proc reader()</span>
-<span id="cb130-3"><a href="#cb130-3"></a><span class="cf">begin</span></span>
-<span id="cb130-4"><a href="#cb130-4"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">call</span> bar();</span>
-<span id="cb130-5"><a href="#cb130-5"></a>  <span class="cf">loop</span> fetch C</span>
-<span id="cb130-6"><a href="#cb130-6"></a>  <span class="cf">begin</span></span>
-<span id="cb130-7"><a href="#cb130-7"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%d %s\n&quot;</span>, C.<span class="kw">id</span>, C.stuff);  <span class="co">-- or whatever</span></span>
-<span id="cb130-8"><a href="#cb130-8"></a>  <span class="cf">end</span>;</span>
-<span id="cb130-9"><a href="#cb130-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb130"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb130-1"><a href="#cb130-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- reading the above</span></span>
+<span id="cb130-2"><a href="#cb130-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc reader()</span>
+<span id="cb130-3"><a href="#cb130-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb130-4"><a href="#cb130-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">call</span> bar();</span>
+<span id="cb130-5"><a href="#cb130-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">loop</span> fetch C</span>
+<span id="cb130-6"><a href="#cb130-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb130-7"><a href="#cb130-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;%d %s\n&quot;</span>, C.<span class="kw">id</span>, C.stuff);  <span class="co">-- or whatever</span></span>
+<span id="cb130-8"><a href="#cb130-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb130-9"><a href="#cb130-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>If <code>bar</code> had been created with a <code>select union</code> and <code>order by</code> to merge the results, the above would have worked with <code>C</code> being a standard statement cursor, iterating over the union. Since <code>foo</code> produces a result set, CQL transparently produces a suitable cursor implementation behind the scenes but otherwise the usage is the same.</p>
 <p>Note this is a lousy way to iterate over rows; you have to materialize the entire result set so that you can just step over it. Re-consuming like this is not recommended at all for production code but it is ideal for testing result sets that were made with <code>out union</code> which otherwise would require C/C++ to test. Testing CQL with CQL is generally a lot easier.</p>
 <h3 id="reshaping-data-cursor-like-forms">Reshaping Data, Cursor <code>LIKE</code> forms</h3>
 <p>There are lots of cases where you have big rows with many columns and there are various manipulations you need to do. Some of these choices are emitting extra, related, rows, some of them are altering some of the columns before emitting the rows into the result set for use by some client.</p>
 <p>What follows is a set of useful syntactic sugar constructs that simplify handling complex rows. The idea is that pretty much anywhere you can specify a list of columns you can instead use the <code>LIKE x</code> construct to get the columns as the appear in object <code>x</code> – which is usually a cursor. It’s a lot easier to illustrate with examples, even though these are, again, a bit contrived.</p>
 <p>First we need some table with lots of columns usually the column names are much bigger which makes it all the more important to not have to type them over and over.</p>
-<div class="sourceCode" id="cb131"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb131-1"><a href="#cb131-1"></a><span class="kw">create</span> <span class="kw">table</span> big (</span>
-<span id="cb131-2"><a href="#cb131-2"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span>,</span>
-<span id="cb131-3"><a href="#cb131-3"></a>  id2 <span class="dt">integer</span> <span class="kw">unique</span>,</span>
-<span id="cb131-4"><a href="#cb131-4"></a>  a <span class="dt">integer</span>,</span>
-<span id="cb131-5"><a href="#cb131-5"></a>  b <span class="dt">integer</span>,</span>
-<span id="cb131-6"><a href="#cb131-6"></a>  c <span class="dt">integer</span>,</span>
-<span id="cb131-7"><a href="#cb131-7"></a>  d <span class="dt">integer</span>,</span>
-<span id="cb131-8"><a href="#cb131-8"></a>  e <span class="dt">integer</span>,</span>
-<span id="cb131-9"><a href="#cb131-9"></a>  f <span class="dt">integer</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb131"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb131-1"><a href="#cb131-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> big (</span>
+<span id="cb131-2"><a href="#cb131-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span>,</span>
+<span id="cb131-3"><a href="#cb131-3" aria-hidden="true" tabindex="-1"></a>  id2 <span class="dt">integer</span> <span class="kw">unique</span>,</span>
+<span id="cb131-4"><a href="#cb131-4" aria-hidden="true" tabindex="-1"></a>  a <span class="dt">integer</span>,</span>
+<span id="cb131-5"><a href="#cb131-5" aria-hidden="true" tabindex="-1"></a>  b <span class="dt">integer</span>,</span>
+<span id="cb131-6"><a href="#cb131-6" aria-hidden="true" tabindex="-1"></a>  c <span class="dt">integer</span>,</span>
+<span id="cb131-7"><a href="#cb131-7" aria-hidden="true" tabindex="-1"></a>  d <span class="dt">integer</span>,</span>
+<span id="cb131-8"><a href="#cb131-8" aria-hidden="true" tabindex="-1"></a>  e <span class="dt">integer</span>,</span>
+<span id="cb131-9"><a href="#cb131-9" aria-hidden="true" tabindex="-1"></a>  f <span class="dt">integer</span>);</span></code></pre></div>
 <p>We’re going to emit two rows as the result of this proc. Easy enough…</p>
-<div class="sourceCode" id="cb132"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb132-1"><a href="#cb132-1"></a><span class="kw">create</span> proc foo(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb132-2"><a href="#cb132-2"></a><span class="cf">begin</span></span>
-<span id="cb132-3"><a href="#cb132-3"></a>  <span class="co">-- this is the shape of the result we want, it&#39;s some of the columns of &quot;big&quot;</span></span>
-<span id="cb132-4"><a href="#cb132-4"></a>  <span class="co">-- note this query doesn&#39;t run, we just use it&#39;s shape to create a cursor</span></span>
-<span id="cb132-5"><a href="#cb132-5"></a>  <span class="co">-- with those columns.</span></span>
-<span id="cb132-6"><a href="#cb132-6"></a>  <span class="kw">declare</span> result <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="kw">id</span>, b, c, d <span class="kw">from</span> big;</span>
-<span id="cb132-7"><a href="#cb132-7"></a></span>
-<span id="cb132-8"><a href="#cb132-8"></a>  <span class="co">-- fetch the main row, specified by id_</span></span>
-<span id="cb132-9"><a href="#cb132-9"></a>  <span class="kw">declare</span> main_row <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> big <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb132-10"><a href="#cb132-10"></a>  fetch main_row;</span>
-<span id="cb132-11"><a href="#cb132-11"></a></span>
-<span id="cb132-12"><a href="#cb132-12"></a>  <span class="co">-- now fetch the result columns out of the main row</span></span>
-<span id="cb132-13"><a href="#cb132-13"></a>  <span class="co">-- like result means &quot;the column names found in &#39;result&#39;&quot;</span></span>
-<span id="cb132-14"><a href="#cb132-14"></a>  fetch result <span class="kw">from</span> <span class="kw">cursor</span> main_row(<span class="kw">like</span> result);</span>
-<span id="cb132-15"><a href="#cb132-15"></a></span>
-<span id="cb132-16"><a href="#cb132-16"></a>  <span class="co">-- this is our first result row</span></span>
-<span id="cb132-17"><a href="#cb132-17"></a>  <span class="kw">out</span> <span class="kw">union</span> result;</span>
-<span id="cb132-18"><a href="#cb132-18"></a></span>
-<span id="cb132-19"><a href="#cb132-19"></a>  <span class="co">-- now we want the related row, but we only need 2 columns</span></span>
-<span id="cb132-20"><a href="#cb132-20"></a>  <span class="kw">declare</span> alt_row <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> b, c <span class="kw">from</span> big <span class="kw">where</span> big.id2 <span class="op">=</span> main_row.id2;</span>
-<span id="cb132-21"><a href="#cb132-21"></a>  fetch alt_row;</span>
-<span id="cb132-22"><a href="#cb132-22"></a></span>
-<span id="cb132-23"><a href="#cb132-23"></a>  <span class="co">-- update some of the fields of the result from the alt result</span></span>
-<span id="cb132-24"><a href="#cb132-24"></a>  <span class="kw">update</span> <span class="kw">cursor</span> result(<span class="kw">like</span> alt_row) <span class="kw">from</span> <span class="kw">cursor</span> alt_row;</span>
-<span id="cb132-25"><a href="#cb132-25"></a></span>
-<span id="cb132-26"><a href="#cb132-26"></a>  <span class="co">-- and emit that row</span></span>
-<span id="cb132-27"><a href="#cb132-27"></a>  <span class="kw">out</span> <span class="kw">union</span> result;</span>
-<span id="cb132-28"><a href="#cb132-28"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb132"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb132-1"><a href="#cb132-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb132-2"><a href="#cb132-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb132-3"><a href="#cb132-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- this is the shape of the result we want, it&#39;s some of the columns of &quot;big&quot;</span></span>
+<span id="cb132-4"><a href="#cb132-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- note this query doesn&#39;t run, we just use it&#39;s shape to create a cursor</span></span>
+<span id="cb132-5"><a href="#cb132-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- with those columns.</span></span>
+<span id="cb132-6"><a href="#cb132-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> result <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="kw">id</span>, b, c, d <span class="kw">from</span> big;</span>
+<span id="cb132-7"><a href="#cb132-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-8"><a href="#cb132-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- fetch the main row, specified by id_</span></span>
+<span id="cb132-9"><a href="#cb132-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> main_row <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> big <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb132-10"><a href="#cb132-10" aria-hidden="true" tabindex="-1"></a>  fetch main_row;</span>
+<span id="cb132-11"><a href="#cb132-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-12"><a href="#cb132-12" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- now fetch the result columns out of the main row</span></span>
+<span id="cb132-13"><a href="#cb132-13" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- like result means &quot;the column names found in &#39;result&#39;&quot;</span></span>
+<span id="cb132-14"><a href="#cb132-14" aria-hidden="true" tabindex="-1"></a>  fetch result <span class="kw">from</span> <span class="kw">cursor</span> main_row(<span class="kw">like</span> result);</span>
+<span id="cb132-15"><a href="#cb132-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-16"><a href="#cb132-16" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- this is our first result row</span></span>
+<span id="cb132-17"><a href="#cb132-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">out</span> <span class="kw">union</span> result;</span>
+<span id="cb132-18"><a href="#cb132-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-19"><a href="#cb132-19" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- now we want the related row, but we only need 2 columns</span></span>
+<span id="cb132-20"><a href="#cb132-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> alt_row <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> b, c <span class="kw">from</span> big <span class="kw">where</span> big.id2 <span class="op">=</span> main_row.id2;</span>
+<span id="cb132-21"><a href="#cb132-21" aria-hidden="true" tabindex="-1"></a>  fetch alt_row;</span>
+<span id="cb132-22"><a href="#cb132-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-23"><a href="#cb132-23" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- update some of the fields of the result from the alt result</span></span>
+<span id="cb132-24"><a href="#cb132-24" aria-hidden="true" tabindex="-1"></a>  <span class="kw">update</span> <span class="kw">cursor</span> result(<span class="kw">like</span> alt_row) <span class="kw">from</span> <span class="kw">cursor</span> alt_row;</span>
+<span id="cb132-25"><a href="#cb132-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb132-26"><a href="#cb132-26" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- and emit that row</span></span>
+<span id="cb132-27"><a href="#cb132-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">out</span> <span class="kw">union</span> result;</span>
+<span id="cb132-28"><a href="#cb132-28" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Now let’s briefly discuss what is above. The two essential parts are:</p>
 <p><code>fetch result from cursor main_row(like result);</code></p>
 <p>and</p>
@@ -2156,25 +2288,25 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 <p>In the first case what we’re saying is that we want to load the columns of <code>result</code> from <code>main_row</code> but we only want to take the columns that are actually present in <code>result</code>. So this is a narrowing of a wide row into a smaller row. In this case the smaller row, <code>result</code> is what we want to emit. We needed the other columns to compute <code>alt_row</code>.</p>
 <p>The second case, what we’re saying is that we want update <code>result</code> by replacing the columns found in <code>alt_row</code> with the values in <code>alt_row</code>. So in this case we’re writing a smaller cursor into part of a wider cursor. Note that we used the <code>update</code> form here becuase it preserves all other columns. If we used <code>fetch</code> we would be rewriting the entire row contents, using <code>NULL</code> if necessary, not desired here.</p>
 <p>Here is the rewritten version of the above procedure; this is what ultimately gets compiled into C.</p>
-<div class="sourceCode" id="cb133"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb133-1"><a href="#cb133-1"></a><span class="kw">CREATE</span> PROC foo (id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb133-2"><a href="#cb133-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb133-3"><a href="#cb133-3"></a>  <span class="kw">DECLARE</span> result <span class="kw">CURSOR</span> <span class="kw">LIKE</span> <span class="kw">SELECT</span> <span class="kw">id</span>, b, c, d <span class="kw">FROM</span> big;</span>
-<span id="cb133-4"><a href="#cb133-4"></a>  <span class="kw">DECLARE</span> main_row <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> big <span class="kw">WHERE</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb133-5"><a href="#cb133-5"></a>  FETCH main_row;</span>
-<span id="cb133-6"><a href="#cb133-6"></a></span>
-<span id="cb133-7"><a href="#cb133-7"></a>  FETCH result(<span class="kw">id</span>, b, c, d)</span>
-<span id="cb133-8"><a href="#cb133-8"></a>    <span class="kw">FROM</span> <span class="kw">VALUES</span>(main_row.<span class="kw">id</span>, main_row.b, main_row.c, main_row.d);</span>
-<span id="cb133-9"><a href="#cb133-9"></a>  <span class="kw">OUT</span> <span class="kw">UNION</span> result;</span>
-<span id="cb133-10"><a href="#cb133-10"></a></span>
-<span id="cb133-11"><a href="#cb133-11"></a>  <span class="kw">DECLARE</span> alt_row <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> b, c <span class="kw">FROM</span> big <span class="kw">WHERE</span> big.id2 <span class="op">=</span> main_row.id2;</span>
-<span id="cb133-12"><a href="#cb133-12"></a>  FETCH alt_row;</span>
-<span id="cb133-13"><a href="#cb133-13"></a></span>
-<span id="cb133-14"><a href="#cb133-14"></a>  <span class="kw">UPDATE</span> <span class="kw">CURSOR</span> result(b, c) <span class="kw">FROM</span> <span class="kw">VALUES</span>(alt_row.b, alt_row.c);</span>
-<span id="cb133-15"><a href="#cb133-15"></a>  <span class="kw">OUT</span> <span class="kw">UNION</span> result;</span>
-<span id="cb133-16"><a href="#cb133-16"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb133"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb133-1"><a href="#cb133-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC foo (id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb133-2"><a href="#cb133-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb133-3"><a href="#cb133-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> result <span class="kw">CURSOR</span> <span class="kw">LIKE</span> <span class="kw">SELECT</span> <span class="kw">id</span>, b, c, d <span class="kw">FROM</span> big;</span>
+<span id="cb133-4"><a href="#cb133-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> main_row <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> big <span class="kw">WHERE</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb133-5"><a href="#cb133-5" aria-hidden="true" tabindex="-1"></a>  FETCH main_row;</span>
+<span id="cb133-6"><a href="#cb133-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb133-7"><a href="#cb133-7" aria-hidden="true" tabindex="-1"></a>  FETCH result(<span class="kw">id</span>, b, c, d)</span>
+<span id="cb133-8"><a href="#cb133-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> <span class="kw">VALUES</span>(main_row.<span class="kw">id</span>, main_row.b, main_row.c, main_row.d);</span>
+<span id="cb133-9"><a href="#cb133-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> <span class="kw">UNION</span> result;</span>
+<span id="cb133-10"><a href="#cb133-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb133-11"><a href="#cb133-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> alt_row <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> b, c <span class="kw">FROM</span> big <span class="kw">WHERE</span> big.id2 <span class="op">=</span> main_row.id2;</span>
+<span id="cb133-12"><a href="#cb133-12" aria-hidden="true" tabindex="-1"></a>  FETCH alt_row;</span>
+<span id="cb133-13"><a href="#cb133-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb133-14"><a href="#cb133-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UPDATE</span> <span class="kw">CURSOR</span> result(b, c) <span class="kw">FROM</span> <span class="kw">VALUES</span>(alt_row.b, alt_row.c);</span>
+<span id="cb133-15"><a href="#cb133-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> <span class="kw">UNION</span> result;</span>
+<span id="cb133-16"><a href="#cb133-16" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Of course you could have typed all that before but when there’s 50 odd columns it gets old fast and it’s very error prone. The sugar form is going to be 100% correct and much less typing.</p>
 <p>Finally, while I’ve shown both <code>LIKE</code> forms seperately they can also be used together. For instance</p>
-<div class="sourceCode" id="cb134"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb134-1"><a href="#cb134-1"></a>    <span class="kw">update</span> <span class="kw">cursor</span> C(<span class="kw">like</span> X) <span class="kw">from</span> <span class="kw">cursor</span> D(<span class="kw">like</span> X);</span></code></pre></div>
+<div class="sourceCode" id="cb134"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb134-1"><a href="#cb134-1" aria-hidden="true" tabindex="-1"></a>    <span class="kw">update</span> <span class="kw">cursor</span> C(<span class="kw">like</span> X) <span class="kw">from</span> <span class="kw">cursor</span> D(<span class="kw">like</span> X);</span></code></pre></div>
 <p>The above would mean, “move the columns that are found in <code>X</code> from cursor <code>D</code> to cursor <code>C</code>”, presumably <code>X</code> has columns common to both.</p>
 <h3 id="fetch-statement-specifics">Fetch Statement Specifics</h3>
 <p>Many of the examples used the <code>FETCH</code> statement in a sort of demonstrative way that is hopefully self-evident but the statement has many forms and so it’s wroth going over them specifically. Below we’ll use the letters <code>C</code> and <code>D</code> for the names of cursors. Usually <code>C</code>;</p>
@@ -2191,28 +2323,28 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 </ul>
 <p>In the first form <code>C</code> is said to be <em>automatic</em> in that it automatically declares the storage needed to hold all its columns. As mentioned above automatic cursors have storage for their row.</p>
 <p>Having done this fetch you can use C as a scalar variable to see if it holds a row, e.g.</p>
-<div class="sourceCode" id="cb135"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb135-1"><a href="#cb135-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo <span class="kw">limit</span> <span class="dv">1</span>;</span>
-<span id="cb135-2"><a href="#cb135-2"></a>fetch C;</span>
-<span id="cb135-3"><a href="#cb135-3"></a><span class="cf">if</span> C <span class="cf">then</span></span>
-<span id="cb135-4"><a href="#cb135-4"></a>  <span class="co">-- bingo we have a row</span></span>
-<span id="cb135-5"><a href="#cb135-5"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%s\n&quot;</span>, C.whatever);</span>
-<span id="cb135-6"><a href="#cb135-6"></a><span class="cf">end</span> <span class="cf">if</span></span></code></pre></div>
+<div class="sourceCode" id="cb135"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb135-1"><a href="#cb135-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo <span class="kw">limit</span> <span class="dv">1</span>;</span>
+<span id="cb135-2"><a href="#cb135-2" aria-hidden="true" tabindex="-1"></a>fetch C;</span>
+<span id="cb135-3"><a href="#cb135-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> C <span class="cf">then</span></span>
+<span id="cb135-4"><a href="#cb135-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- bingo we have a row</span></span>
+<span id="cb135-5"><a href="#cb135-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%s\n&quot;</span>, C.whatever);</span>
+<span id="cb135-6"><a href="#cb135-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span></span></code></pre></div>
 <p>You can easily iterate, e.g.</p>
-<div class="sourceCode" id="cb136"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb136-1"><a href="#cb136-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo;</span>
-<span id="cb136-2"><a href="#cb136-2"></a><span class="cf">loop</span> fetch C</span>
-<span id="cb136-3"><a href="#cb136-3"></a><span class="cf">begin</span></span>
-<span id="cb136-4"><a href="#cb136-4"></a>  <span class="co">-- one time for every row</span></span>
-<span id="cb136-5"><a href="#cb136-5"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%s\n&quot;</span>, C.whatever);</span>
-<span id="cb136-6"><a href="#cb136-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb136"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb136-1"><a href="#cb136-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo;</span>
+<span id="cb136-2"><a href="#cb136-2" aria-hidden="true" tabindex="-1"></a><span class="cf">loop</span> fetch C</span>
+<span id="cb136-3"><a href="#cb136-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb136-4"><a href="#cb136-4" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- one time for every row</span></span>
+<span id="cb136-5"><a href="#cb136-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%s\n&quot;</span>, C.whatever);</span>
+<span id="cb136-6"><a href="#cb136-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Automatic cursors are so much easier to use than explicit storage that explicit storage is rarely seen. Storing to <code>out</code> parameters is a case where explicit is ok, the <code>out</code> parameters have to be declared anyway.</p>
-<p>#### For Value Cursors</p>
+<h4 id="for-value-cursors">For Value Cursors</h4>
 <p>A cursor declared in one of these forms:</p>
 <ul>
 <li><code>declare C cursor fetch from call foo(args)</code>
 <ul>
 <li><code>foo</code> must be a procedure that returns one row with <code>OUT</code></li>
 </ul></li>
-<li>`declare C cursor like select 1 id, “x” name;</li>
+<li><code>declare C cursor like select 1 id, "x" name;</code></li>
 <li><code>declare C cursor like X;</code>
 <ul>
 <li>where X is the name of a table, a view, another cursor, or a procedure that returns a structured result</li>
@@ -2253,7 +2385,7 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 <li><code>fetch C(a,b) from cursor D(a,b)</code>
 <ul>
 <li>the named columns of D are used as the values</li>
-<li>in this case it becomes: `fetch C(a,b) from values(D.a, D.b);</li>
+<li>in this case it becomes: <code>fetch C(a,b) from values(D.a, D.b);</code></li>
 </ul></li>
 </ul>
 <p>That most recent form does seem like it saves much but recall the first rewrite:</p>
@@ -2291,7 +2423,7 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 </ul>
 <p>As is mentioned above, the <code>fetch</code> form means to load an entire row into the cursor. This is important because “half loaded” cursors would be semantically problematic. However there are many cases where you might like to amend the values of an already loaded cursor. You can do this with the <code>update</code> form.</p>
 <ul>
-<li>`update cursor C(a,b,..) from values(1,2,..);
+<li><code>update cursor C(a,b,..) from values(1,2,..);</code>
 <ul>
 <li>the update form is a no-op if the cursor is not already loaded with values (!!)</li>
 <li>the columns and values are type checked so a valid row is ensured (or no row)</li>
@@ -2301,49 +2433,49 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 <h3 id="calling-procedures-with-bulk-arguments">Calling Procedures with Bulk Arguments</h3>
 <p>It’s often desireable to treat bundles of arguments as a unit, or cursors as a unit, especially calling other procedures. The patterns above are very helpful for moving data between cursors, arguments, and the database. These can be rounded out with similar constructs for procedure calls as follows.</p>
 <p>First we’ll define some shapes to use in the examples. Note that we made <code>U</code> using <code>T</code>.</p>
-<div class="sourceCode" id="cb137"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb137-1"><a href="#cb137-1"></a><span class="kw">create</span> <span class="kw">table</span> T(x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, y <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,  z <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb137-2"><a href="#cb137-2"></a><span class="kw">create</span> <span class="kw">table</span> U(<span class="kw">like</span> T, a <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb137"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb137-1"><a href="#cb137-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> T(x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, y <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,  z <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb137-2"><a href="#cb137-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> U(<span class="kw">like</span> T, a <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
 <p>As we’ve seen, we can do this:</p>
-<div class="sourceCode" id="cb138"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb138-1"><a href="#cb138-1"></a><span class="kw">create</span> proc p1(<span class="kw">like</span> T)</span>
-<span id="cb138-2"><a href="#cb138-2"></a><span class="cf">begin</span></span>
-<span id="cb138-3"><a href="#cb138-3"></a>   <span class="kw">call</span> printf(<span class="ot">&quot;%d %d %d\n&quot;</span>, x_, y_, z_);</span>
-<span id="cb138-4"><a href="#cb138-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb138"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb138-1"><a href="#cb138-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc p1(<span class="kw">like</span> T)</span>
+<span id="cb138-2"><a href="#cb138-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb138-3"><a href="#cb138-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">call</span> printf(<span class="ot">&quot;%d %d %d\n&quot;</span>, x_, y_, z_);</span>
+<span id="cb138-4"><a href="#cb138-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>But the following is also possible. It isn’t an especially fabulous example but of course it generalizes. The arguments will be <code>x_</code>, <code>y_</code>, and <code>z_</code>.</p>
-<div class="sourceCode" id="cb139"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb139-1"><a href="#cb139-1"></a><span class="kw">create</span> proc p2(<span class="kw">like</span> T)</span>
-<span id="cb139-2"><a href="#cb139-2"></a><span class="cf">begin</span></span>
-<span id="cb139-3"><a href="#cb139-3"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%d %d %d\n&quot;</span>, <span class="kw">from</span> arguments);</span>
-<span id="cb139-4"><a href="#cb139-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb139"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb139-1"><a href="#cb139-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc p2(<span class="kw">like</span> T)</span>
+<span id="cb139-2"><a href="#cb139-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb139-3"><a href="#cb139-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> printf(<span class="ot">&quot;%d %d %d\n&quot;</span>, <span class="kw">from</span> arguments);</span>
+<span id="cb139-4"><a href="#cb139-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Now we might want to chain these things together. This next example uses a cursor to call <code>p1</code>.</p>
-<div class="sourceCode" id="cb140"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb140-1"><a href="#cb140-1"></a><span class="kw">create</span> proc q1()</span>
-<span id="cb140-2"><a href="#cb140-2"></a><span class="cf">begin</span></span>
-<span id="cb140-3"><a href="#cb140-3"></a> <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> T;</span>
-<span id="cb140-4"><a href="#cb140-4"></a> <span class="cf">loop</span> fetch C</span>
-<span id="cb140-5"><a href="#cb140-5"></a> <span class="cf">begin</span></span>
-<span id="cb140-6"><a href="#cb140-6"></a>   <span class="co">/* this is the same as call p(C.x, C.y, C.z) */</span></span>
-<span id="cb140-7"><a href="#cb140-7"></a>   <span class="kw">call</span> p1(<span class="kw">from</span> C);</span>
-<span id="cb140-8"><a href="#cb140-8"></a> <span class="cf">end</span>;</span>
-<span id="cb140-9"><a href="#cb140-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb140"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb140-1"><a href="#cb140-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc q1()</span>
+<span id="cb140-2"><a href="#cb140-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb140-3"><a href="#cb140-3" aria-hidden="true" tabindex="-1"></a> <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> T;</span>
+<span id="cb140-4"><a href="#cb140-4" aria-hidden="true" tabindex="-1"></a> <span class="cf">loop</span> fetch C</span>
+<span id="cb140-5"><a href="#cb140-5" aria-hidden="true" tabindex="-1"></a> <span class="cf">begin</span></span>
+<span id="cb140-6"><a href="#cb140-6" aria-hidden="true" tabindex="-1"></a>   <span class="co">/* this is the same as call p(C.x, C.y, C.z) */</span></span>
+<span id="cb140-7"><a href="#cb140-7" aria-hidden="true" tabindex="-1"></a>   <span class="kw">call</span> p1(<span class="kw">from</span> C);</span>
+<span id="cb140-8"><a href="#cb140-8" aria-hidden="true" tabindex="-1"></a> <span class="cf">end</span>;</span>
+<span id="cb140-9"><a href="#cb140-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The <code>like</code> construct allows you to select some of the arguments, or some of a cursor to use as arguments. This next procedure has more arguments than just <code>T</code>. The arguments will be <code>x_</code>, <code>y_</code>, <code>z_</code>, <code>a_</code>, <code>b_</code></p>
-<div class="sourceCode" id="cb141"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb141-1"><a href="#cb141-1"></a><span class="kw">create</span> proc q2(<span class="kw">like</span> U)</span>
-<span id="cb141-2"><a href="#cb141-2"></a><span class="cf">begin</span></span>
-<span id="cb141-3"><a href="#cb141-3"></a>  <span class="co">/* just the args that match T: so this is still call p(x_, y_, z_) */</span></span>
-<span id="cb141-4"><a href="#cb141-4"></a>  <span class="kw">call</span> p1(<span class="kw">from</span> arguments <span class="kw">like</span> T);</span>
-<span id="cb141-5"><a href="#cb141-5"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb141"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb141-1"><a href="#cb141-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc q2(<span class="kw">like</span> U)</span>
+<span id="cb141-2"><a href="#cb141-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb141-3"><a href="#cb141-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* just the args that match T: so this is still call p(x_, y_, z_) */</span></span>
+<span id="cb141-4"><a href="#cb141-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> p1(<span class="kw">from</span> arguments <span class="kw">like</span> T);</span>
+<span id="cb141-5"><a href="#cb141-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Or similarly. using a cursor.</p>
-<div class="sourceCode" id="cb142"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb142-1"><a href="#cb142-1"></a><span class="kw">create</span> proc q3(<span class="kw">like</span> U)</span>
-<span id="cb142-2"><a href="#cb142-2"></a><span class="cf">begin</span></span>
-<span id="cb142-3"><a href="#cb142-3"></a> <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> U;</span>
-<span id="cb142-4"><a href="#cb142-4"></a> <span class="cf">loop</span> fetch C</span>
-<span id="cb142-5"><a href="#cb142-5"></a> <span class="cf">begin</span></span>
-<span id="cb142-6"><a href="#cb142-6"></a>  <span class="co">/* just the columns that match T so this is still call p(C.x, C.y, C.z) */</span></span>
-<span id="cb142-7"><a href="#cb142-7"></a>  <span class="kw">call</span> p1(<span class="kw">from</span> C <span class="kw">like</span> T);</span>
-<span id="cb142-8"><a href="#cb142-8"></a> <span class="cf">end</span>;</span>
-<span id="cb142-9"><a href="#cb142-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb142"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb142-1"><a href="#cb142-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc q3(<span class="kw">like</span> U)</span>
+<span id="cb142-2"><a href="#cb142-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb142-3"><a href="#cb142-3" aria-hidden="true" tabindex="-1"></a> <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> U;</span>
+<span id="cb142-4"><a href="#cb142-4" aria-hidden="true" tabindex="-1"></a> <span class="cf">loop</span> fetch C</span>
+<span id="cb142-5"><a href="#cb142-5" aria-hidden="true" tabindex="-1"></a> <span class="cf">begin</span></span>
+<span id="cb142-6"><a href="#cb142-6" aria-hidden="true" tabindex="-1"></a>  <span class="co">/* just the columns that match T so this is still call p(C.x, C.y, C.z) */</span></span>
+<span id="cb142-7"><a href="#cb142-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> p1(<span class="kw">from</span> C <span class="kw">like</span> T);</span>
+<span id="cb142-8"><a href="#cb142-8" aria-hidden="true" tabindex="-1"></a> <span class="cf">end</span>;</span>
+<span id="cb142-9"><a href="#cb142-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Note that the <code>from</code> argument forms do not have to be all the arguments. For instance you can get columns from two cursors like so:</p>
-<div class="sourceCode" id="cb143"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb143-1"><a href="#cb143-1"></a>  <span class="kw">call</span> something(<span class="kw">from</span> C, <span class="kw">from</span> D)</span></code></pre></div>
+<div class="sourceCode" id="cb143"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb143-1"><a href="#cb143-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> something(<span class="kw">from</span> C, <span class="kw">from</span> D)</span></code></pre></div>
 <p>All the varieties can be combined but of course the procedure signature must match. And all these forms work in function expressions as well as procedure calls.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb144"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb144-1"><a href="#cb144-1"></a>  <span class="kw">set</span> x <span class="op">:=</span> a_function(<span class="kw">from</span> C);</span></code></pre></div>
+<div class="sourceCode" id="cb144"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb144-1"><a href="#cb144-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> x <span class="op">:=</span> a_function(<span class="kw">from</span> C);</span></code></pre></div>
 <p>Since these forms are simply syntatic sugar, they can also appear inside of functions in SQL statements. The variables mentioned will be expanded and become bound variables just like any other variable that appears in a SQL statement.</p>
 <p>Note the form x IN (from arguments) is not supported at this time, though this is a realitively easy addition.</p>
 <h3 id="missing-data-columns-nulls-and-dummy-data">Missing Data Columns, Nulls and Dummy Data</h3>
@@ -2357,14 +2489,14 @@ Any failures can be caught with <code>try/catch</code> as usual. This feature is
 </ul>
 <p>In addition to the automatic NULL you may add the annotation <code>@dummy_seed([long integer expression])</code>, if present * the expression is evaluated and stored in the hidden variable <em>seed</em> * all integers, and long integers get <em>seed</em> as their value (possibly truncated) * booleans get 1 if and only if <em>seed</em> is non-zero * strings get the name of the string column an underscore and the value as text (e.g. “myText_7” if <em>seed</em> is 7) * blobs are not currently supported for dummy data (CQL is missing blob conversions which are needed first)</p>
 <p>This construct is hugely powerful in a loop to create many complete rows with very little effort, even if the schema change over time.</p>
-<div class="sourceCode" id="cb145"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb145-1"><a href="#cb145-1"></a><span class="kw">declare</span> i <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb145-2"><a href="#cb145-2"></a><span class="kw">declare</span> C <span class="kw">like</span> my_table;</span>
-<span id="cb145-3"><a href="#cb145-3"></a><span class="kw">set</span> i <span class="op">:=</span> <span class="dv">0</span>;</span>
-<span id="cb145-4"><a href="#cb145-4"></a><span class="cf">while</span> (i <span class="op">&lt;</span> <span class="dv">20</span>)</span>
-<span id="cb145-5"><a href="#cb145-5"></a><span class="cf">begin</span></span>
-<span id="cb145-6"><a href="#cb145-6"></a>   fetch C(<span class="kw">id</span>) <span class="kw">from</span> <span class="kw">values</span>(i<span class="op">+</span><span class="dv">10000</span>) @dummy_seed(i);</span>
-<span id="cb145-7"><a href="#cb145-7"></a>   <span class="kw">insert</span> <span class="kw">into</span> my_table <span class="kw">from</span> <span class="kw">cursor</span> C;</span>
-<span id="cb145-8"><a href="#cb145-8"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb145"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb145-1"><a href="#cb145-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> i <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb145-2"><a href="#cb145-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">like</span> my_table;</span>
+<span id="cb145-3"><a href="#cb145-3" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> i <span class="op">:=</span> <span class="dv">0</span>;</span>
+<span id="cb145-4"><a href="#cb145-4" aria-hidden="true" tabindex="-1"></a><span class="cf">while</span> (i <span class="op">&lt;</span> <span class="dv">20</span>)</span>
+<span id="cb145-5"><a href="#cb145-5" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb145-6"><a href="#cb145-6" aria-hidden="true" tabindex="-1"></a>   fetch C(<span class="kw">id</span>) <span class="kw">from</span> <span class="kw">values</span>(i<span class="op">+</span><span class="dv">10000</span>) @dummy_seed(i);</span>
+<span id="cb145-7"><a href="#cb145-7" aria-hidden="true" tabindex="-1"></a>   <span class="kw">insert</span> <span class="kw">into</span> my_table <span class="kw">from</span> <span class="kw">cursor</span> C;</span>
+<span id="cb145-8"><a href="#cb145-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Now in this example we don’t need to know anything about <code>my_table</code> other than that it has a column named <code>id</code>. As the example shows several things. * we got the shape of the cursor from the table we were inserting into * you can do your own computation for some of the columns (those named) and leave the unnamed values to be defaulted * the rewrites mentioned above work for the <code>insert</code> statement as well as <code>fetch</code> * in fact <code>insert into my_table(id) values(i+10000) @dummy_seed(i)</code> would have worked too with no cursor at all * bonus, dummy blob data does work in insert statements because SQLite can do the string conversion easily * the dummy value for a blob is a blob that holds the text of the column name and the text of the seed just like a string column</p>
 <p>The <code>@dummy_seed</code> form can be modified with <code>@dummy_nullables</code>, this indicates that rather than using NULL for any nullable value that is missing, CQL should use the seed value. This overrides the default behavior of using NULL where columns are needed. Note the NULL filling works a little differently on insert statements. Since SQLite will provide a NULL if one is legal the column doesn’t have to be added to the list with a NULL value during rewriting, it can simply be omitted, making the statement smaller.</p>
 <p>Finally for <code>insert</code> statement only, SQLite will normally use the default value of a column if it has one, so there is no need to add missing columsn with default values to the insert statement. However if you specify <code>@dummy_defaults</code> then columns with a default value will instead be rewritten and they will get <code>_seed_</code> as their value.</p>
@@ -2385,51 +2517,51 @@ insert into my_table(a, b, c, m, n, x, y) values(7, 1000, 1000, 1000, 1000, 1000
 <h3 id="generalized-cursor-lifetimes-aka-cursor-boxing">Generalized Cursor Lifetimes aka Cursor “Boxing”</h3>
 <p>Generalized Cursor Lifetime refers to capturing a Statement Cursor in an object so that it can used more flexibly. Wrapping something in an object is often called “boxing”. Since Generalized Cursor Lifetime is a mouthful we’ll refer to it as “boxing” from here forward. The symmetric operation “unboxing” refers to converting the boxed object back into a cursor.</p>
 <p>The normal cursor usage pattern is by far the most common, a cursor is created directly with something like these forms:</p>
-<div class="sourceCode" id="cb149"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb149-1"><a href="#cb149-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> shape_source;</span>
-<span id="cb149-2"><a href="#cb149-2"></a></span>
-<span id="cb149-3"><a href="#cb149-3"></a><span class="kw">declare</span> D <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">call</span> proc_that_returns_a_shape();</span></code></pre></div>
+<div class="sourceCode" id="cb149"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb149-1"><a href="#cb149-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> shape_source;</span>
+<span id="cb149-2"><a href="#cb149-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb149-3"><a href="#cb149-3" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> D <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">call</span> proc_that_returns_a_shape();</span></code></pre></div>
 <p>At this point the cursor can be used normally as follows:</p>
-<div class="sourceCode" id="cb150"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb150-1"><a href="#cb150-1"></a><span class="cf">loop</span> fetch C</span>
-<span id="cb150-2"><a href="#cb150-2"></a><span class="cf">begin</span></span>
-<span id="cb150-3"><a href="#cb150-3"></a>  <span class="co">-- do stuff with C</span></span>
-<span id="cb150-4"><a href="#cb150-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb150"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb150-1"><a href="#cb150-1" aria-hidden="true" tabindex="-1"></a><span class="cf">loop</span> fetch C</span>
+<span id="cb150-2"><a href="#cb150-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb150-3"><a href="#cb150-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- do stuff with C</span></span>
+<span id="cb150-4"><a href="#cb150-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Those are the usual patterns and they allow statement cursors to be consumed sort of “up” the call chain from where the cursor was created. But what if you want some worker procedures that consume a cursor? There is no way to pass your cursor down again with these normal patterns alone.</p>
 <p>To generalize the patterns, allowing, for instance, a cursor to be returned as an out parameter or accepted as an in parameter you first need to declare an object variable that can hold the cursor and has a type indicating the shape of the cursor.</p>
 <p>To make an object that can hold a cursor:</p>
-<div class="sourceCode" id="cb151"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb151-1"><a href="#cb151-1"></a><span class="kw">declare</span> obj <span class="dt">object</span><span class="op">&lt;</span>T <span class="kw">cursor</span><span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb151"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb151-1"><a href="#cb151-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> obj <span class="dt">object</span><span class="op">&lt;</span>T <span class="kw">cursor</span><span class="op">&gt;</span>;</span></code></pre></div>
 <p>Where <code>T</code> is the name of a shape. It can be a table name, or a view name, or it can be the name of the canonical procedure that returns the result. T should be some kind of global name, something that could be accessed with <code>#include</code> in various places. Referring to the examples above, choices for <code>T</code> might be <code>shape_source</code> the table or <code>proc_that_returns_a_shape</code> the procedure.</p>
 <p>Note: it’s always possible make a fake procedure that returns a result to sort of “typedef” a shape name. e.g.</p>
-<div class="sourceCode" id="cb152"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb152-1"><a href="#cb152-1"></a><span class="kw">declare</span> proc my_shape() (<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, name text);</span></code></pre></div>
+<div class="sourceCode" id="cb152"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb152-1"><a href="#cb152-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> proc my_shape() (<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, name text);</span></code></pre></div>
 <p>The procedure here <code>my_shape</code> doesn’t have to actually ever be created, in fact it’s better if it isn’t. It won’t ever be called, its hypothetical result is just being as a shape. This can be useful if you have several procedures like <code>proc_that_returns_a_shape</code> that all return results with the columns of <code>my_shape</code>.</p>
 <p>To create the boxed cursor, first declare the object variable that will hold it and then set object from the cursor. Note that in the following example the cursor <code>C</code> must have the shape defined by <code>my_shape</code> or an error is produced. The type of the object is crucial because, as we’ll see, during unboxing, during unboxing that type defines the shape of the unboxed cursor.</p>
-<div class="sourceCode" id="cb153"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb153-1"><a href="#cb153-1"></a><span class="co">-- recap: declare the box that holds the cursor (T changed to my_shape for this example)</span></span>
-<span id="cb153-2"><a href="#cb153-2"></a><span class="kw">declare</span> box_obj <span class="dt">object</span><span class="op">&lt;</span>my_shape <span class="kw">cursor</span><span class="op">&gt;</span>;</span>
-<span id="cb153-3"><a href="#cb153-3"></a></span>
-<span id="cb153-4"><a href="#cb153-4"></a><span class="co">-- box the cursor into the object (the cursor shape must match the box shape)</span></span>
-<span id="cb153-5"><a href="#cb153-5"></a><span class="kw">set</span> box_obj <span class="kw">from</span> <span class="kw">cursor</span> C;</span></code></pre></div>
+<div class="sourceCode" id="cb153"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb153-1"><a href="#cb153-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- recap: declare the box that holds the cursor (T changed to my_shape for this example)</span></span>
+<span id="cb153-2"><a href="#cb153-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> box_obj <span class="dt">object</span><span class="op">&lt;</span>my_shape <span class="kw">cursor</span><span class="op">&gt;</span>;</span>
+<span id="cb153-3"><a href="#cb153-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb153-4"><a href="#cb153-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- box the cursor into the object (the cursor shape must match the box shape)</span></span>
+<span id="cb153-5"><a href="#cb153-5" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> box_obj <span class="kw">from</span> <span class="kw">cursor</span> C;</span></code></pre></div>
 <p>The variable <code>box_obj</code> can now be passed around as usual. It could be stored in a suitable <code>out</code> variable or it could be passed to a procedure as an <code>in</code> parameter. Then, later, you can “unbox” <code>box_obj</code> to get a cursor back. Like so</p>
-<div class="sourceCode" id="cb154"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb154-1"><a href="#cb154-1"></a><span class="co">-- unboxing a cursor from an object, the type of box_obj defines the type of the created cursor</span></span>
-<span id="cb154-2"><a href="#cb154-2"></a><span class="kw">declare</span> D <span class="kw">cursor</span> <span class="cf">for</span> box_obj;</span></code></pre></div>
+<div class="sourceCode" id="cb154"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb154-1"><a href="#cb154-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- unboxing a cursor from an object, the type of box_obj defines the type of the created cursor</span></span>
+<span id="cb154-2"><a href="#cb154-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> D <span class="kw">cursor</span> <span class="cf">for</span> box_obj;</span></code></pre></div>
 <p>These primitives will allow cursors to be passed around with general purpose lifetime.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb155"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb155-1"><a href="#cb155-1"></a><span class="co">-- consumes a cursor</span></span>
-<span id="cb155-2"><a href="#cb155-2"></a><span class="kw">create</span> proc cursor_user(box_obj <span class="dt">object</span><span class="op">&lt;</span>my_shape <span class="kw">cursor</span><span class="op">&gt;</span>)</span>
-<span id="cb155-3"><a href="#cb155-3"></a><span class="cf">begin</span></span>
-<span id="cb155-4"><a href="#cb155-4"></a>   <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> box_obj;  <span class="co">-- the cursors shape will be my_shape matching box</span></span>
-<span id="cb155-5"><a href="#cb155-5"></a>   <span class="cf">loop</span> fetch C</span>
-<span id="cb155-6"><a href="#cb155-6"></a>   <span class="cf">begin</span></span>
-<span id="cb155-7"><a href="#cb155-7"></a>      <span class="co">-- do something with C</span></span>
-<span id="cb155-8"><a href="#cb155-8"></a>   <span class="cf">end</span>;</span>
-<span id="cb155-9"><a href="#cb155-9"></a><span class="cf">end</span>;</span>
-<span id="cb155-10"><a href="#cb155-10"></a></span>
-<span id="cb155-11"><a href="#cb155-11"></a><span class="co">-- captures a cursor and passes it on</span></span>
-<span id="cb155-12"><a href="#cb155-12"></a><span class="kw">create</span> proc cursor_boxer()</span>
-<span id="cb155-13"><a href="#cb155-13"></a><span class="cf">begin</span></span>
-<span id="cb155-14"><a href="#cb155-14"></a>   <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> something_like_my_shape;</span>
-<span id="cb155-15"><a href="#cb155-15"></a>   <span class="kw">declare</span> box_obj <span class="dt">object</span><span class="op">&lt;</span>my_shape <span class="kw">cursor</span><span class="op">&gt;</span></span>
-<span id="cb155-16"><a href="#cb155-16"></a>   <span class="kw">set</span> box <span class="kw">from</span> <span class="kw">cursor</span> C; <span class="co">-- produces error if shape doesn&#39;t match</span></span>
-<span id="cb155-17"><a href="#cb155-17"></a>   <span class="kw">call</span> cursor_user(box_obj);</span>
-<span id="cb155-18"><a href="#cb155-18"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb155"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb155-1"><a href="#cb155-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- consumes a cursor</span></span>
+<span id="cb155-2"><a href="#cb155-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc cursor_user(box_obj <span class="dt">object</span><span class="op">&lt;</span>my_shape <span class="kw">cursor</span><span class="op">&gt;</span>)</span>
+<span id="cb155-3"><a href="#cb155-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb155-4"><a href="#cb155-4" aria-hidden="true" tabindex="-1"></a>   <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> box_obj;  <span class="co">-- the cursors shape will be my_shape matching box</span></span>
+<span id="cb155-5"><a href="#cb155-5" aria-hidden="true" tabindex="-1"></a>   <span class="cf">loop</span> fetch C</span>
+<span id="cb155-6"><a href="#cb155-6" aria-hidden="true" tabindex="-1"></a>   <span class="cf">begin</span></span>
+<span id="cb155-7"><a href="#cb155-7" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- do something with C</span></span>
+<span id="cb155-8"><a href="#cb155-8" aria-hidden="true" tabindex="-1"></a>   <span class="cf">end</span>;</span>
+<span id="cb155-9"><a href="#cb155-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span>
+<span id="cb155-10"><a href="#cb155-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb155-11"><a href="#cb155-11" aria-hidden="true" tabindex="-1"></a><span class="co">-- captures a cursor and passes it on</span></span>
+<span id="cb155-12"><a href="#cb155-12" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc cursor_boxer()</span>
+<span id="cb155-13"><a href="#cb155-13" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb155-14"><a href="#cb155-14" aria-hidden="true" tabindex="-1"></a>   <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> something_like_my_shape;</span>
+<span id="cb155-15"><a href="#cb155-15" aria-hidden="true" tabindex="-1"></a>   <span class="kw">declare</span> box_obj <span class="dt">object</span><span class="op">&lt;</span>my_shape <span class="kw">cursor</span><span class="op">&gt;</span></span>
+<span id="cb155-16"><a href="#cb155-16" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> box <span class="kw">from</span> <span class="kw">cursor</span> C; <span class="co">-- produces error if shape doesn&#39;t match</span></span>
+<span id="cb155-17"><a href="#cb155-17" aria-hidden="true" tabindex="-1"></a>   <span class="kw">call</span> cursor_user(box_obj);</span>
+<span id="cb155-18"><a href="#cb155-18" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Importantly, once you box a cursor the underlying SQLite statement’s lifetime is managed by the box object with normal retain/release semantics. The box and underlying statement can be released simply by setting all references to it to null as usual.</p>
 <p>With this pattern it’s possible to, for instance, create a cursor, box it, consume some of the rows in one procedure, do some other stuff, and then consume the rest of the rows in another different procedure.</p>
 <p>Important Notes:</p>
@@ -2457,36 +2589,36 @@ In this way it’s a lot more like say the C compiler than it is like say Java o
 <h3 id="declaring-procedures-defined-elsewhere">Declaring Procedures Defined Elsewhere</h3>
 <p>Stored procedures defined in another file can be declared to CQL in various ways for each major type of stored procedure. These are covered in the sections below.</p>
 <h3 id="simple-procedures-database-free">Simple Procedures (database free):</h3>
-<div class="sourceCode" id="cb156"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb156-1"><a href="#cb156-1"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> foo(<span class="kw">id</span> <span class="dt">integer</span>, <span class="kw">out</span> name text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb156"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb156-1"><a href="#cb156-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> foo(<span class="kw">id</span> <span class="dt">integer</span>, <span class="kw">out</span> name text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
 <p>This introduces the symbol name without providing the body.<br />
 This has important variations.</p>
 <h3 id="procedures-that-use-the-database">Procedures that use the database</h3>
-<div class="sourceCode" id="cb157"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb157-1"><a href="#cb157-1"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> foo(<span class="kw">id</span> <span class="dt">integer</span>, <span class="kw">out</span> name text <span class="kw">not</span> <span class="kw">null</span>) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb157"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb157-1"><a href="#cb157-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> foo(<span class="kw">id</span> <span class="dt">integer</span>, <span class="kw">out</span> name text <span class="kw">not</span> <span class="kw">null</span>) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
 <p>Most procedures you write will use SQLite in some fashion, maybe a <code>select</code> or something. The <code>USING TRANSACTION</code> annotation indicates that the proc in question uses the database and therefore the generated code will need a database connection in-argument and it will return a SQLite error code.</p>
 <h3 id="procedures-that-create-a-result-set">Procedures that create a result set</h3>
 <p>If the procedure in question is going to use <code>select</code> or <code>call</code> to create a result set, the type of that result set has to be declared. An example might look like this:</p>
-<div class="sourceCode" id="cb158"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb158-1"><a href="#cb158-1"></a><span class="kw">DECLARE</span> PROC with_result_set () (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb158-2"><a href="#cb158-2"></a>                                 name TEXT, </span>
-<span id="cb158-3"><a href="#cb158-3"></a>                                 rate <span class="dt">LONG</span> <span class="dt">INTEGER</span>, </span>
-<span id="cb158-4"><a href="#cb158-4"></a>                                 <span class="kw">type</span> <span class="dt">INTEGER</span>, </span>
-<span id="cb158-5"><a href="#cb158-5"></a>                                 <span class="kw">size</span> <span class="dt">REAL</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb158"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb158-1"><a href="#cb158-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC with_result_set () (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb158-2"><a href="#cb158-2" aria-hidden="true" tabindex="-1"></a>                                 name TEXT, </span>
+<span id="cb158-3"><a href="#cb158-3" aria-hidden="true" tabindex="-1"></a>                                 rate <span class="dt">LONG</span> <span class="dt">INTEGER</span>, </span>
+<span id="cb158-4"><a href="#cb158-4" aria-hidden="true" tabindex="-1"></a>                                 <span class="kw">type</span> <span class="dt">INTEGER</span>, </span>
+<span id="cb158-5"><a href="#cb158-5" aria-hidden="true" tabindex="-1"></a>                                 <span class="kw">size</span> <span class="dt">REAL</span>);</span></code></pre></div>
 <p>This says that the procedure takes no arguments (other than the implicit database connection) and it has an implicit out-argument that can be read to get a result set with the indicated columns: id, name, rate, type, and size.<br />
 This form implies <code>USING TRANSACTION</code>.</p>
 <h3 id="procedures-that-return-a-single-row-with-a-value-cursor">Procedures that return a single row with a value cursor</h3>
 <p>If the procedure emits a cursor with the <code>OUT</code> statement to produce a single row then it can be declared as follows:</p>
-<div class="sourceCode" id="cb159"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb159-1"><a href="#cb159-1"></a><span class="kw">DECLARE</span> PROC with_result_set () <span class="kw">OUT</span> (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb159-2"><a href="#cb159-2"></a>                                     name TEXT, </span>
-<span id="cb159-3"><a href="#cb159-3"></a>                                     rate <span class="dt">LONG</span> <span class="dt">INTEGER</span>, </span>
-<span id="cb159-4"><a href="#cb159-4"></a>                                     <span class="kw">type</span> <span class="dt">INTEGER</span>, </span>
-<span id="cb159-5"><a href="#cb159-5"></a>                                     <span class="kw">size</span> <span class="dt">REAL</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb159"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb159-1"><a href="#cb159-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC with_result_set () <span class="kw">OUT</span> (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb159-2"><a href="#cb159-2" aria-hidden="true" tabindex="-1"></a>                                     name TEXT, </span>
+<span id="cb159-3"><a href="#cb159-3" aria-hidden="true" tabindex="-1"></a>                                     rate <span class="dt">LONG</span> <span class="dt">INTEGER</span>, </span>
+<span id="cb159-4"><a href="#cb159-4" aria-hidden="true" tabindex="-1"></a>                                     <span class="kw">type</span> <span class="dt">INTEGER</span>, </span>
+<span id="cb159-5"><a href="#cb159-5" aria-hidden="true" tabindex="-1"></a>                                     <span class="kw">size</span> <span class="dt">REAL</span>);</span></code></pre></div>
 <p>This form can have <code>USING TRANSACTION</code> or not, since it is possible to emit a row with a value cursor and never use the database. See the previous chapter for details on the <code>OUT</code> statement.</p>
 <h3 id="procedures-that-return-a-full-result-set">Procedures that return a full result set</h3>
 <p>If the procedure emits many rows with the <code>OUT UNION</code> statement to produce a full result set then it can be declared as follows:</p>
-<div class="sourceCode" id="cb160"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb160-1"><a href="#cb160-1"></a><span class="kw">DECLARE</span> PROC with_result_set () <span class="kw">OUT</span> <span class="kw">UNION</span> (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb160-2"><a href="#cb160-2"></a>                                     name TEXT, </span>
-<span id="cb160-3"><a href="#cb160-3"></a>                                     rate <span class="dt">LONG</span> <span class="dt">INTEGER</span>, </span>
-<span id="cb160-4"><a href="#cb160-4"></a>                                     <span class="kw">type</span> <span class="dt">INTEGER</span>, </span>
-<span id="cb160-5"><a href="#cb160-5"></a>                                     <span class="kw">size</span> <span class="dt">REAL</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb160"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb160-1"><a href="#cb160-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC with_result_set () <span class="kw">OUT</span> <span class="kw">UNION</span> (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb160-2"><a href="#cb160-2" aria-hidden="true" tabindex="-1"></a>                                     name TEXT, </span>
+<span id="cb160-3"><a href="#cb160-3" aria-hidden="true" tabindex="-1"></a>                                     rate <span class="dt">LONG</span> <span class="dt">INTEGER</span>, </span>
+<span id="cb160-4"><a href="#cb160-4" aria-hidden="true" tabindex="-1"></a>                                     <span class="kw">type</span> <span class="dt">INTEGER</span>, </span>
+<span id="cb160-5"><a href="#cb160-5" aria-hidden="true" tabindex="-1"></a>                                     <span class="kw">size</span> <span class="dt">REAL</span>);</span></code></pre></div>
 <p>This form can have <code>USING TRANSACTION</code> or not, since it is possible to emit a rows with a value cursor and never use the database. See the previous chapter for details on the <code>OUT UNION</code> statement.</p>
 <h3 id="exporting-declared-symbols-automatically">Exporting Declared Symbols Automatically</h3>
 <p>To avoid errors, the declarations for any given file can be automatically created by adding something like <code>--generate_exports</code> to the command line. This will require an additonal file name to be passed in the <code>--cg</code> portion to capture the exports.</p>
@@ -2497,109 +2629,109 @@ This form implies <code>USING TRANSACTION</code>.</p>
 <pre><code>#include &quot;foo_imports.sql&quot;</code></pre>
 <h3 id="declaration-examples">Declaration Examples</h3>
 <p>Here are some more examples directly from the CQL test cases; these are all auto-generated with <code>--generate_exports</code>.</p>
-<div class="sourceCode" id="cb163"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb163-1"><a href="#cb163-1"></a><span class="kw">DECLARE</span> PROC test (i <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>);</span>
-<span id="cb163-2"><a href="#cb163-2"></a></span>
-<span id="cb163-3"><a href="#cb163-3"></a><span class="kw">DECLARE</span> PROC out_test (<span class="kw">OUT</span> i <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">OUT</span> ii <span class="dt">INTEGER</span>);</span>
-<span id="cb163-4"><a href="#cb163-4"></a></span>
-<span id="cb163-5"><a href="#cb163-5"></a><span class="kw">DECLARE</span> PROC outparm_test (<span class="kw">OUT</span> foo <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb163-6"><a href="#cb163-6"></a></span>
-<span id="cb163-7"><a href="#cb163-7"></a><span class="kw">DECLARE</span> PROC select_from_view () (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">type</span> <span class="dt">INTEGER</span>);</span>
-<span id="cb163-8"><a href="#cb163-8"></a></span>
-<span id="cb163-9"><a href="#cb163-9"></a><span class="kw">DECLARE</span> PROC make_view () <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb163-10"><a href="#cb163-10"></a></span>
-<span id="cb163-11"><a href="#cb163-11"></a><span class="kw">DECLARE</span> PROC copy_int (a <span class="dt">INTEGER</span>, <span class="kw">OUT</span> b <span class="dt">INTEGER</span>);</span>
-<span id="cb163-12"><a href="#cb163-12"></a></span>
-<span id="cb163-13"><a href="#cb163-13"></a><span class="kw">DECLARE</span> PROC complex_return () </span>
-<span id="cb163-14"><a href="#cb163-14"></a>  (_bool BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb163-15"><a href="#cb163-15"></a>   _integer <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb163-16"><a href="#cb163-16"></a>   _longint <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb163-17"><a href="#cb163-17"></a>   _real <span class="dt">REAL</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb163-18"><a href="#cb163-18"></a>   _text TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb163-19"><a href="#cb163-19"></a>   _nullable_bool BOOL);</span>
-<span id="cb163-20"><a href="#cb163-20"></a></span>
-<span id="cb163-21"><a href="#cb163-21"></a><span class="kw">DECLARE</span> PROC outint_nullable (</span>
-<span id="cb163-22"><a href="#cb163-22"></a>  <span class="kw">OUT</span> output <span class="dt">INTEGER</span>, </span>
-<span id="cb163-23"><a href="#cb163-23"></a>  <span class="kw">OUT</span> result BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb163-24"><a href="#cb163-24"></a><span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb163-25"><a href="#cb163-25"></a></span>
-<span id="cb163-26"><a href="#cb163-26"></a><span class="kw">DECLARE</span> PROC outint_notnull (</span>
-<span id="cb163-27"><a href="#cb163-27"></a>  <span class="kw">OUT</span> output <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb163-28"><a href="#cb163-28"></a>  <span class="kw">OUT</span> result BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb163-29"><a href="#cb163-29"></a><span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb163-30"><a href="#cb163-30"></a></span>
-<span id="cb163-31"><a href="#cb163-31"></a><span class="kw">DECLARE</span> PROC obj_proc (<span class="kw">OUT</span> an_object <span class="dt">OBJECT</span>);</span>
-<span id="cb163-32"><a href="#cb163-32"></a></span>
-<span id="cb163-33"><a href="#cb163-33"></a><span class="kw">DECLARE</span> PROC insert_values (</span>
-<span id="cb163-34"><a href="#cb163-34"></a>  id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb163-35"><a href="#cb163-35"></a>  type_ <span class="dt">INTEGER</span>)</span>
-<span id="cb163-36"><a href="#cb163-36"></a>  <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb163"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb163-1"><a href="#cb163-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC test (i <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>);</span>
+<span id="cb163-2"><a href="#cb163-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-3"><a href="#cb163-3" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC out_test (<span class="kw">OUT</span> i <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">OUT</span> ii <span class="dt">INTEGER</span>);</span>
+<span id="cb163-4"><a href="#cb163-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-5"><a href="#cb163-5" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC outparm_test (<span class="kw">OUT</span> foo <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb163-6"><a href="#cb163-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-7"><a href="#cb163-7" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC select_from_view () (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">type</span> <span class="dt">INTEGER</span>);</span>
+<span id="cb163-8"><a href="#cb163-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-9"><a href="#cb163-9" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC make_view () <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb163-10"><a href="#cb163-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-11"><a href="#cb163-11" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC copy_int (a <span class="dt">INTEGER</span>, <span class="kw">OUT</span> b <span class="dt">INTEGER</span>);</span>
+<span id="cb163-12"><a href="#cb163-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-13"><a href="#cb163-13" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC complex_return () </span>
+<span id="cb163-14"><a href="#cb163-14" aria-hidden="true" tabindex="-1"></a>  (_bool BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb163-15"><a href="#cb163-15" aria-hidden="true" tabindex="-1"></a>   _integer <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb163-16"><a href="#cb163-16" aria-hidden="true" tabindex="-1"></a>   _longint <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb163-17"><a href="#cb163-17" aria-hidden="true" tabindex="-1"></a>   _real <span class="dt">REAL</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb163-18"><a href="#cb163-18" aria-hidden="true" tabindex="-1"></a>   _text TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb163-19"><a href="#cb163-19" aria-hidden="true" tabindex="-1"></a>   _nullable_bool BOOL);</span>
+<span id="cb163-20"><a href="#cb163-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-21"><a href="#cb163-21" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC outint_nullable (</span>
+<span id="cb163-22"><a href="#cb163-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> output <span class="dt">INTEGER</span>, </span>
+<span id="cb163-23"><a href="#cb163-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> result BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb163-24"><a href="#cb163-24" aria-hidden="true" tabindex="-1"></a><span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb163-25"><a href="#cb163-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-26"><a href="#cb163-26" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC outint_notnull (</span>
+<span id="cb163-27"><a href="#cb163-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> output <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb163-28"><a href="#cb163-28" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> result BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb163-29"><a href="#cb163-29" aria-hidden="true" tabindex="-1"></a><span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb163-30"><a href="#cb163-30" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-31"><a href="#cb163-31" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC obj_proc (<span class="kw">OUT</span> an_object <span class="dt">OBJECT</span>);</span>
+<span id="cb163-32"><a href="#cb163-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb163-33"><a href="#cb163-33" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC insert_values (</span>
+<span id="cb163-34"><a href="#cb163-34" aria-hidden="true" tabindex="-1"></a>  id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb163-35"><a href="#cb163-35" aria-hidden="true" tabindex="-1"></a>  type_ <span class="dt">INTEGER</span>)</span>
+<span id="cb163-36"><a href="#cb163-36" aria-hidden="true" tabindex="-1"></a>  <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
 <p>So far we’ve avoided discussing the generated C code in any details but here it seems helpful to show exactly what these declarations correspond to in the generated C to demystify all this. There is a very straightforward conversion.</p>
-<div class="sourceCode" id="cb164"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb164-1"><a href="#cb164-1"></a><span class="dt">void</span> test(cql_int32 i);</span>
-<span id="cb164-2"><a href="#cb164-2"></a></span>
-<span id="cb164-3"><a href="#cb164-3"></a><span class="dt">void</span> out_test(</span>
-<span id="cb164-4"><a href="#cb164-4"></a>  cql_int32 *_Nonnull i, </span>
-<span id="cb164-5"><a href="#cb164-5"></a>  cql_nullable_int32 *_Nonnull ii);</span>
-<span id="cb164-6"><a href="#cb164-6"></a></span>
-<span id="cb164-7"><a href="#cb164-7"></a>cql_code outparm_test(</span>
-<span id="cb164-8"><a href="#cb164-8"></a>  sqlite3 *_Nonnull _db_, </span>
-<span id="cb164-9"><a href="#cb164-9"></a>  cql_int32 *_Nonnull foo);</span>
-<span id="cb164-10"><a href="#cb164-10"></a></span>
-<span id="cb164-11"><a href="#cb164-11"></a>cql_code select_from_view_fetch_results(</span>
-<span id="cb164-12"><a href="#cb164-12"></a>  sqlite3 *_Nonnull _db_, </span>
-<span id="cb164-13"><a href="#cb164-13"></a>  select_from_view_result_set_ref _Nullable *_Nonnull result_set);</span>
-<span id="cb164-14"><a href="#cb164-14"></a></span>
-<span id="cb164-15"><a href="#cb164-15"></a>cql_code make_view(sqlite3 *_Nonnull _db_);</span>
-<span id="cb164-16"><a href="#cb164-16"></a></span>
-<span id="cb164-17"><a href="#cb164-17"></a><span class="dt">void</span> copy_int(cql_nullable_int32 a, cql_nullable_int32 *_Nonnull b);</span>
-<span id="cb164-18"><a href="#cb164-18"></a></span>
-<span id="cb164-19"><a href="#cb164-19"></a>cql_code complex_return_fetch_results(</span>
-<span id="cb164-20"><a href="#cb164-20"></a>  sqlite3 *_Nonnull _db_, </span>
-<span id="cb164-21"><a href="#cb164-21"></a>  complex_return_result_set_ref _Nullable *_Nonnull result_set);</span>
-<span id="cb164-22"><a href="#cb164-22"></a></span>
-<span id="cb164-23"><a href="#cb164-23"></a>cql_code outint_nullable(</span>
-<span id="cb164-24"><a href="#cb164-24"></a>  sqlite3 *_Nonnull _db_, </span>
-<span id="cb164-25"><a href="#cb164-25"></a>  cql_nullable_int32 *_Nonnull output, </span>
-<span id="cb164-26"><a href="#cb164-26"></a>  cql_bool *_Nonnull result);</span>
-<span id="cb164-27"><a href="#cb164-27"></a></span>
-<span id="cb164-28"><a href="#cb164-28"></a>cql_code outint_notnull(</span>
-<span id="cb164-29"><a href="#cb164-29"></a>  sqlite3 *_Nonnull _db_, </span>
-<span id="cb164-30"><a href="#cb164-30"></a>  cql_int32 *_Nonnull output, </span>
-<span id="cb164-31"><a href="#cb164-31"></a>  cql_bool *_Nonnull result);</span>
-<span id="cb164-32"><a href="#cb164-32"></a></span>
-<span id="cb164-33"><a href="#cb164-33"></a><span class="dt">void</span> obj_proc(</span>
-<span id="cb164-34"><a href="#cb164-34"></a>  cql_object_ref _Nullable *_Nonnull an_object);</span>
-<span id="cb164-35"><a href="#cb164-35"></a></span>
-<span id="cb164-36"><a href="#cb164-36"></a>cql_code insert_values(</span>
-<span id="cb164-37"><a href="#cb164-37"></a>  sqlite3 *_Nonnull _db_, </span>
-<span id="cb164-38"><a href="#cb164-38"></a>  cql_int32 id_, </span>
-<span id="cb164-39"><a href="#cb164-39"></a>  cql_nullable_int32 type_);</span></code></pre></div>
+<div class="sourceCode" id="cb164"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb164-1"><a href="#cb164-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> test<span class="op">(</span>cql_int32 i<span class="op">);</span></span>
+<span id="cb164-2"><a href="#cb164-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-3"><a href="#cb164-3" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> out_test<span class="op">(</span></span>
+<span id="cb164-4"><a href="#cb164-4" aria-hidden="true" tabindex="-1"></a>  cql_int32 <span class="op">*</span>_Nonnull i<span class="op">,</span> </span>
+<span id="cb164-5"><a href="#cb164-5" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 <span class="op">*</span>_Nonnull ii<span class="op">);</span></span>
+<span id="cb164-6"><a href="#cb164-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-7"><a href="#cb164-7" aria-hidden="true" tabindex="-1"></a>cql_code outparm_test<span class="op">(</span></span>
+<span id="cb164-8"><a href="#cb164-8" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb164-9"><a href="#cb164-9" aria-hidden="true" tabindex="-1"></a>  cql_int32 <span class="op">*</span>_Nonnull foo<span class="op">);</span></span>
+<span id="cb164-10"><a href="#cb164-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-11"><a href="#cb164-11" aria-hidden="true" tabindex="-1"></a>cql_code select_from_view_fetch_results<span class="op">(</span></span>
+<span id="cb164-12"><a href="#cb164-12" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb164-13"><a href="#cb164-13" aria-hidden="true" tabindex="-1"></a>  select_from_view_result_set_ref _Nullable <span class="op">*</span>_Nonnull result_set<span class="op">);</span></span>
+<span id="cb164-14"><a href="#cb164-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-15"><a href="#cb164-15" aria-hidden="true" tabindex="-1"></a>cql_code make_view<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">);</span></span>
+<span id="cb164-16"><a href="#cb164-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-17"><a href="#cb164-17" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> copy_int<span class="op">(</span>cql_nullable_int32 a<span class="op">,</span> cql_nullable_int32 <span class="op">*</span>_Nonnull b<span class="op">);</span></span>
+<span id="cb164-18"><a href="#cb164-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-19"><a href="#cb164-19" aria-hidden="true" tabindex="-1"></a>cql_code complex_return_fetch_results<span class="op">(</span></span>
+<span id="cb164-20"><a href="#cb164-20" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb164-21"><a href="#cb164-21" aria-hidden="true" tabindex="-1"></a>  complex_return_result_set_ref _Nullable <span class="op">*</span>_Nonnull result_set<span class="op">);</span></span>
+<span id="cb164-22"><a href="#cb164-22" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-23"><a href="#cb164-23" aria-hidden="true" tabindex="-1"></a>cql_code outint_nullable<span class="op">(</span></span>
+<span id="cb164-24"><a href="#cb164-24" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb164-25"><a href="#cb164-25" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 <span class="op">*</span>_Nonnull output<span class="op">,</span> </span>
+<span id="cb164-26"><a href="#cb164-26" aria-hidden="true" tabindex="-1"></a>  cql_bool <span class="op">*</span>_Nonnull result<span class="op">);</span></span>
+<span id="cb164-27"><a href="#cb164-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-28"><a href="#cb164-28" aria-hidden="true" tabindex="-1"></a>cql_code outint_notnull<span class="op">(</span></span>
+<span id="cb164-29"><a href="#cb164-29" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb164-30"><a href="#cb164-30" aria-hidden="true" tabindex="-1"></a>  cql_int32 <span class="op">*</span>_Nonnull output<span class="op">,</span> </span>
+<span id="cb164-31"><a href="#cb164-31" aria-hidden="true" tabindex="-1"></a>  cql_bool <span class="op">*</span>_Nonnull result<span class="op">);</span></span>
+<span id="cb164-32"><a href="#cb164-32" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-33"><a href="#cb164-33" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> obj_proc<span class="op">(</span></span>
+<span id="cb164-34"><a href="#cb164-34" aria-hidden="true" tabindex="-1"></a>  cql_object_ref _Nullable <span class="op">*</span>_Nonnull an_object<span class="op">);</span></span>
+<span id="cb164-35"><a href="#cb164-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb164-36"><a href="#cb164-36" aria-hidden="true" tabindex="-1"></a>cql_code insert_values<span class="op">(</span></span>
+<span id="cb164-37"><a href="#cb164-37" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb164-38"><a href="#cb164-38" aria-hidden="true" tabindex="-1"></a>  cql_int32 id_<span class="op">,</span> </span>
+<span id="cb164-39"><a href="#cb164-39" aria-hidden="true" tabindex="-1"></a>  cql_nullable_int32 type_<span class="op">);</span></span></code></pre></div>
 <p>As you can see, these declarations use exactly the normal SQLite types and so it is very easy to declare a procedure in CQL and then implement it yourself in straight C, simply by conforming to the contract.</p>
 <p>Importantly, SQLite does not know anything about CQL stored procedures, or anything at all about CQL really so CQL stored procedure names cannot be used in any way in SQL statements. CQL control flow like the <code>call</code> statement can be used to invoke other procedures and results can be captured by combing the <code>OUT</code> statement and a <code>DECLARE CURSOR</code> construct but SQLite is not involved in those things. This is another place where the inherent two-headed nature of CQL leaks out.</p>
 <p>Finally, this is a good place to reinforce that procedures with any of the structured result types (<code>select</code>, <code>out</code>, <code>out union</code>) can be used with a suitable cursor.</p>
-<div class="sourceCode" id="cb165"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb165-1"><a href="#cb165-1"></a><span class="kw">create</span> <span class="kw">procedure</span> get_stuff()</span>
-<span id="cb165-2"><a href="#cb165-2"></a><span class="cf">begin</span></span>
-<span id="cb165-3"><a href="#cb165-3"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> stuff;</span>
-<span id="cb165-4"><a href="#cb165-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb165"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb165-1"><a href="#cb165-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> get_stuff()</span>
+<span id="cb165-2"><a href="#cb165-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb165-3"><a href="#cb165-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> stuff;</span>
+<span id="cb165-4"><a href="#cb165-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Can be used two interesting ways:</p>
-<div class="sourceCode" id="cb166"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb166-1"><a href="#cb166-1"></a><span class="kw">create</span> <span class="kw">procedure</span> meta_stuff(meta bool)</span>
-<span id="cb166-2"><a href="#cb166-2"></a><span class="cf">begin</span></span>
-<span id="cb166-3"><a href="#cb166-3"></a>  <span class="cf">if</span> meta <span class="cf">then</span></span>
-<span id="cb166-4"><a href="#cb166-4"></a>    <span class="kw">call</span> get_stuff();</span>
-<span id="cb166-5"><a href="#cb166-5"></a>  <span class="cf">else</span></span>
-<span id="cb166-6"><a href="#cb166-6"></a>    <span class="kw">call</span> get_other_stuff();</span>
-<span id="cb166-7"><a href="#cb166-7"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb166-8"><a href="#cb166-8"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb166"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb166-1"><a href="#cb166-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> meta_stuff(meta bool)</span>
+<span id="cb166-2"><a href="#cb166-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb166-3"><a href="#cb166-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> meta <span class="cf">then</span></span>
+<span id="cb166-4"><a href="#cb166-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> get_stuff();</span>
+<span id="cb166-5"><a href="#cb166-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span></span>
+<span id="cb166-6"><a href="#cb166-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> get_other_stuff();</span>
+<span id="cb166-7"><a href="#cb166-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb166-8"><a href="#cb166-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Assuming that <code>get_stuff</code> and <code>get_other_stuff</code> have the same shape, then this procedure simply passes on one or the other’s result set unmodified as its own return value.</p>
 <p>But you could do more than simply pass on the result.</p>
-<div class="sourceCode" id="cb167"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb167-1"><a href="#cb167-1"></a><span class="kw">create</span> <span class="kw">procedure</span> meta_stuff(meta bool)</span>
-<span id="cb167-2"><a href="#cb167-2"></a><span class="cf">begin</span></span>
-<span id="cb167-3"><a href="#cb167-3"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">call</span> get_stuff();  <span class="co">-- or get_meta_stuff(...)</span></span>
-<span id="cb167-4"><a href="#cb167-4"></a>  <span class="cf">loop</span> fetch C</span>
-<span id="cb167-5"><a href="#cb167-5"></a>  <span class="cf">begin</span></span>
-<span id="cb167-6"><a href="#cb167-6"></a>     <span class="co">-- do stuff with C</span></span>
-<span id="cb167-7"><a href="#cb167-7"></a>     <span class="co">-- may be out union some of the rows after adjustment even</span></span>
-<span id="cb167-8"><a href="#cb167-8"></a>  <span class="cf">end</span>;</span>
-<span id="cb167-9"><a href="#cb167-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb167"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb167-1"><a href="#cb167-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> meta_stuff(meta bool)</span>
+<span id="cb167-2"><a href="#cb167-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb167-3"><a href="#cb167-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">call</span> get_stuff();  <span class="co">-- or get_meta_stuff(...)</span></span>
+<span id="cb167-4"><a href="#cb167-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">loop</span> fetch C</span>
+<span id="cb167-5"><a href="#cb167-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb167-6"><a href="#cb167-6" aria-hidden="true" tabindex="-1"></a>     <span class="co">-- do stuff with C</span></span>
+<span id="cb167-7"><a href="#cb167-7" aria-hidden="true" tabindex="-1"></a>     <span class="co">-- may be out union some of the rows after adjustment even</span></span>
+<span id="cb167-8"><a href="#cb167-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb167-9"><a href="#cb167-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Here we can see that we used the procedure to get the results and then process them directly somehow.</p>
 <p>And of course the result of an <code>OUT</code> can similarly be processed using a value cursor as we previously saw.</p>
 <p>These combinations allow for pretty general composition of stored procedures as long as they are not recombined with SQLite statements.</p>
@@ -2612,71 +2744,71 @@ This form implies <code>USING TRANSACTION</code>.</p>
 -->
 <p>Most of this tutorial is about the CQL language itself but here we must diverge a bit. The purpose of the result set features of CQL is to create a C interface to SQLite data. Because of this there are a lot of essential details that require looking carefully at the generated C code. Appendix 2 covers this code in even more detail but here it makes sense to at least talk about the interface.</p>
 <p>If we have this simple stored procedure:</p>
-<div class="sourceCode" id="cb168"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb168-1"><a href="#cb168-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, b bool, t text);</span>
-<span id="cb168-2"><a href="#cb168-2"></a></span>
-<span id="cb168-3"><a href="#cb168-3"></a><span class="kw">create</span> proc read_foo(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb168-4"><a href="#cb168-4"></a><span class="cf">begin</span></span>
-<span id="cb168-5"><a href="#cb168-5"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb168-6"><a href="#cb168-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb168"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb168-1"><a href="#cb168-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, b bool, t text);</span>
+<span id="cb168-2"><a href="#cb168-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb168-3"><a href="#cb168-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc read_foo(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb168-4"><a href="#cb168-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb168-5"><a href="#cb168-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo <span class="kw">where</span> <span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb168-6"><a href="#cb168-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>We’ve created a simple data reader, this CQL code will cause the compiler to generated helper functions to read the data and materialize a result set.</p>
 <p>Let’s look at the public interface of that result set now considering the most essential pieces.</p>
-<div class="sourceCode" id="cb169"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb169-1"><a href="#cb169-1"></a><span class="co">/* this is almost everything in the generated header file */</span></span>
-<span id="cb169-2"><a href="#cb169-2"></a><span class="pp">#define read_foo_data_types_count 3</span></span>
-<span id="cb169-3"><a href="#cb169-3"></a>cql_result_set_type_decl(</span>
-<span id="cb169-4"><a href="#cb169-4"></a>  read_foo_result_set, \</span>
-<span id="cb169-5"><a href="#cb169-5"></a>  read_foo_result_set_ref);</span>
-<span id="cb169-6"><a href="#cb169-6"></a></span>
-<span id="cb169-7"><a href="#cb169-7"></a><span class="kw">extern</span> cql_int32 read_foo_get_id(read_foo_result_set_ref</span>
-<span id="cb169-8"><a href="#cb169-8"></a>  _Nonnull result_set, cql_int32 row);</span>
-<span id="cb169-9"><a href="#cb169-9"></a><span class="kw">extern</span> cql_bool read_foo_get_b_is_null(read_foo_result_set_ref </span>
-<span id="cb169-10"><a href="#cb169-10"></a>  _Nonnull result_set, cql_int32 row);</span>
-<span id="cb169-11"><a href="#cb169-11"></a><span class="kw">extern</span> cql_bool read_foo_get_b_value(read_foo_result_set_ref </span>
-<span id="cb169-12"><a href="#cb169-12"></a>  _Nonnull result_set, cql_int32 row);</span>
-<span id="cb169-13"><a href="#cb169-13"></a><span class="kw">extern</span> cql_string_ref _Nullable read_foo_get_t(</span>
-<span id="cb169-14"><a href="#cb169-14"></a>   read_foo_result_set_ref  _Nonnull result_set, </span>
-<span id="cb169-15"><a href="#cb169-15"></a>   cql_int32 row);</span>
-<span id="cb169-16"><a href="#cb169-16"></a><span class="kw">extern</span> cql_int32 read_foo_result_count(read_foo_result_set_ref </span>
-<span id="cb169-17"><a href="#cb169-17"></a>  _Nonnull result_set);</span>
-<span id="cb169-18"><a href="#cb169-18"></a><span class="kw">extern</span> cql_code read_foo_fetch_results(sqlite3 *_Nonnull _db_, </span>
-<span id="cb169-19"><a href="#cb169-19"></a>  read_foo_result_set_ref _Nullable *_Nonnull result_set, </span>
-<span id="cb169-20"><a href="#cb169-20"></a>  cql_int32 id_);</span>
-<span id="cb169-21"><a href="#cb169-21"></a><span class="pp">#define read_foo_row_hash(result_set, row) \</span></span>
-<span id="cb169-22"><a href="#cb169-22"></a><span class="pp">  cql_result_set_get_meta((cql_result_set_ref)(result_set))-&gt;\</span></span>
-<span id="cb169-23"><a href="#cb169-23"></a><span class="pp">  rowHash((cql_result_set_ref)(result_set), row)</span></span>
-<span id="cb169-24"><a href="#cb169-24"></a><span class="pp">#define read_foo_row_equal(rs1, row1, rs2, row2) \</span></span>
-<span id="cb169-25"><a href="#cb169-25"></a><span class="pp">cql_result_set_get_meta((cql_result_set_ref)(rs1)) \</span></span>
-<span id="cb169-26"><a href="#cb169-26"></a><span class="pp"> -&gt;rowsEqual( \</span></span>
-<span id="cb169-27"><a href="#cb169-27"></a><span class="pp">   (cql_result_set_ref)(rs1),  row1,  \</span></span>
-<span id="cb169-28"><a href="#cb169-28"></a><span class="pp">   (cql_result_set_ref)(rs2),  row2)</span></span></code></pre></div>
+<div class="sourceCode" id="cb169"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb169-1"><a href="#cb169-1" aria-hidden="true" tabindex="-1"></a><span class="co">/* this is almost everything in the generated header file */</span></span>
+<span id="cb169-2"><a href="#cb169-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define read_foo_data_types_count 3</span></span>
+<span id="cb169-3"><a href="#cb169-3" aria-hidden="true" tabindex="-1"></a>cql_result_set_type_decl<span class="op">(</span></span>
+<span id="cb169-4"><a href="#cb169-4" aria-hidden="true" tabindex="-1"></a>  read_foo_result_set<span class="op">,</span> \</span>
+<span id="cb169-5"><a href="#cb169-5" aria-hidden="true" tabindex="-1"></a>  read_foo_result_set_ref<span class="op">);</span></span>
+<span id="cb169-6"><a href="#cb169-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb169-7"><a href="#cb169-7" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 read_foo_get_id<span class="op">(</span>read_foo_result_set_ref</span>
+<span id="cb169-8"><a href="#cb169-8" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">,</span> cql_int32 row<span class="op">);</span></span>
+<span id="cb169-9"><a href="#cb169-9" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_bool read_foo_get_b_is_null<span class="op">(</span>read_foo_result_set_ref </span>
+<span id="cb169-10"><a href="#cb169-10" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">,</span> cql_int32 row<span class="op">);</span></span>
+<span id="cb169-11"><a href="#cb169-11" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_bool read_foo_get_b_value<span class="op">(</span>read_foo_result_set_ref </span>
+<span id="cb169-12"><a href="#cb169-12" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">,</span> cql_int32 row<span class="op">);</span></span>
+<span id="cb169-13"><a href="#cb169-13" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nullable read_foo_get_t<span class="op">(</span></span>
+<span id="cb169-14"><a href="#cb169-14" aria-hidden="true" tabindex="-1"></a>   read_foo_result_set_ref  _Nonnull result_set<span class="op">,</span> </span>
+<span id="cb169-15"><a href="#cb169-15" aria-hidden="true" tabindex="-1"></a>   cql_int32 row<span class="op">);</span></span>
+<span id="cb169-16"><a href="#cb169-16" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 read_foo_result_count<span class="op">(</span>read_foo_result_set_ref </span>
+<span id="cb169-17"><a href="#cb169-17" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">);</span></span>
+<span id="cb169-18"><a href="#cb169-18" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_code read_foo_fetch_results<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb169-19"><a href="#cb169-19" aria-hidden="true" tabindex="-1"></a>  read_foo_result_set_ref _Nullable <span class="op">*</span>_Nonnull result_set<span class="op">,</span> </span>
+<span id="cb169-20"><a href="#cb169-20" aria-hidden="true" tabindex="-1"></a>  cql_int32 id_<span class="op">);</span></span>
+<span id="cb169-21"><a href="#cb169-21" aria-hidden="true" tabindex="-1"></a><span class="pp">#define read_foo_row_hash(result_set, row) \</span></span>
+<span id="cb169-22"><a href="#cb169-22" aria-hidden="true" tabindex="-1"></a><span class="pp">  cql_result_set_get_meta((cql_result_set_ref)(result_set))-&gt;\</span></span>
+<span id="cb169-23"><a href="#cb169-23" aria-hidden="true" tabindex="-1"></a><span class="pp">  rowHash((cql_result_set_ref)(result_set), row)</span></span>
+<span id="cb169-24"><a href="#cb169-24" aria-hidden="true" tabindex="-1"></a><span class="pp">#define read_foo_row_equal(rs1, row1, rs2, row2) \</span></span>
+<span id="cb169-25"><a href="#cb169-25" aria-hidden="true" tabindex="-1"></a><span class="pp">cql_result_set_get_meta((cql_result_set_ref)(rs1)) \</span></span>
+<span id="cb169-26"><a href="#cb169-26" aria-hidden="true" tabindex="-1"></a><span class="pp"> -&gt;rowsEqual( \</span></span>
+<span id="cb169-27"><a href="#cb169-27" aria-hidden="true" tabindex="-1"></a><span class="pp">   (cql_result_set_ref)(rs1),  row1,  \</span></span>
+<span id="cb169-28"><a href="#cb169-28" aria-hidden="true" tabindex="-1"></a><span class="pp">   (cql_result_set_ref)(rs2),  row2)</span></span></code></pre></div>
 <p>Let’s consider some of these individually now</p>
-<div class="sourceCode" id="cb170"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb170-1"><a href="#cb170-1"></a>cql_result_set_type_decl(</span>
-<span id="cb170-2"><a href="#cb170-2"></a>  read_foo_result_set, </span>
-<span id="cb170-3"><a href="#cb170-3"></a>  read_foo_result_set_ref);</span></code></pre></div>
+<div class="sourceCode" id="cb170"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb170-1"><a href="#cb170-1" aria-hidden="true" tabindex="-1"></a>cql_result_set_type_decl<span class="op">(</span></span>
+<span id="cb170-2"><a href="#cb170-2" aria-hidden="true" tabindex="-1"></a>  read_foo_result_set<span class="op">,</span> </span>
+<span id="cb170-3"><a href="#cb170-3" aria-hidden="true" tabindex="-1"></a>  read_foo_result_set_ref<span class="op">);</span></span></code></pre></div>
 <p>This declares the data type for <code>read_foo_result_set</code> and the associated object reference <code>read_foo_result_set_ref</code>.<br />
 As it turns out the underlying data type for all result sets is the same, only the shape of the data varies.</p>
-<div class="sourceCode" id="cb171"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb171-1"><a href="#cb171-1"></a><span class="kw">extern</span> cql_code read_foo_fetch_results(sqlite3 *_Nonnull _db_, </span>
-<span id="cb171-2"><a href="#cb171-2"></a>  read_foo_result_set_ref _Nullable *_Nonnull result_set, </span>
-<span id="cb171-3"><a href="#cb171-3"></a>  cql_int32 id_);</span></code></pre></div>
+<div class="sourceCode" id="cb171"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb171-1"><a href="#cb171-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_code read_foo_fetch_results<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span> </span>
+<span id="cb171-2"><a href="#cb171-2" aria-hidden="true" tabindex="-1"></a>  read_foo_result_set_ref _Nullable <span class="op">*</span>_Nonnull result_set<span class="op">,</span> </span>
+<span id="cb171-3"><a href="#cb171-3" aria-hidden="true" tabindex="-1"></a>  cql_int32 id_<span class="op">);</span></span></code></pre></div>
 <p>The result set fetcher method gives you a <code>read_foo_result_set_ref</code> if it succeeds. It accepts the <code>id_</code> argument which it will internally pass along to <code>read_foo(...)</code>. The latter function provides a <code>sqlite3_stmt*</code> which can then be iterated in the fetcher. This method is the main public entry point for result sets.</p>
 <p>Once you have a result set, you can read values out of it.</p>
-<div class="sourceCode" id="cb172"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb172-1"><a href="#cb172-1"></a><span class="kw">extern</span> cql_int32 read_foo_result_count(read_foo_result_set_ref </span>
-<span id="cb172-2"><a href="#cb172-2"></a>  _Nonnull result_set);</span></code></pre></div>
+<div class="sourceCode" id="cb172"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb172-1"><a href="#cb172-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 read_foo_result_count<span class="op">(</span>read_foo_result_set_ref </span>
+<span id="cb172-2"><a href="#cb172-2" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">);</span></span></code></pre></div>
 <p>That function tells you how many rows are in the result set.</p>
 <p>For each row you can use any of the row readers:</p>
-<div class="sourceCode" id="cb173"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb173-1"><a href="#cb173-1"></a><span class="kw">extern</span> cql_int32 read_foo_get_id(read_foo_result_set_ref</span>
-<span id="cb173-2"><a href="#cb173-2"></a>  _Nonnull result_set, cql_int32 row);</span>
-<span id="cb173-3"><a href="#cb173-3"></a><span class="kw">extern</span> cql_bool read_foo_get_b_is_null(read_foo_result_set_ref </span>
-<span id="cb173-4"><a href="#cb173-4"></a>  _Nonnull result_set, cql_int32 row);</span>
-<span id="cb173-5"><a href="#cb173-5"></a><span class="kw">extern</span> cql_bool read_foo_get_b_value(read_foo_result_set_ref </span>
-<span id="cb173-6"><a href="#cb173-6"></a>  _Nonnull result_set, cql_int32 row);</span>
-<span id="cb173-7"><a href="#cb173-7"></a><span class="kw">extern</span> cql_string_ref _Nullable read_foo_get_t(</span>
-<span id="cb173-8"><a href="#cb173-8"></a>   read_foo_result_set_ref  _Nonnull result_set, </span>
-<span id="cb173-9"><a href="#cb173-9"></a>   cql_int32 row);</span></code></pre></div>
+<div class="sourceCode" id="cb173"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb173-1"><a href="#cb173-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 read_foo_get_id<span class="op">(</span>read_foo_result_set_ref</span>
+<span id="cb173-2"><a href="#cb173-2" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">,</span> cql_int32 row<span class="op">);</span></span>
+<span id="cb173-3"><a href="#cb173-3" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_bool read_foo_get_b_is_null<span class="op">(</span>read_foo_result_set_ref </span>
+<span id="cb173-4"><a href="#cb173-4" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">,</span> cql_int32 row<span class="op">);</span></span>
+<span id="cb173-5"><a href="#cb173-5" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_bool read_foo_get_b_value<span class="op">(</span>read_foo_result_set_ref </span>
+<span id="cb173-6"><a href="#cb173-6" aria-hidden="true" tabindex="-1"></a>  _Nonnull result_set<span class="op">,</span> cql_int32 row<span class="op">);</span></span>
+<span id="cb173-7"><a href="#cb173-7" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nullable read_foo_get_t<span class="op">(</span></span>
+<span id="cb173-8"><a href="#cb173-8" aria-hidden="true" tabindex="-1"></a>   read_foo_result_set_ref  _Nonnull result_set<span class="op">,</span> </span>
+<span id="cb173-9"><a href="#cb173-9" aria-hidden="true" tabindex="-1"></a>   cql_int32 row<span class="op">);</span></span></code></pre></div>
 <p>These let you read the <code>id</code> of a particular row, and get a <code>cql_int32</code> or you can read the nullable boolean, using the <code>read_foo_get_b_is_null</code> function first to see if the boolean is null and then <code>read_foo_get_b_value</code> to get the value. Finally the string can be accessed with <code>read_foo_get_t</code>. As you can see there is a simple naming convention for each of the field readers.</p>
 <p>Note: The compiler has runtime arrays that control naming conventions as well as using CamelCasing. Additional customizations may be created by adding new runtime arrays into the CQL compiler.</p>
 <p>Finally, also part of the public interface, are these macros:</p>
-<div class="sourceCode" id="cb174"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb174-1"><a href="#cb174-1"></a><span class="pp">#define read_foo_row_hash(result_set, row) </span></span>
-<span id="cb174-2"><a href="#cb174-2"></a><span class="pp">#define read_foo_row_equal(rs1, row1, rs2, row2)</span></span></code></pre></div>
+<div class="sourceCode" id="cb174"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb174-1"><a href="#cb174-1" aria-hidden="true" tabindex="-1"></a><span class="pp">#define read_foo_row_hash(result_set, row) </span></span>
+<span id="cb174-2"><a href="#cb174-2" aria-hidden="true" tabindex="-1"></a><span class="pp">#define read_foo_row_equal(rs1, row1, rs2, row2)</span></span></code></pre></div>
 <p>These use the CQL runtime to hash a row or compare two rows from identical result set types. Metadata included in the result set allows general purpose code to work for every result set. Based on configuration, result set copying methods can also be generated. When you’re done with a result set you can use the <code>cql_release(...)</code> method to free the memory.</p>
 <p>Importantly, all of the rows from the query in the stored procedure are materialized immediately and become part of the result set. Potentially large amounts of memory can be used if a lot of rows are generated.</p>
 <p>The code that actually creates the result set starting from the prepared statement is always the same. The essential parts are:</p>
@@ -2727,25 +2859,25 @@ read_foo_fetch_results(
 <h3 id="results-sets-from-out-union">Results Sets From <code>OUT UNION</code></h3>
 <p>The <code>out</code> keyword was added for writing procedures that produce a single row result set. With that, it became possible to make any single row result you wanted, assembling it from whatever sources you needed. That is an important case as single row results happen frequently and they are comparatively easy to create and pass around using C structures for the backing store. However, it’s not everything, there are also cases where full flexibility is needed while producing a standard many-row result set. For this we have <code>out union</code> which was dicussed fully in Chapter 5. Here we’ll discuss the code generation behind that.</p>
 <p>Here’s an example from the CQL tests:</p>
-<div class="sourceCode" id="cb179"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb179-1"><a href="#cb179-1"></a><span class="kw">create</span> proc some_integers(<span class="kw">start</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">stop</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb179-2"><a href="#cb179-2"></a><span class="cf">begin</span></span>
-<span id="cb179-3"><a href="#cb179-3"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="dv">1</span> v, <span class="dv">2</span> v_squared, <span class="ot">&quot;xx&quot;</span> some_text;</span>
-<span id="cb179-4"><a href="#cb179-4"></a>  <span class="kw">declare</span> i <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
-<span id="cb179-5"><a href="#cb179-5"></a>  <span class="kw">set</span> i <span class="op">:=</span> <span class="kw">start</span>;</span>
-<span id="cb179-6"><a href="#cb179-6"></a>  <span class="cf">while</span> (i <span class="op">&lt;</span> <span class="kw">stop</span>)</span>
-<span id="cb179-7"><a href="#cb179-7"></a>  <span class="cf">begin</span></span>
-<span id="cb179-8"><a href="#cb179-8"></a>   fetch C(v, v_squared, junk) <span class="kw">from</span> <span class="kw">values</span> (i, i<span class="op">*</span>i, printf(<span class="ot">&quot;%d&quot;</span>, i));</span>
-<span id="cb179-9"><a href="#cb179-9"></a>   <span class="kw">out</span> <span class="kw">union</span> C;</span>
-<span id="cb179-10"><a href="#cb179-10"></a>   <span class="kw">set</span> i <span class="op">:=</span> i <span class="op">+</span> <span class="dv">1</span>;</span>
-<span id="cb179-11"><a href="#cb179-11"></a> <span class="cf">end</span>;</span>
-<span id="cb179-12"><a href="#cb179-12"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb179"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb179-1"><a href="#cb179-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc some_integers(<span class="kw">start</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">stop</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb179-2"><a href="#cb179-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb179-3"><a href="#cb179-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> <span class="kw">select</span> <span class="dv">1</span> v, <span class="dv">2</span> v_squared, <span class="ot">&quot;xx&quot;</span> some_text;</span>
+<span id="cb179-4"><a href="#cb179-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">declare</span> i <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>;</span>
+<span id="cb179-5"><a href="#cb179-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> i <span class="op">:=</span> <span class="kw">start</span>;</span>
+<span id="cb179-6"><a href="#cb179-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">while</span> (i <span class="op">&lt;</span> <span class="kw">stop</span>)</span>
+<span id="cb179-7"><a href="#cb179-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb179-8"><a href="#cb179-8" aria-hidden="true" tabindex="-1"></a>   fetch C(v, v_squared, junk) <span class="kw">from</span> <span class="kw">values</span> (i, i<span class="op">*</span>i, printf(<span class="ot">&quot;%d&quot;</span>, i));</span>
+<span id="cb179-9"><a href="#cb179-9" aria-hidden="true" tabindex="-1"></a>   <span class="kw">out</span> <span class="kw">union</span> C;</span>
+<span id="cb179-10"><a href="#cb179-10" aria-hidden="true" tabindex="-1"></a>   <span class="kw">set</span> i <span class="op">:=</span> i <span class="op">+</span> <span class="dv">1</span>;</span>
+<span id="cb179-11"><a href="#cb179-11" aria-hidden="true" tabindex="-1"></a> <span class="cf">end</span>;</span>
+<span id="cb179-12"><a href="#cb179-12" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>In this example the entire result set is made up out of thin air. Of course any combination of this computation or data-access is possible, so you can ultimately make any rows you want in any order using SQLite to help you as much or as little as you need.</p>
 <p>Virtually all the code pieces to do this already exist for normal result sets. The important parts of the output code look like this in your generated C.</p>
 <p>We need a buffer to hold the rows we are going to accumulate; We use <code>cql_bytebuf</code> just like the normal fetcher above.</p>
-<div class="sourceCode" id="cb180"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb180-1"><a href="#cb180-1"></a><span class="co">// This bit creates a growable buffer to hold the rows</span></span>
-<span id="cb180-2"><a href="#cb180-2"></a><span class="co">// This is how we do all the other result sets, too</span></span>
-<span id="cb180-3"><a href="#cb180-3"></a>cql_bytebuf _rows_;</span>
-<span id="cb180-4"><a href="#cb180-4"></a>cql_bytebuf_open(&amp;_rows_);</span></code></pre></div>
+<div class="sourceCode" id="cb180"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb180-1"><a href="#cb180-1" aria-hidden="true" tabindex="-1"></a><span class="co">// This bit creates a growable buffer to hold the rows</span></span>
+<span id="cb180-2"><a href="#cb180-2" aria-hidden="true" tabindex="-1"></a><span class="co">// This is how we do all the other result sets, too</span></span>
+<span id="cb180-3"><a href="#cb180-3" aria-hidden="true" tabindex="-1"></a>cql_bytebuf _rows_<span class="op">;</span></span>
+<span id="cb180-4"><a href="#cb180-4" aria-hidden="true" tabindex="-1"></a>cql_bytebuf_open<span class="op">(&amp;</span>_rows_<span class="op">);</span></span></code></pre></div>
 <p>We need to be able to copy the cursor into the buffer and retain any internal references</p>
 <pre><code>// This bit is what you get when you &quot;out union&quot; a cursor &quot;C&quot;
 // first we +1 any references in the cursor then we copy its bits 
@@ -2770,38 +2902,38 @@ if (C_._has_row_) cql_bytebuf_append(&amp;_rows_, (const void *)&amp;C_, sizeof(
 <p>In an other example of the two-headed nature of CQL, there are two ways to declare functions. As we have already seen you can make function-like procedures and call them like functions simply by making a procedure with an <code>out</code> parameter. However, there are also cases where it is reasonable to make function calls to external functions of other kinds. There are three major types of functions you might wish to call.</p>
 <h4 id="ordinary-scalar-functions">Ordinary Scalar Functions</h4>
 <p>These functions are written in regular C and provide for the ability to do operations on in-memory objects. For instance, you could create functions that allow you to read and write from a dictionary. You can declare these functions like so:</p>
-<div class="sourceCode" id="cb183"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb183-1"><a href="#cb183-1"></a><span class="kw">declare</span> <span class="kw">function</span> dict_get_value(dict <span class="dt">object</span>, key_ text <span class="kw">not</span> <span class="kw">null</span>) text;</span></code></pre></div>
+<div class="sourceCode" id="cb183"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb183-1"><a href="#cb183-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">function</span> dict_get_value(dict <span class="dt">object</span>, key_ text <span class="kw">not</span> <span class="kw">null</span>) text;</span></code></pre></div>
 <p>Such a function is not known to SQLite and therefore cannot appear in SQL statements. CQL will enforce this.</p>
 <p>The above function returns a text reference, and, importantly, this is a borrowed reference. The dictionary is presumably holding on to the reference and as long as it is not mutated the reference is valid. CQL will retain this reference as soon as it is stored and release it automatically when it is out of scope. So, in this case, the dictionary continues to own the object.</p>
 <p>It is also possible to declare functions that create objects. Such as this example:</p>
-<div class="sourceCode" id="cb184"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb184-1"><a href="#cb184-1"></a><span class="kw">declare</span> <span class="kw">function</span> dict_create() <span class="kw">create</span> <span class="dt">object</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb184"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb184-1"><a href="#cb184-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">function</span> dict_create() <span class="kw">create</span> <span class="dt">object</span>;</span></code></pre></div>
 <p>This declaration tells CQL that the function will create a new object for our use. CQL does not retain the provided object, rather assuming ownership of the presumably one reference count the object already has. When the object goes out of scope it is release as usual.</p>
 <p>If we also declare this procedure:</p>
-<div class="sourceCode" id="cb185"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb185-1"><a href="#cb185-1"></a><span class="kw">declare</span> <span class="kw">procedure</span> dict_add(</span>
-<span id="cb185-2"><a href="#cb185-2"></a>    dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb185-3"><a href="#cb185-3"></a>    key_ text <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb185-4"><a href="#cb185-4"></a>    <span class="fu">value</span> text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb185"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb185-1"><a href="#cb185-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">procedure</span> dict_add(</span>
+<span id="cb185-2"><a href="#cb185-2" aria-hidden="true" tabindex="-1"></a>    dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb185-3"><a href="#cb185-3" aria-hidden="true" tabindex="-1"></a>    key_ text <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb185-4"><a href="#cb185-4" aria-hidden="true" tabindex="-1"></a>    <span class="fu">value</span> text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
 <p>Then with this family of declarations we could write something like this:</p>
-<div class="sourceCode" id="cb186"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb186-1"><a href="#cb186-1"></a><span class="kw">create</span> proc create_and_init(<span class="kw">out</span> dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb186-2"><a href="#cb186-2"></a><span class="cf">begin</span></span>
-<span id="cb186-3"><a href="#cb186-3"></a>  <span class="kw">set</span> dict <span class="op">:=</span> dict_create();</span>
-<span id="cb186-4"><a href="#cb186-4"></a>  <span class="kw">call</span> dict_add(dict, <span class="ot">&quot;k1&quot;</span>, <span class="ot">&quot;v1&quot;</span>);</span>
-<span id="cb186-5"><a href="#cb186-5"></a>  <span class="kw">call</span> dict_add(dict, <span class="ot">&quot;k2&quot;</span>, <span class="ot">&quot;v2&quot;</span>);</span>
-<span id="cb186-6"><a href="#cb186-6"></a>  <span class="cf">if</span> (dict_get_value(dict, <span class="ot">&quot;k1&quot;</span>) <span class="op">==</span> dict__get_value(dict, <span class="ot">&quot;k2)) then</span></span>
-<span id="cb186-7"><a href="#cb186-7"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;insanity has ensued\n&quot;</span>);</span>
-<span id="cb186-8"><a href="#cb186-8"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb186-9"><a href="#cb186-9"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb186"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb186-1"><a href="#cb186-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc create_and_init(<span class="kw">out</span> dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb186-2"><a href="#cb186-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb186-3"><a href="#cb186-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> dict <span class="op">:=</span> dict_create();</span>
+<span id="cb186-4"><a href="#cb186-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> dict_add(dict, <span class="ot">&quot;k1&quot;</span>, <span class="ot">&quot;v1&quot;</span>);</span>
+<span id="cb186-5"><a href="#cb186-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> dict_add(dict, <span class="ot">&quot;k2&quot;</span>, <span class="ot">&quot;v2&quot;</span>);</span>
+<span id="cb186-6"><a href="#cb186-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (dict_get_value(dict, <span class="ot">&quot;k1&quot;</span>) <span class="op">==</span> dict__get_value(dict, <span class="ot">&quot;k2)) then</span></span>
+<span id="cb186-7"><a href="#cb186-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> printf(<span class="ot">&quot;insanity has ensued\n&quot;</span>);</span>
+<span id="cb186-8"><a href="#cb186-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb186-9"><a href="#cb186-9" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Note: Ordinary scalar functions may not use the database in any way, when they are invoked they will not be provided with the database pointer and so they will be unable to do any database operations. To do database operations use regular procedures. You can create a function-like-procedure using the <code>out</code> convention discussed previously.</p>
 <h4 id="sql-scalar-functions">SQL Scalar Functions</h4>
 <p>SQLite includes the ability to add new functions to its expressions using <code>sqlite3_create_function</code>. In order to use this function in CQL, you must also provide its prototype definition to the compiler. You can do so like in this example:</p>
-<div class="sourceCode" id="cb187"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb187-1"><a href="#cb187-1"></a><span class="kw">declare</span> <span class="kw">select</span> <span class="kw">function</span> strencode(t text <span class="kw">not</span> <span class="kw">null</span>) text <span class="kw">not</span> <span class="kw">null</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb187"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb187-1"><a href="#cb187-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">select</span> <span class="kw">function</span> strencode(t text <span class="kw">not</span> <span class="kw">null</span>) text <span class="kw">not</span> <span class="kw">null</span>;</span></code></pre></div>
 <p>This introduces the function <code>strencode</code> to the compiler for use in SQL constructs. With this done you could write a procedure something like this:</p>
-<div class="sourceCode" id="cb188"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb188-1"><a href="#cb188-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(<span class="kw">id</span> <span class="dt">integer</span>, t text);</span>
-<span id="cb188-2"><a href="#cb188-2"></a></span>
-<span id="cb188-3"><a href="#cb188-3"></a><span class="kw">create</span> <span class="kw">procedure</span> bar(id_ <span class="dt">integer</span>)</span>
-<span id="cb188-4"><a href="#cb188-4"></a><span class="cf">begin</span></span>
-<span id="cb188-5"><a href="#cb188-5"></a>   <span class="kw">select</span> strencode(T1.t) <span class="kw">from</span> foo T1 <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb188-6"><a href="#cb188-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb188"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb188-1"><a href="#cb188-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(<span class="kw">id</span> <span class="dt">integer</span>, t text);</span>
+<span id="cb188-2"><a href="#cb188-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb188-3"><a href="#cb188-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> bar(id_ <span class="dt">integer</span>)</span>
+<span id="cb188-4"><a href="#cb188-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb188-5"><a href="#cb188-5" aria-hidden="true" tabindex="-1"></a>   <span class="kw">select</span> strencode(T1.t) <span class="kw">from</span> foo T1 <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb188-6"><a href="#cb188-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This presumably returns the “encoded” text, whatever that might be. Note that if <code>sqlite3_create_function</code> is not called before this code runs, a run-time error will ensue. Just as CQL must assume that declared tables really are created, it also assumes that declared function really are created. This is another case of telling the compiler in advance what the situation will be at runtime.</p>
 <p>SQLite allows for many flexible kinds of user defined functions. CQL doesn’t concern itself with the details of the implementation of the function, it only needs the signature so that it can validate calls.</p>
 <p>Note that SQL Scalar Functions cannot contain <code>object</code> parameters. To pass an <code>object</code>, you should instead pass the memory address of this object using a <code>LONG INT</code> parameter. To access the address of an <code>object</code> at runtime, you should use the <code>ptr()</code> function. See <a href="#notes-on-builtin-functions">the notes section below</a> for more information.</p>
@@ -2809,17 +2941,17 @@ if (C_._has_row_) cql_bytebuf_append(&amp;_rows_, (const void *)&amp;C_, sizeof(
 <h4 id="sql-table-valued-functions">SQL Table Valued Functions</h4>
 <p>More recent versions of SQLite also include the ability to add table-valued functions to statements in place of actual tables. These functions can use their arguments to create a “virtual table” value for use in place of a table. For this to work, again SQLite must be told of the existence of the table. There are a series of steps to make this happen beginning with <code>sqlite3_create_module</code> which are described in the SQLite documents under “The Virtual Table Mechanism Of SQLite.”</p>
 <p>Once that has been done, a table-valued function can be defined for most object types. For instance it is possible to create a table-valued function like so:</p>
-<div class="sourceCode" id="cb189"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb189-1"><a href="#cb189-1"></a><span class="kw">declare</span> <span class="kw">select</span> <span class="kw">function</span> dict_contents(dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb189-2"><a href="#cb189-2"></a>   (k text <span class="kw">not</span> <span class="kw">null</span>, v text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb189"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb189-1"><a href="#cb189-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">select</span> <span class="kw">function</span> dict_contents(dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb189-2"><a href="#cb189-2" aria-hidden="true" tabindex="-1"></a>   (k text <span class="kw">not</span> <span class="kw">null</span>, v text <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
 <p>This is just like the previous type of select function but the return type is a table shape. Once the above has been done you can legally write something like this:</p>
-<div class="sourceCode" id="cb190"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb190-1"><a href="#cb190-1"></a><span class="kw">create</span> proc read_dict(dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>, pattern text)</span>
-<span id="cb190-2"><a href="#cb190-2"></a><span class="cf">begin</span></span>
-<span id="cb190-3"><a href="#cb190-3"></a>  <span class="cf">if</span> pattern <span class="kw">is</span> <span class="kw">not</span> <span class="kw">null</span> <span class="cf">then</span></span>
-<span id="cb190-4"><a href="#cb190-4"></a>    <span class="kw">select</span> k, v <span class="kw">from</span> dict_contents(dict) T1 <span class="kw">where</span> T1.k <span class="kw">LIKE</span> pattern;</span>
-<span id="cb190-5"><a href="#cb190-5"></a>  <span class="cf">else</span></span>
-<span id="cb190-6"><a href="#cb190-6"></a>    <span class="kw">select</span> k, v <span class="kw">from</span> dict_contents(dict);</span>
-<span id="cb190-7"><a href="#cb190-7"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
-<span id="cb190-8"><a href="#cb190-8"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb190"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb190-1"><a href="#cb190-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc read_dict(dict <span class="dt">object</span> <span class="kw">not</span> <span class="kw">null</span>, pattern text)</span>
+<span id="cb190-2"><a href="#cb190-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb190-3"><a href="#cb190-3" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> pattern <span class="kw">is</span> <span class="kw">not</span> <span class="kw">null</span> <span class="cf">then</span></span>
+<span id="cb190-4"><a href="#cb190-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> k, v <span class="kw">from</span> dict_contents(dict) T1 <span class="kw">where</span> T1.k <span class="kw">LIKE</span> pattern;</span>
+<span id="cb190-5"><a href="#cb190-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">else</span></span>
+<span id="cb190-6"><a href="#cb190-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> k, v <span class="kw">from</span> dict_contents(dict);</span>
+<span id="cb190-7"><a href="#cb190-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> <span class="cf">if</span>;</span>
+<span id="cb190-8"><a href="#cb190-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This construct is very general indeed but the runtime set up for it is much more complicated than scalar functions and only more modern versions of SQLite even support it.</p>
 <h3 id="notes-on-builtin-functions">Notes on Builtin Functions</h3>
 <p>Some of the SQLite builtin functions are hard-coded, these are the functions that have semantics that are not readily captured with a simple prototype. Other SQLite functions can be declared wtih <code>declare select funtion ...</code> and then used.</p>
@@ -2943,27 +3075,27 @@ if (C_._has_row_) cql_bytebuf_append(&amp;_rows_, (const void *)&amp;C_, sizeof(
 <p>The sqlite documentation can be helpful (CQL syntax is a subset). https://www.sqlite.org/lang_savepoint.html</p>
 <h4 id="the-procedure-savepoint-statement">The <code>PROCEDURE SAVEPOINT</code> Statement</h4>
 <p>A common pattern is to have a savepoint associated with a particular procedure, the savepoint’s scope is the same as the procedure. More precisely</p>
-<div class="sourceCode" id="cb191"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb191-1"><a href="#cb191-1"></a><span class="kw">create</span> <span class="kw">procedure</span> foo()</span>
-<span id="cb191-2"><a href="#cb191-2"></a><span class="cf">begin</span></span>
-<span id="cb191-3"><a href="#cb191-3"></a>  proc <span class="kw">savepoint</span></span>
-<span id="cb191-4"><a href="#cb191-4"></a>  <span class="cf">begin</span></span>
-<span id="cb191-5"><a href="#cb191-5"></a>   <span class="co">-- your code</span></span>
-<span id="cb191-6"><a href="#cb191-6"></a>  <span class="cf">end</span>;</span>
-<span id="cb191-7"><a href="#cb191-7"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb191"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb191-1"><a href="#cb191-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> foo()</span>
+<span id="cb191-2"><a href="#cb191-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb191-3"><a href="#cb191-3" aria-hidden="true" tabindex="-1"></a>  proc <span class="kw">savepoint</span></span>
+<span id="cb191-4"><a href="#cb191-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span></span>
+<span id="cb191-5"><a href="#cb191-5" aria-hidden="true" tabindex="-1"></a>   <span class="co">-- your code</span></span>
+<span id="cb191-6"><a href="#cb191-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span>;</span>
+<span id="cb191-7"><a href="#cb191-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Becomes:</p>
-<div class="sourceCode" id="cb192"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb192-1"><a href="#cb192-1"></a><span class="kw">create</span> <span class="kw">procedure</span> foo()</span>
-<span id="cb192-2"><a href="#cb192-2"></a><span class="cf">begin</span></span>
-<span id="cb192-3"><a href="#cb192-3"></a>  <span class="kw">savepoint</span> @proc;  <span class="co">-- @proc is always the name of the current procedure</span></span>
-<span id="cb192-4"><a href="#cb192-4"></a>  <span class="cf">begin</span> try</span>
-<span id="cb192-5"><a href="#cb192-5"></a>    <span class="co">-- your code</span></span>
-<span id="cb192-6"><a href="#cb192-6"></a>    release <span class="kw">savepoint</span> @proc;</span>
-<span id="cb192-7"><a href="#cb192-7"></a>  <span class="cf">end</span> try;</span>
-<span id="cb192-8"><a href="#cb192-8"></a>  <span class="cf">begin</span> catch</span>
-<span id="cb192-9"><a href="#cb192-9"></a>    <span class="kw">rollback</span> <span class="kw">transaction</span> <span class="kw">to</span> <span class="kw">savepoint</span> @proc;</span>
-<span id="cb192-10"><a href="#cb192-10"></a>    release <span class="kw">savepoint</span> @proc;</span>
-<span id="cb192-11"><a href="#cb192-11"></a>    throw;</span>
-<span id="cb192-12"><a href="#cb192-12"></a>  <span class="cf">end</span> catch;</span>
-<span id="cb192-13"><a href="#cb192-13"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb192"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb192-1"><a href="#cb192-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> foo()</span>
+<span id="cb192-2"><a href="#cb192-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb192-3"><a href="#cb192-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">savepoint</span> @proc;  <span class="co">-- @proc is always the name of the current procedure</span></span>
+<span id="cb192-4"><a href="#cb192-4" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span> try</span>
+<span id="cb192-5"><a href="#cb192-5" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- your code</span></span>
+<span id="cb192-6"><a href="#cb192-6" aria-hidden="true" tabindex="-1"></a>    release <span class="kw">savepoint</span> @proc;</span>
+<span id="cb192-7"><a href="#cb192-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> try;</span>
+<span id="cb192-8"><a href="#cb192-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">begin</span> catch</span>
+<span id="cb192-9"><a href="#cb192-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">rollback</span> <span class="kw">transaction</span> <span class="kw">to</span> <span class="kw">savepoint</span> @proc;</span>
+<span id="cb192-10"><a href="#cb192-10" aria-hidden="true" tabindex="-1"></a>    release <span class="kw">savepoint</span> @proc;</span>
+<span id="cb192-11"><a href="#cb192-11" aria-hidden="true" tabindex="-1"></a>    throw;</span>
+<span id="cb192-12"><a href="#cb192-12" aria-hidden="true" tabindex="-1"></a>  <span class="cf">end</span> catch;</span>
+<span id="cb192-13"><a href="#cb192-13" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This form is not quite syntatic sugar because there are some interesting rules:</p>
 <ul>
 <li>the <code>proc savepoint</code> form must be used at the top level of the procedure hence no <code>leave</code> or <code>continue</code> may escape it</li>
@@ -2974,14 +3106,14 @@ if (C_._has_row_) cql_bytebuf_append(&amp;_rows_, (const void *)&amp;C_, sizeof(
 </ul>
 <h4 id="the-rollback-return-statement">The <code>ROLLBACK RETURN</code> Statement</h4>
 <p>This form may be used only inside of a <code>proc savepoint</code> block. It indicates that the savepoint should be rolled back and then the procedure should return. It is exactly equivalent to:</p>
-<div class="sourceCode" id="cb193"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb193-1"><a href="#cb193-1"></a>  <span class="kw">rollback</span> <span class="kw">transaction</span> <span class="kw">to</span> <span class="kw">savepoint</span> @proc;</span>
-<span id="cb193-2"><a href="#cb193-2"></a>  release <span class="kw">savepoint</span> @proc;</span>
-<span id="cb193-3"><a href="#cb193-3"></a>  <span class="kw">return</span>; <span class="co">-- wouldn&#39;t actually be allowed inside of proc savepoint, see note below</span></span></code></pre></div>
+<div class="sourceCode" id="cb193"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb193-1"><a href="#cb193-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">rollback</span> <span class="kw">transaction</span> <span class="kw">to</span> <span class="kw">savepoint</span> @proc;</span>
+<span id="cb193-2"><a href="#cb193-2" aria-hidden="true" tabindex="-1"></a>  release <span class="kw">savepoint</span> @proc;</span>
+<span id="cb193-3"><a href="#cb193-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">return</span>; <span class="co">-- wouldn&#39;t actually be allowed inside of proc savepoint, see note below</span></span></code></pre></div>
 <p>Note: to avoid errors, the loose <code>return</code> above is not actually allowed inside of <code>proc savepoint</code> you must use <code>rollback return</code> or <code>commit return</code>.</p>
 <h4 id="the-commit-return-statement">The <code>COMMIT RETURN</code> Statement</h4>
 <p>This form may be used only inside of a <code>proc savepoint</code> block. It indicates that the savepoint should be released and then the procedure should return. It is exactly equivalent to:</p>
-<div class="sourceCode" id="cb194"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb194-1"><a href="#cb194-1"></a>  release <span class="kw">savepoint</span> @proc;</span>
-<span id="cb194-2"><a href="#cb194-2"></a>  <span class="kw">return</span>; <span class="co">-- wouldn&#39;t actually be allowed inside of proc savepoint, see note below</span></span></code></pre></div>
+<div class="sourceCode" id="cb194"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb194-1"><a href="#cb194-1" aria-hidden="true" tabindex="-1"></a>  release <span class="kw">savepoint</span> @proc;</span>
+<span id="cb194-2"><a href="#cb194-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">return</span>; <span class="co">-- wouldn&#39;t actually be allowed inside of proc savepoint, see note below</span></span></code></pre></div>
 <p>Of course this isn’t exactly a commit, in that there might be an outer savepoint or outer transaction that might still be rolled back but it is commited at its level of nesting if you will. Or, equivalently, you can think of it as merging the savepoint into the transaction in flight.</p>
 <p>Note: to avoid errors, the loose <code>return</code> above is not actually allowed inside of <code>proc savepoint</code> you must use <code>rollback return</code> or <code>commit return</code>.</p>
 <h4 id="the-create-virtual-table-statement">The <code>CREATE VIRTUAL TABLE</code> Statement</h4>
@@ -2991,10 +3123,10 @@ if (C_._has_row_) cql_bytebuf_append(&amp;_rows_, (const void *)&amp;C_, sizeof(
 <li>the arguments do not necessarily say anything about the table’s schema at all</li>
 </ul>
 <p>So the CQL form departs from the standard syntax to this form:</p>
-<div class="sourceCode" id="cb195"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb195-1"><a href="#cb195-1"></a><span class="kw">create</span> virtual <span class="kw">table</span> virt_table <span class="kw">using</span> my_module [(module arguments)]  <span class="kw">as</span> (</span>
-<span id="cb195-2"><a href="#cb195-2"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb195-3"><a href="#cb195-3"></a>  name text</span>
-<span id="cb195-4"><a href="#cb195-4"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb195"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb195-1"><a href="#cb195-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> virtual <span class="kw">table</span> virt_table <span class="kw">using</span> my_module [(module arguments)]  <span class="kw">as</span> (</span>
+<span id="cb195-2"><a href="#cb195-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb195-3"><a href="#cb195-3" aria-hidden="true" tabindex="-1"></a>  name text</span>
+<span id="cb195-4"><a href="#cb195-4" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>The part after the <code>AS</code> is used by CQL as a table declaration for the virtual table. The grammar for that is exactly the same as a normal <code>CREATE TABLE</code> statement. However that part is not transmitted to SQLite; when the table is created, SQLite sees only the part it cares about, the part before the <code>AS</code>.</p>
 <p>In order to have strict parsing rules, the module arguments follow one of these forms:</p>
 <ol type="1">
@@ -3003,12 +3135,12 @@ if (C_._has_row_) cql_bytebuf_append(&amp;_rows_, (const void *)&amp;C_, sizeof(
 <li>the words <code>arguments following</code></li>
 </ol>
 <h5 id="case-1-example">Case 1 Example</h5>
-<div class="sourceCode" id="cb196"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb196-1"><a href="#cb196-1"></a><span class="kw">create</span> virtual <span class="kw">table</span> virt_table <span class="kw">using</span> my_module <span class="kw">as</span> (</span>
-<span id="cb196-2"><a href="#cb196-2"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb196-3"><a href="#cb196-3"></a>  name text</span>
-<span id="cb196-4"><a href="#cb196-4"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb196"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb196-1"><a href="#cb196-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> virtual <span class="kw">table</span> virt_table <span class="kw">using</span> my_module <span class="kw">as</span> (</span>
+<span id="cb196-2"><a href="#cb196-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb196-3"><a href="#cb196-3" aria-hidden="true" tabindex="-1"></a>  name text</span>
+<span id="cb196-4"><a href="#cb196-4" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>becomes (to SQLite)</p>
-<div class="sourceCode" id="cb197"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb197-1"><a href="#cb197-1"></a><span class="kw">CREATE</span> VIRTUAL <span class="kw">TABLE</span> virt_table <span class="kw">USING</span> my_module;</span></code></pre></div>
+<div class="sourceCode" id="cb197"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb197-1"><a href="#cb197-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> VIRTUAL <span class="kw">TABLE</span> virt_table <span class="kw">USING</span> my_module;</span></code></pre></div>
 <p>Note: empty arguments <code>USING my_module()</code> are not allowed in the SQLite docs but do seem to work in SQLite. We take the position that no args should be done with no parens, at least for now.</p>
 <h5 id="case-2-example">Case 2 Example</h5>
 <pre><code>create virtual table virt_table using my_module(foo, &#39;goo&#39;, (1.5, (bar, baz))) as (
@@ -3411,197 +3543,197 @@ end;</code></pre>
 <p>With just those annotations you can automatically create the following upgrade script which is itself CQL (and hence has to be compiled). This code is totally readable!</p>
 <p>I’ve split the script into logical pieces to explain what’s going on.</p>
 <h4 id="preamble">Preamble</h4>
-<div class="sourceCode" id="cb208"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb208-1"><a href="#cb208-1"></a><span class="co">-- ...copyright notice... possibly generated source tag... elided to avoid confusion</span></span>
-<span id="cb208-2"><a href="#cb208-2"></a></span>
-<span id="cb208-3"><a href="#cb208-3"></a><span class="co">-- no columns will be considered hidden in this script</span></span>
-<span id="cb208-4"><a href="#cb208-4"></a><span class="co">-- DDL in procs will not count as declarations</span></span>
-<span id="cb208-5"><a href="#cb208-5"></a><span class="ot">@SCHEMA_UPGRADE_SCRIPT;</span></span></code></pre></div>
+<div class="sourceCode" id="cb208"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb208-1"><a href="#cb208-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- ...copyright notice... possibly generated source tag... elided to avoid confusion</span></span>
+<span id="cb208-2"><a href="#cb208-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb208-3"><a href="#cb208-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- no columns will be considered hidden in this script</span></span>
+<span id="cb208-4"><a href="#cb208-4" aria-hidden="true" tabindex="-1"></a><span class="co">-- DDL in procs will not count as declarations</span></span>
+<span id="cb208-5"><a href="#cb208-5" aria-hidden="true" tabindex="-1"></a><span class="ot">@SCHEMA_UPGRADE_SCRIPT;</span></span></code></pre></div>
 <p>Schema upgrade scripts need to see all the columns even the ones that would be logically deleted in normal mode. This is so that things like <code>alter table add column</code> can refer to real columns and <code>drop table</code> can refer to a table that shouldn’t even be visible. Remember in CQL the declarations tell you the logical state of the universe and DLL mutations are expected to create that condition, so you should be dropping tables that are marked with <code>@delete</code> CQL stores the current state of the universe in this table.</p>
-<div class="sourceCode" id="cb209"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb209-1"><a href="#cb209-1"></a><span class="co">-- schema crc -7714030317354747478</span></span></code></pre></div>
+<div class="sourceCode" id="cb209"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb209-1"><a href="#cb209-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- schema crc -7714030317354747478</span></span></code></pre></div>
 <p>The schema crc is computed by hashing all the schema declarations in canonical form. That’s everything in this next section.</p>
 <h4 id="declaration-section">Declaration Section</h4>
 <p>Wherein all the necessary objects are declared…</p>
-<div class="sourceCode" id="cb210"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb210-1"><a href="#cb210-1"></a><span class="co">-- declare sqlite_master -- </span></span>
-<span id="cb210-2"><a href="#cb210-2"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> sqlite_master (</span>
-<span id="cb210-3"><a href="#cb210-3"></a>  <span class="kw">type</span> TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb210-4"><a href="#cb210-4"></a>  name TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb210-5"><a href="#cb210-5"></a>  tbl_name TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb210-6"><a href="#cb210-6"></a>  rootpage <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb210-7"><a href="#cb210-7"></a>  sql TEXT <span class="kw">NOT</span> <span class="kw">NULL</span></span>
-<span id="cb210-8"><a href="#cb210-8"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb210"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb210-1"><a href="#cb210-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- declare sqlite_master -- </span></span>
+<span id="cb210-2"><a href="#cb210-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> sqlite_master (</span>
+<span id="cb210-3"><a href="#cb210-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">type</span> TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb210-4"><a href="#cb210-4" aria-hidden="true" tabindex="-1"></a>  name TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb210-5"><a href="#cb210-5" aria-hidden="true" tabindex="-1"></a>  tbl_name TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb210-6"><a href="#cb210-6" aria-hidden="true" tabindex="-1"></a>  rootpage <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb210-7"><a href="#cb210-7" aria-hidden="true" tabindex="-1"></a>  sql TEXT <span class="kw">NOT</span> <span class="kw">NULL</span></span>
+<span id="cb210-8"><a href="#cb210-8" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>The <code>sqlite_master</code> table is built-in but it has to be introduced to CQL so that we can query it. Like all the other loose DDL declarations here there is no code generated for this. We are simply declaring tables. To create code you have to put the DDL in a proc. Normally DDL in procs also declares the table but since we may need the original version of a table created and the final version declared we have <code>@schema_upgrade_script</code> to help avoid name conflicts.</p>
-<div class="sourceCode" id="cb211"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb211-1"><a href="#cb211-1"></a><span class="co">-- declare full schema of tables and views to be upgraded -- </span></span>
-<span id="cb211-2"><a href="#cb211-2"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> foo(</span>
-<span id="cb211-3"><a href="#cb211-3"></a>  <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb211-4"><a href="#cb211-4"></a>  rate <span class="dt">LONG</span> <span class="dt">INT</span> @DELETE(<span class="dv">5</span>),</span>
-<span id="cb211-5"><a href="#cb211-5"></a>  rate_2 <span class="dt">LONG</span> <span class="dt">INT</span> @DELETE(<span class="dv">4</span>, DeleteRate2Proc),</span>
-<span id="cb211-6"><a href="#cb211-6"></a>  id2 <span class="dt">INTEGER</span> <span class="kw">DEFAULT</span> <span class="dv">12345</span> @CREATE(<span class="dv">4</span>, CreateId2Proc),</span>
-<span id="cb211-7"><a href="#cb211-7"></a>  name TEXT @CREATE(<span class="dv">5</span>),</span>
-<span id="cb211-8"><a href="#cb211-8"></a>  name_2 TEXT @CREATE(<span class="dv">6</span>)</span>
-<span id="cb211-9"><a href="#cb211-9"></a>);</span>
-<span id="cb211-10"><a href="#cb211-10"></a></span>
-<span id="cb211-11"><a href="#cb211-11"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> table2(</span>
-<span id="cb211-12"><a href="#cb211-12"></a>  <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb211-13"><a href="#cb211-13"></a>  name1 TEXT @CREATE(<span class="dv">2</span>, CreateName1Proc),</span>
-<span id="cb211-14"><a href="#cb211-14"></a>  name2 TEXT @CREATE(<span class="dv">2</span>, CreateName2Proc),</span>
-<span id="cb211-15"><a href="#cb211-15"></a>  name3 TEXT @CREATE(<span class="dv">2</span>),</span>
-<span id="cb211-16"><a href="#cb211-16"></a>  name4 TEXT @CREATE(<span class="dv">2</span>)</span>
-<span id="cb211-17"><a href="#cb211-17"></a>);</span>
-<span id="cb211-18"><a href="#cb211-18"></a></span>
-<span id="cb211-19"><a href="#cb211-19"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> added_table(</span>
-<span id="cb211-20"><a href="#cb211-20"></a>  <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb211-21"><a href="#cb211-21"></a>  name1 TEXT,</span>
-<span id="cb211-22"><a href="#cb211-22"></a>  name2 TEXT @CREATE(<span class="dv">4</span>)</span>
-<span id="cb211-23"><a href="#cb211-23"></a>) @CREATE(<span class="dv">3</span>) @DELETE(<span class="dv">5</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb211"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb211-1"><a href="#cb211-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- declare full schema of tables and views to be upgraded -- </span></span>
+<span id="cb211-2"><a href="#cb211-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> foo(</span>
+<span id="cb211-3"><a href="#cb211-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb211-4"><a href="#cb211-4" aria-hidden="true" tabindex="-1"></a>  rate <span class="dt">LONG</span> <span class="dt">INT</span> @DELETE(<span class="dv">5</span>),</span>
+<span id="cb211-5"><a href="#cb211-5" aria-hidden="true" tabindex="-1"></a>  rate_2 <span class="dt">LONG</span> <span class="dt">INT</span> @DELETE(<span class="dv">4</span>, DeleteRate2Proc),</span>
+<span id="cb211-6"><a href="#cb211-6" aria-hidden="true" tabindex="-1"></a>  id2 <span class="dt">INTEGER</span> <span class="kw">DEFAULT</span> <span class="dv">12345</span> @CREATE(<span class="dv">4</span>, CreateId2Proc),</span>
+<span id="cb211-7"><a href="#cb211-7" aria-hidden="true" tabindex="-1"></a>  name TEXT @CREATE(<span class="dv">5</span>),</span>
+<span id="cb211-8"><a href="#cb211-8" aria-hidden="true" tabindex="-1"></a>  name_2 TEXT @CREATE(<span class="dv">6</span>)</span>
+<span id="cb211-9"><a href="#cb211-9" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb211-10"><a href="#cb211-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb211-11"><a href="#cb211-11" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> table2(</span>
+<span id="cb211-12"><a href="#cb211-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb211-13"><a href="#cb211-13" aria-hidden="true" tabindex="-1"></a>  name1 TEXT @CREATE(<span class="dv">2</span>, CreateName1Proc),</span>
+<span id="cb211-14"><a href="#cb211-14" aria-hidden="true" tabindex="-1"></a>  name2 TEXT @CREATE(<span class="dv">2</span>, CreateName2Proc),</span>
+<span id="cb211-15"><a href="#cb211-15" aria-hidden="true" tabindex="-1"></a>  name3 TEXT @CREATE(<span class="dv">2</span>),</span>
+<span id="cb211-16"><a href="#cb211-16" aria-hidden="true" tabindex="-1"></a>  name4 TEXT @CREATE(<span class="dv">2</span>)</span>
+<span id="cb211-17"><a href="#cb211-17" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb211-18"><a href="#cb211-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb211-19"><a href="#cb211-19" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> added_table(</span>
+<span id="cb211-20"><a href="#cb211-20" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb211-21"><a href="#cb211-21" aria-hidden="true" tabindex="-1"></a>  name1 TEXT,</span>
+<span id="cb211-22"><a href="#cb211-22" aria-hidden="true" tabindex="-1"></a>  name2 TEXT @CREATE(<span class="dv">4</span>)</span>
+<span id="cb211-23"><a href="#cb211-23" aria-hidden="true" tabindex="-1"></a>) @CREATE(<span class="dv">3</span>) @DELETE(<span class="dv">5</span>);</span></code></pre></div>
 <p>NOTE: all the tables are emitted including all the annotations. This lets us do the maximum validation when we compile this script.</p>
-<div class="sourceCode" id="cb212"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb212-1"><a href="#cb212-1"></a><span class="kw">CREATE</span> <span class="kw">VIEW</span> live_view <span class="kw">AS</span></span>
-<span id="cb212-2"><a href="#cb212-2"></a><span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb212-3"><a href="#cb212-3"></a>  <span class="kw">FROM</span> foo;</span>
-<span id="cb212-4"><a href="#cb212-4"></a></span>
-<span id="cb212-5"><a href="#cb212-5"></a><span class="kw">CREATE</span> <span class="kw">VIEW</span> another_live_view <span class="kw">AS</span></span>
-<span id="cb212-6"><a href="#cb212-6"></a><span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb212-7"><a href="#cb212-7"></a>  <span class="kw">FROM</span> foo;</span>
-<span id="cb212-8"><a href="#cb212-8"></a></span>
-<span id="cb212-9"><a href="#cb212-9"></a><span class="kw">CREATE</span> <span class="kw">VIEW</span> dead_view <span class="kw">AS</span></span>
-<span id="cb212-10"><a href="#cb212-10"></a><span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb212-11"><a href="#cb212-11"></a>  <span class="kw">FROM</span> foo @DELETE(<span class="dv">2</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb212"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb212-1"><a href="#cb212-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">VIEW</span> live_view <span class="kw">AS</span></span>
+<span id="cb212-2"><a href="#cb212-2" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb212-3"><a href="#cb212-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">FROM</span> foo;</span>
+<span id="cb212-4"><a href="#cb212-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb212-5"><a href="#cb212-5" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">VIEW</span> another_live_view <span class="kw">AS</span></span>
+<span id="cb212-6"><a href="#cb212-6" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb212-7"><a href="#cb212-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">FROM</span> foo;</span>
+<span id="cb212-8"><a href="#cb212-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb212-9"><a href="#cb212-9" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">VIEW</span> dead_view <span class="kw">AS</span></span>
+<span id="cb212-10"><a href="#cb212-10" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb212-11"><a href="#cb212-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">FROM</span> foo @DELETE(<span class="dv">2</span>);</span></code></pre></div>
 <p>These view declarations do very little. We only need the view names so we can legally drop the views. We create the views elsewhere.</p>
-<div class="sourceCode" id="cb213"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb213-1"><a href="#cb213-1"></a><span class="kw">CREATE</span> <span class="kw">INDEX</span> index_still_present <span class="kw">ON</span> table2 (name1, name2);</span>
-<span id="cb213-2"><a href="#cb213-2"></a><span class="kw">CREATE</span> <span class="kw">INDEX</span> index_going_away <span class="kw">ON</span> table2 (name3) @DELETE(<span class="dv">3</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb213"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb213-1"><a href="#cb213-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">INDEX</span> index_still_present <span class="kw">ON</span> table2 (name1, name2);</span>
+<span id="cb213-2"><a href="#cb213-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">INDEX</span> index_going_away <span class="kw">ON</span> table2 (name3) @DELETE(<span class="dv">3</span>);</span></code></pre></div>
 <p>Just like views, these declarations introduce the index names and nothing else.</p>
-<div class="sourceCode" id="cb214"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb214-1"><a href="#cb214-1"></a><span class="kw">CREATE</span> <span class="kw">TRIGGER</span> trigger_one</span>
-<span id="cb214-2"><a href="#cb214-2"></a>  <span class="kw">AFTER</span> <span class="kw">INSERT</span> <span class="kw">ON</span> foo</span>
-<span id="cb214-3"><a href="#cb214-3"></a><span class="cf">BEGIN</span></span>
-<span id="cb214-4"><a href="#cb214-4"></a><span class="kw">DELETE</span> <span class="kw">FROM</span> table2 <span class="kw">WHERE</span> table2.<span class="kw">id</span> <span class="op">=</span> <span class="kw">new</span>.<span class="kw">id</span>;</span>
-<span id="cb214-5"><a href="#cb214-5"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb214"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb214-1"><a href="#cb214-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TRIGGER</span> trigger_one</span>
+<span id="cb214-2"><a href="#cb214-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">AFTER</span> <span class="kw">INSERT</span> <span class="kw">ON</span> foo</span>
+<span id="cb214-3"><a href="#cb214-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb214-4"><a href="#cb214-4" aria-hidden="true" tabindex="-1"></a><span class="kw">DELETE</span> <span class="kw">FROM</span> table2 <span class="kw">WHERE</span> table2.<span class="kw">id</span> <span class="op">=</span> <span class="kw">new</span>.<span class="kw">id</span>;</span>
+<span id="cb214-5"><a href="#cb214-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>We have only the one trigger, we declare it here.</p>
-<div class="sourceCode" id="cb215"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb215-1"><a href="#cb215-1"></a><span class="co">-- facets table declaration --</span></span>
-<span id="cb215-2"><a href="#cb215-2"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> test_cql_schema_facets(</span>
-<span id="cb215-3"><a href="#cb215-3"></a>  facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
-<span id="cb215-4"><a href="#cb215-4"></a>  version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
-<span id="cb215-5"><a href="#cb215-5"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb215"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb215-1"><a href="#cb215-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- facets table declaration --</span></span>
+<span id="cb215-2"><a href="#cb215-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> test_cql_schema_facets(</span>
+<span id="cb215-3"><a href="#cb215-3" aria-hidden="true" tabindex="-1"></a>  facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
+<span id="cb215-4"><a href="#cb215-4" aria-hidden="true" tabindex="-1"></a>  version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
+<span id="cb215-5"><a href="#cb215-5" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>This is where we will store everything we know about the current state of the schema. Below we define a few helper procs for reading and writing that table and reading <code>sqlite_master</code></p>
-<div class="sourceCode" id="cb216"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb216-1"><a href="#cb216-1"></a><span class="co">-- saved facets table declaration --</span></span>
-<span id="cb216-2"><a href="#cb216-2"></a><span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_cql_schema_facets_saved(</span>
-<span id="cb216-3"><a href="#cb216-3"></a>  facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
-<span id="cb216-4"><a href="#cb216-4"></a>  version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
-<span id="cb216-5"><a href="#cb216-5"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb216"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb216-1"><a href="#cb216-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- saved facets table declaration --</span></span>
+<span id="cb216-2"><a href="#cb216-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_cql_schema_facets_saved(</span>
+<span id="cb216-3"><a href="#cb216-3" aria-hidden="true" tabindex="-1"></a>  facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
+<span id="cb216-4"><a href="#cb216-4" aria-hidden="true" tabindex="-1"></a>  version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
+<span id="cb216-5"><a href="#cb216-5" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>We will snapshot the facets table at the start of the run so that we can produce a summary of the changes at the end of the run. This table will hold that snapshot.</p>
 <p>NOTE: the prefix “test” was specified when this file was built so all the methods and tables begin with <code>test_</code>.</p>
 <h4 id="helper-procedures">Helper Procedures</h4>
-<div class="sourceCode" id="cb217"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb217-1"><a href="#cb217-1"></a><span class="co">-- helper proc for testing for the presence of a column/type</span></span>
-<span id="cb217-2"><a href="#cb217-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_check_column_exists(table_name TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb217-3"><a href="#cb217-3"></a>                                          decl TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb217-4"><a href="#cb217-4"></a>                                          <span class="kw">OUT</span> <span class="kw">present</span> BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb217-5"><a href="#cb217-5"></a><span class="cf">BEGIN</span></span>
-<span id="cb217-6"><a href="#cb217-6"></a>  <span class="kw">SET</span> <span class="kw">present</span> <span class="op">:=</span> (<span class="kw">SELECT</span> <span class="kw">EXISTS</span>(<span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> sqlite_master </span>
-<span id="cb217-7"><a href="#cb217-7"></a>                  <span class="kw">WHERE</span> tbl_name <span class="op">=</span> table_name <span class="kw">AND</span> sql GLOB decl));</span>
-<span id="cb217-8"><a href="#cb217-8"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb217"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb217-1"><a href="#cb217-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for testing for the presence of a column/type</span></span>
+<span id="cb217-2"><a href="#cb217-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_check_column_exists(table_name TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb217-3"><a href="#cb217-3" aria-hidden="true" tabindex="-1"></a>                                          decl TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb217-4"><a href="#cb217-4" aria-hidden="true" tabindex="-1"></a>                                          <span class="kw">OUT</span> <span class="kw">present</span> BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb217-5"><a href="#cb217-5" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb217-6"><a href="#cb217-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> <span class="kw">present</span> <span class="op">:=</span> (<span class="kw">SELECT</span> <span class="kw">EXISTS</span>(<span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> sqlite_master </span>
+<span id="cb217-7"><a href="#cb217-7" aria-hidden="true" tabindex="-1"></a>                  <span class="kw">WHERE</span> tbl_name <span class="op">=</span> table_name <span class="kw">AND</span> sql GLOB decl));</span>
+<span id="cb217-8"><a href="#cb217-8" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p><code>check_column_exists</code> inspects <code>sqlite_master</code> and returns true if a column matching <code>decl</code> exists.</p>
-<div class="sourceCode" id="cb218"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb218-1"><a href="#cb218-1"></a><span class="co">-- helper proc for creating the schema version table</span></span>
-<span id="cb218-2"><a href="#cb218-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_create_cql_schema_facets_if_needed()</span>
-<span id="cb218-3"><a href="#cb218-3"></a><span class="cf">BEGIN</span></span>
-<span id="cb218-4"><a href="#cb218-4"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> test_cql_schema_facets(</span>
-<span id="cb218-5"><a href="#cb218-5"></a>    facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
-<span id="cb218-6"><a href="#cb218-6"></a>    version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
-<span id="cb218-7"><a href="#cb218-7"></a>  );</span>
-<span id="cb218-8"><a href="#cb218-8"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb218"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb218-1"><a href="#cb218-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for creating the schema version table</span></span>
+<span id="cb218-2"><a href="#cb218-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_create_cql_schema_facets_if_needed()</span>
+<span id="cb218-3"><a href="#cb218-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb218-4"><a href="#cb218-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> test_cql_schema_facets(</span>
+<span id="cb218-5"><a href="#cb218-5" aria-hidden="true" tabindex="-1"></a>    facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
+<span id="cb218-6"><a href="#cb218-6" aria-hidden="true" tabindex="-1"></a>    version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
+<span id="cb218-7"><a href="#cb218-7" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb218-8"><a href="#cb218-8" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Here we actually create the <code>cql_schema_facets</code> table with DDL inside a proc. In a non-schema-upgrade script the above would give a name conflict.</p>
-<div class="sourceCode" id="cb219"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb219-1"><a href="#cb219-1"></a><span class="co">-- helper proc for saving the schema version table</span></span>
-<span id="cb219-2"><a href="#cb219-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_save_cql_schema_facets()</span>
-<span id="cb219-3"><a href="#cb219-3"></a><span class="cf">BEGIN</span></span>
-<span id="cb219-4"><a href="#cb219-4"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> test_cql_schema_facets_saved;</span>
-<span id="cb219-5"><a href="#cb219-5"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_cql_schema_facets_saved(</span>
-<span id="cb219-6"><a href="#cb219-6"></a>    facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
-<span id="cb219-7"><a href="#cb219-7"></a>    version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
-<span id="cb219-8"><a href="#cb219-8"></a>  );</span>
-<span id="cb219-9"><a href="#cb219-9"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> test_cql_schema_facets_saved</span>
-<span id="cb219-10"><a href="#cb219-10"></a>    <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> test_cql_schema_facets;</span>
-<span id="cb219-11"><a href="#cb219-11"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb219"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb219-1"><a href="#cb219-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for saving the schema version table</span></span>
+<span id="cb219-2"><a href="#cb219-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_save_cql_schema_facets()</span>
+<span id="cb219-3"><a href="#cb219-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb219-4"><a href="#cb219-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> test_cql_schema_facets_saved;</span>
+<span id="cb219-5"><a href="#cb219-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_cql_schema_facets_saved(</span>
+<span id="cb219-6"><a href="#cb219-6" aria-hidden="true" tabindex="-1"></a>    facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
+<span id="cb219-7"><a href="#cb219-7" aria-hidden="true" tabindex="-1"></a>    version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
+<span id="cb219-8"><a href="#cb219-8" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb219-9"><a href="#cb219-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> test_cql_schema_facets_saved</span>
+<span id="cb219-10"><a href="#cb219-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> test_cql_schema_facets;</span>
+<span id="cb219-11"><a href="#cb219-11" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>The <code>save_sql_schema_facets</code> procedure simply makes a snapshot of the current facets table. Later we use this snapshot to report the differences by joining these tables.</p>
-<div class="sourceCode" id="cb220"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb220-1"><a href="#cb220-1"></a><span class="co">-- helper proc for setting the schema version of a facet</span></span>
-<span id="cb220-2"><a href="#cb220-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_set_facet_version(_facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb220-3"><a href="#cb220-3"></a>                                            _version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb220-4"><a href="#cb220-4"></a><span class="cf">BEGIN</span></span>
-<span id="cb220-5"><a href="#cb220-5"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> <span class="kw">REPLACE</span> <span class="kw">INTO</span> test_cql_schema_facets (facet, version) </span>
-<span id="cb220-6"><a href="#cb220-6"></a>       <span class="kw">VALUES</span>(_facet, _version);</span>
-<span id="cb220-7"><a href="#cb220-7"></a><span class="cf">END</span>;</span>
-<span id="cb220-8"><a href="#cb220-8"></a></span>
-<span id="cb220-9"><a href="#cb220-9"></a><span class="co">-- helper proc for getting the schema version of a facet</span></span>
-<span id="cb220-10"><a href="#cb220-10"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_get_facet_version(_facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb220-11"><a href="#cb220-11"></a>                                            <span class="kw">out</span> _version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb220-12"><a href="#cb220-12"></a><span class="cf">BEGIN</span></span>
-<span id="cb220-13"><a href="#cb220-13"></a>  <span class="cf">BEGIN</span> TRY</span>
-<span id="cb220-14"><a href="#cb220-14"></a>    <span class="kw">SET</span> _version <span class="op">:=</span> (<span class="kw">SELECT</span> version <span class="kw">FROM</span> test_cql_schema_facets </span>
-<span id="cb220-15"><a href="#cb220-15"></a>        <span class="kw">WHERE</span> facet <span class="op">=</span> _facet <span class="kw">LIMIT</span> <span class="dv">1</span>);</span>
-<span id="cb220-16"><a href="#cb220-16"></a>  <span class="cf">END</span> TRY;</span>
-<span id="cb220-17"><a href="#cb220-17"></a>  <span class="cf">BEGIN</span> CATCH</span>
-<span id="cb220-18"><a href="#cb220-18"></a>    <span class="kw">SET</span> _version <span class="op">:=</span> <span class="dv">0</span>;</span>
-<span id="cb220-19"><a href="#cb220-19"></a>  <span class="cf">END</span> CATCH;</span>
-<span id="cb220-20"><a href="#cb220-20"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb220"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb220-1"><a href="#cb220-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for setting the schema version of a facet</span></span>
+<span id="cb220-2"><a href="#cb220-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_set_facet_version(_facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb220-3"><a href="#cb220-3" aria-hidden="true" tabindex="-1"></a>                                            _version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb220-4"><a href="#cb220-4" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb220-5"><a href="#cb220-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> <span class="kw">REPLACE</span> <span class="kw">INTO</span> test_cql_schema_facets (facet, version) </span>
+<span id="cb220-6"><a href="#cb220-6" aria-hidden="true" tabindex="-1"></a>       <span class="kw">VALUES</span>(_facet, _version);</span>
+<span id="cb220-7"><a href="#cb220-7" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb220-8"><a href="#cb220-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb220-9"><a href="#cb220-9" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for getting the schema version of a facet</span></span>
+<span id="cb220-10"><a href="#cb220-10" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_get_facet_version(_facet TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb220-11"><a href="#cb220-11" aria-hidden="true" tabindex="-1"></a>                                            <span class="kw">out</span> _version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb220-12"><a href="#cb220-12" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb220-13"><a href="#cb220-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> TRY</span>
+<span id="cb220-14"><a href="#cb220-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> _version <span class="op">:=</span> (<span class="kw">SELECT</span> version <span class="kw">FROM</span> test_cql_schema_facets </span>
+<span id="cb220-15"><a href="#cb220-15" aria-hidden="true" tabindex="-1"></a>        <span class="kw">WHERE</span> facet <span class="op">=</span> _facet <span class="kw">LIMIT</span> <span class="dv">1</span>);</span>
+<span id="cb220-16"><a href="#cb220-16" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> TRY;</span>
+<span id="cb220-17"><a href="#cb220-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> CATCH</span>
+<span id="cb220-18"><a href="#cb220-18" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> _version <span class="op">:=</span> <span class="dv">0</span>;</span>
+<span id="cb220-19"><a href="#cb220-19" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> CATCH;</span>
+<span id="cb220-20"><a href="#cb220-20" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>The two procs <code>cql_get_facet_version</code> and <code>cql_set_facet_version</code> do just what you would expect. Note the use of <code>try</code> and <code>catch</code> to return a default value if the select fails.</p>
 <p>There are two additional helper procedures that do essentially the same thing using a schema version index. These two methods exist only to avoid unnecessary repeated string literals in the output file which cause bloat.</p>
-<div class="sourceCode" id="cb221"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb221-1"><a href="#cb221-1"></a><span class="co">-- helper proc for getting the schema version CRC for a version index</span></span>
-<span id="cb221-2"><a href="#cb221-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_get_version_crc(_v <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb221-3"><a href="#cb221-3"></a>                                          <span class="kw">out</span> _crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb221-4"><a href="#cb221-4"></a><span class="cf">BEGIN</span></span>
-<span id="cb221-5"><a href="#cb221-5"></a>  <span class="cf">BEGIN</span> TRY</span>
-<span id="cb221-6"><a href="#cb221-6"></a>    <span class="kw">SET</span> _crc <span class="op">:=</span> (<span class="kw">SELECT</span> version <span class="kw">FROM</span> test_cql_schema_facets </span>
-<span id="cb221-7"><a href="#cb221-7"></a>        <span class="kw">WHERE</span> facet <span class="op">=</span> <span class="st">&#39;cql_schema_v&#39;</span><span class="op">||</span>_v <span class="kw">LIMIT</span> <span class="dv">1</span>);</span>
-<span id="cb221-8"><a href="#cb221-8"></a>  <span class="cf">END</span> TRY;</span>
-<span id="cb221-9"><a href="#cb221-9"></a>  <span class="cf">BEGIN</span> CATCH</span>
-<span id="cb221-10"><a href="#cb221-10"></a>    <span class="kw">SET</span> _crc <span class="op">:=</span> <span class="op">-</span><span class="dv">1</span>;</span>
-<span id="cb221-11"><a href="#cb221-11"></a>  <span class="cf">END</span> CATCH;</span>
-<span id="cb221-12"><a href="#cb221-12"></a><span class="cf">END</span>;</span>
-<span id="cb221-13"><a href="#cb221-13"></a></span>
-<span id="cb221-14"><a href="#cb221-14"></a><span class="co">-- helper proc for setting the schema version CRC for a version index</span></span>
-<span id="cb221-15"><a href="#cb221-15"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_set_version_crc(_v <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
-<span id="cb221-16"><a href="#cb221-16"></a>                                          _crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb221-17"><a href="#cb221-17"></a><span class="cf">BEGIN</span></span>
-<span id="cb221-18"><a href="#cb221-18"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> <span class="kw">REPLACE</span> <span class="kw">INTO</span> test_cql_schema_facets (facet, version) </span>
-<span id="cb221-19"><a href="#cb221-19"></a>       <span class="kw">VALUES</span>(<span class="st">&#39;cql_schema_v&#39;</span><span class="op">||</span>_v, _crc);</span>
-<span id="cb221-20"><a href="#cb221-20"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb221"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb221-1"><a href="#cb221-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for getting the schema version CRC for a version index</span></span>
+<span id="cb221-2"><a href="#cb221-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_get_version_crc(_v <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb221-3"><a href="#cb221-3" aria-hidden="true" tabindex="-1"></a>                                          <span class="kw">out</span> _crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb221-4"><a href="#cb221-4" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb221-5"><a href="#cb221-5" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> TRY</span>
+<span id="cb221-6"><a href="#cb221-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> _crc <span class="op">:=</span> (<span class="kw">SELECT</span> version <span class="kw">FROM</span> test_cql_schema_facets </span>
+<span id="cb221-7"><a href="#cb221-7" aria-hidden="true" tabindex="-1"></a>        <span class="kw">WHERE</span> facet <span class="op">=</span> <span class="st">&#39;cql_schema_v&#39;</span><span class="op">||</span>_v <span class="kw">LIMIT</span> <span class="dv">1</span>);</span>
+<span id="cb221-8"><a href="#cb221-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> TRY;</span>
+<span id="cb221-9"><a href="#cb221-9" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span> CATCH</span>
+<span id="cb221-10"><a href="#cb221-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SET</span> _crc <span class="op">:=</span> <span class="op">-</span><span class="dv">1</span>;</span>
+<span id="cb221-11"><a href="#cb221-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> CATCH;</span>
+<span id="cb221-12"><a href="#cb221-12" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb221-13"><a href="#cb221-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb221-14"><a href="#cb221-14" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for setting the schema version CRC for a version index</span></span>
+<span id="cb221-15"><a href="#cb221-15" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_set_version_crc(_v <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, </span>
+<span id="cb221-16"><a href="#cb221-16" aria-hidden="true" tabindex="-1"></a>                                          _crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb221-17"><a href="#cb221-17" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb221-18"><a href="#cb221-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> <span class="kw">REPLACE</span> <span class="kw">INTO</span> test_cql_schema_facets (facet, version) </span>
+<span id="cb221-19"><a href="#cb221-19" aria-hidden="true" tabindex="-1"></a>       <span class="kw">VALUES</span>(<span class="st">&#39;cql_schema_v&#39;</span><span class="op">||</span>_v, _crc);</span>
+<span id="cb221-20"><a href="#cb221-20" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>As you can see, these procedures are effectively specializations of <code>cql_get_facet_version</code> and <code>cql_set_facet_version</code> where the facet name is computed from the integer.</p>
 <p>Triggers require some special processing. There are so-called “legacy” triggers that crept into the system. These begin with <code>tr__</code> and they do not have proper tombstones. In fact some are from early versions of CQL before they were properly tracked. To fix any old databases that have these in them, we delete all triggers that start with <code>tr__</code>. Note we have to use the <code>GLOB</code> operator to do this, because <code>_</code> is the <code>LIKE</code> wildcard.</p>
-<div class="sourceCode" id="cb222"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb222-1"><a href="#cb222-1"></a><span class="co">-- helper proc to reset any triggers that are on the old plan --</span></span>
-<span id="cb222-2"><a href="#cb222-2"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> cql_exec_internal(sql TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb222-3"><a href="#cb222-3"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_legacy_triggers()</span>
-<span id="cb222-4"><a href="#cb222-4"></a><span class="cf">BEGIN</span></span>
-<span id="cb222-5"><a href="#cb222-5"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> name <span class="kw">from</span> sqlite_master</span>
-<span id="cb222-6"><a href="#cb222-6"></a>     <span class="kw">WHERE</span> <span class="kw">type</span> <span class="op">=</span> <span class="st">&#39;trigger&#39;</span> <span class="kw">AND</span> name GLOB <span class="st">&#39;tr__*&#39;</span>;</span>
-<span id="cb222-7"><a href="#cb222-7"></a>  <span class="cf">LOOP</span> FETCH C</span>
-<span id="cb222-8"><a href="#cb222-8"></a>  <span class="cf">BEGIN</span></span>
-<span id="cb222-9"><a href="#cb222-9"></a>    <span class="kw">call</span> cql_exec_internal(printf(<span class="st">&#39;DROP TRIGGER %s;&#39;</span>, C.name));</span>
-<span id="cb222-10"><a href="#cb222-10"></a>  <span class="cf">END</span>;</span>
-<span id="cb222-11"><a href="#cb222-11"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb222"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb222-1"><a href="#cb222-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc to reset any triggers that are on the old plan --</span></span>
+<span id="cb222-2"><a href="#cb222-2" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> <span class="kw">PROCEDURE</span> cql_exec_internal(sql TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>) <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb222-3"><a href="#cb222-3" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_legacy_triggers()</span>
+<span id="cb222-4"><a href="#cb222-4" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb222-5"><a href="#cb222-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> name <span class="kw">from</span> sqlite_master</span>
+<span id="cb222-6"><a href="#cb222-6" aria-hidden="true" tabindex="-1"></a>     <span class="kw">WHERE</span> <span class="kw">type</span> <span class="op">=</span> <span class="st">&#39;trigger&#39;</span> <span class="kw">AND</span> name GLOB <span class="st">&#39;tr__*&#39;</span>;</span>
+<span id="cb222-7"><a href="#cb222-7" aria-hidden="true" tabindex="-1"></a>  <span class="cf">LOOP</span> FETCH C</span>
+<span id="cb222-8"><a href="#cb222-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb222-9"><a href="#cb222-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">call</span> cql_exec_internal(printf(<span class="st">&#39;DROP TRIGGER %s;&#39;</span>, C.name));</span>
+<span id="cb222-10"><a href="#cb222-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb222-11"><a href="#cb222-11" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <h4 id="baseline-schema">Baseline Schema</h4>
 <p>The ‘baseline’ or ‘v0’ schema is unannotated (no <code>@create</code> or <code>@recreate</code>). The first real schema management procedures are for creating and dropping these tables.</p>
-<div class="sourceCode" id="cb223"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb223-1"><a href="#cb223-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_install_baseline_schema()</span>
-<span id="cb223-2"><a href="#cb223-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb223-3"><a href="#cb223-3"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> foo(</span>
-<span id="cb223-4"><a href="#cb223-4"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb223-5"><a href="#cb223-5"></a>    rate LONG_INT,</span>
-<span id="cb223-6"><a href="#cb223-6"></a>    rate_2 LONG_INT</span>
-<span id="cb223-7"><a href="#cb223-7"></a>  );</span>
-<span id="cb223-8"><a href="#cb223-8"></a></span>
-<span id="cb223-9"><a href="#cb223-9"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> table2(</span>
-<span id="cb223-10"><a href="#cb223-10"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
-<span id="cb223-11"><a href="#cb223-11"></a>  );</span>
-<span id="cb223-12"><a href="#cb223-12"></a></span>
-<span id="cb223-13"><a href="#cb223-13"></a><span class="cf">END</span>;</span></code></pre></div>
-<div class="sourceCode" id="cb224"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb224-1"><a href="#cb224-1"></a><span class="co">-- helper proc for dropping baseline tables before installing the baseline schema</span></span>
-<span id="cb224-2"><a href="#cb224-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_baseline_tables()</span>
-<span id="cb224-3"><a href="#cb224-3"></a><span class="cf">BEGIN</span></span>
-<span id="cb224-4"><a href="#cb224-4"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> foo;</span>
-<span id="cb224-5"><a href="#cb224-5"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> table2;</span>
-<span id="cb224-6"><a href="#cb224-6"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb223"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb223-1"><a href="#cb223-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_install_baseline_schema()</span>
+<span id="cb223-2"><a href="#cb223-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb223-3"><a href="#cb223-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> foo(</span>
+<span id="cb223-4"><a href="#cb223-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb223-5"><a href="#cb223-5" aria-hidden="true" tabindex="-1"></a>    rate LONG_INT,</span>
+<span id="cb223-6"><a href="#cb223-6" aria-hidden="true" tabindex="-1"></a>    rate_2 LONG_INT</span>
+<span id="cb223-7"><a href="#cb223-7" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb223-8"><a href="#cb223-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb223-9"><a href="#cb223-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> table2(</span>
+<span id="cb223-10"><a href="#cb223-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span></span>
+<span id="cb223-11"><a href="#cb223-11" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb223-12"><a href="#cb223-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb223-13"><a href="#cb223-13" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb224"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb224-1"><a href="#cb224-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- helper proc for dropping baseline tables before installing the baseline schema</span></span>
+<span id="cb224-2"><a href="#cb224-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_baseline_tables()</span>
+<span id="cb224-3"><a href="#cb224-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb224-4"><a href="#cb224-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> foo;</span>
+<span id="cb224-5"><a href="#cb224-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> table2;</span>
+<span id="cb224-6"><a href="#cb224-6" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <h4 id="migration-procedures">Migration Procedures</h4>
 <p>The next section declares the migration procedures that were in the schema. These are expected to be defined elsewhere.</p>
-<div class="sourceCode" id="cb225"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb225-1"><a href="#cb225-1"></a><span class="co">-- declared upgrade procedures if any</span></span>
-<span id="cb225-2"><a href="#cb225-2"></a><span class="kw">DECLARE</span> proc CreateName1Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb225-3"><a href="#cb225-3"></a><span class="kw">DECLARE</span> proc CreateName2Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb225-4"><a href="#cb225-4"></a><span class="kw">DECLARE</span> proc CreateId2Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
-<span id="cb225-5"><a href="#cb225-5"></a><span class="kw">DECLARE</span> proc DeleteRate2Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb225"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb225-1"><a href="#cb225-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- declared upgrade procedures if any</span></span>
+<span id="cb225-2"><a href="#cb225-2" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> proc CreateName1Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb225-3"><a href="#cb225-3" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> proc CreateName2Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb225-4"><a href="#cb225-4" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> proc CreateId2Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span>
+<span id="cb225-5"><a href="#cb225-5" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> proc DeleteRate2Proc() <span class="kw">USING</span> <span class="kw">TRANSACTION</span>;</span></code></pre></div>
 <p>The code below will refer to these migration procedures. We emit a declaration so that we can use the names in context. NOTE: <code>USING TRANSACTION</code> when applied to a proc declaration simply means the proc will access the database so it needs to be provided with a <code>sqlite3 *db</code> parameter.</p>
 <h4 id="views">Views</h4>
 <pre><code>-- drop all the views we know
@@ -3625,45 +3757,45 @@ END;</code></pre>
 <p>View migration is done by dropping all views and putting all views back.</p>
 <p>NOTE: <code>dead_view</code> was not created, but we did try to drop it if it existed.</p>
 <h4 id="indices">Indices</h4>
-<div class="sourceCode" id="cb227"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb227-1"><a href="#cb227-1"></a><span class="co">-- drop all the indices that are deleted or changing</span></span>
-<span id="cb227-2"><a href="#cb227-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_indices()</span>
-<span id="cb227-3"><a href="#cb227-3"></a><span class="cf">BEGIN</span></span>
-<span id="cb227-4"><a href="#cb227-4"></a>  <span class="kw">DECLARE</span> index_crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
-<span id="cb227-5"><a href="#cb227-5"></a>  <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;index_still_present_index_crc&#39;</span>, index_crc);</span>
-<span id="cb227-6"><a href="#cb227-6"></a>  <span class="cf">IF</span> index_crc <span class="op">&lt;&gt;</span> <span class="op">-</span><span class="dv">6823087563145941851</span> <span class="cf">THEN</span></span>
-<span id="cb227-7"><a href="#cb227-7"></a>    <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> index_still_present;</span>
-<span id="cb227-8"><a href="#cb227-8"></a>  <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb227-9"><a href="#cb227-9"></a>  <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> index_going_away;</span>
-<span id="cb227-10"><a href="#cb227-10"></a><span class="cf">END</span>;</span>
-<span id="cb227-11"><a href="#cb227-11"></a></span>
-<span id="cb227-12"><a href="#cb227-12"></a><span class="co">-- create all the indices we need</span></span>
-<span id="cb227-13"><a href="#cb227-13"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_create_indices()</span>
-<span id="cb227-14"><a href="#cb227-14"></a><span class="cf">BEGIN</span></span>
-<span id="cb227-15"><a href="#cb227-15"></a>  <span class="kw">DECLARE</span> index_crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
-<span id="cb227-16"><a href="#cb227-16"></a>  <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;index_still_present_index_crc&#39;</span>, index_crc);</span>
-<span id="cb227-17"><a href="#cb227-17"></a>  <span class="cf">IF</span> index_crc <span class="op">&lt;&gt;</span> <span class="op">-</span><span class="dv">6823087563145941851</span> <span class="cf">THEN</span></span>
-<span id="cb227-18"><a href="#cb227-18"></a>    <span class="kw">CREATE</span> <span class="kw">INDEX</span> index_still_present <span class="kw">ON</span> table2 (name1, name2);</span>
-<span id="cb227-19"><a href="#cb227-19"></a>    <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;index_still_present_index_crc&#39;</span>, <span class="op">-</span><span class="dv">6823087563145941851</span>);</span>
-<span id="cb227-20"><a href="#cb227-20"></a>  <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb227-21"><a href="#cb227-21"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb227"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb227-1"><a href="#cb227-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- drop all the indices that are deleted or changing</span></span>
+<span id="cb227-2"><a href="#cb227-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_indices()</span>
+<span id="cb227-3"><a href="#cb227-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb227-4"><a href="#cb227-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> index_crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb227-5"><a href="#cb227-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;index_still_present_index_crc&#39;</span>, index_crc);</span>
+<span id="cb227-6"><a href="#cb227-6" aria-hidden="true" tabindex="-1"></a>  <span class="cf">IF</span> index_crc <span class="op">&lt;&gt;</span> <span class="op">-</span><span class="dv">6823087563145941851</span> <span class="cf">THEN</span></span>
+<span id="cb227-7"><a href="#cb227-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> index_still_present;</span>
+<span id="cb227-8"><a href="#cb227-8" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb227-9"><a href="#cb227-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> index_going_away;</span>
+<span id="cb227-10"><a href="#cb227-10" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb227-11"><a href="#cb227-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb227-12"><a href="#cb227-12" aria-hidden="true" tabindex="-1"></a><span class="co">-- create all the indices we need</span></span>
+<span id="cb227-13"><a href="#cb227-13" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_create_indices()</span>
+<span id="cb227-14"><a href="#cb227-14" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb227-15"><a href="#cb227-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> index_crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb227-16"><a href="#cb227-16" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;index_still_present_index_crc&#39;</span>, index_crc);</span>
+<span id="cb227-17"><a href="#cb227-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">IF</span> index_crc <span class="op">&lt;&gt;</span> <span class="op">-</span><span class="dv">6823087563145941851</span> <span class="cf">THEN</span></span>
+<span id="cb227-18"><a href="#cb227-18" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CREATE</span> <span class="kw">INDEX</span> index_still_present <span class="kw">ON</span> table2 (name1, name2);</span>
+<span id="cb227-19"><a href="#cb227-19" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;index_still_present_index_crc&#39;</span>, <span class="op">-</span><span class="dv">6823087563145941851</span>);</span>
+<span id="cb227-20"><a href="#cb227-20" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb227-21"><a href="#cb227-21" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Indices are processed similarly to views, however we do not want to drop indices that are not changing. Therefore we compute the CRC of the index definition. At the start of the script any indices that are condemned (e.g. <code>index_going_away</code>) are dropped as well as any that have a new CRC. At the end of migration, changed or new indices are (re)created using <code>cql_create_indices</code>.</p>
 <h4 id="triggers">Triggers</h4>
-<div class="sourceCode" id="cb228"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb228-1"><a href="#cb228-1"></a><span class="op">-</span> <span class="kw">drop</span> <span class="kw">all</span> <span class="kw">the</span> <span class="kw">triggers</span> we know</span>
-<span id="cb228-2"><a href="#cb228-2"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_all_triggers()</span>
-<span id="cb228-3"><a href="#cb228-3"></a><span class="cf">BEGIN</span></span>
-<span id="cb228-4"><a href="#cb228-4"></a>  <span class="kw">CALL</span> test_cql_drop_legacy_triggers();</span>
-<span id="cb228-5"><a href="#cb228-5"></a>  <span class="kw">DROP</span> <span class="kw">TRIGGER</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> trigger_one;</span>
-<span id="cb228-6"><a href="#cb228-6"></a><span class="cf">END</span>;</span>
-<span id="cb228-7"><a href="#cb228-7"></a></span>
-<span id="cb228-8"><a href="#cb228-8"></a><span class="co">-- create all the triggers we know</span></span>
-<span id="cb228-9"><a href="#cb228-9"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_create_all_triggers()</span>
-<span id="cb228-10"><a href="#cb228-10"></a><span class="cf">BEGIN</span></span>
-<span id="cb228-11"><a href="#cb228-11"></a>  <span class="kw">CREATE</span> <span class="kw">TRIGGER</span> trigger_one</span>
-<span id="cb228-12"><a href="#cb228-12"></a>    <span class="kw">AFTER</span> <span class="kw">INSERT</span> <span class="kw">ON</span> foo</span>
-<span id="cb228-13"><a href="#cb228-13"></a>  <span class="cf">BEGIN</span></span>
-<span id="cb228-14"><a href="#cb228-14"></a>  <span class="kw">DELETE</span> <span class="kw">FROM</span> table2 <span class="kw">WHERE</span> table2.<span class="kw">id</span> <span class="op">=</span> <span class="kw">new</span>.<span class="kw">id</span>;</span>
-<span id="cb228-15"><a href="#cb228-15"></a>  <span class="cf">END</span>;</span>
-<span id="cb228-16"><a href="#cb228-16"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb228"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb228-1"><a href="#cb228-1" aria-hidden="true" tabindex="-1"></a><span class="op">-</span> <span class="kw">drop</span> <span class="kw">all</span> <span class="kw">the</span> <span class="kw">triggers</span> we know</span>
+<span id="cb228-2"><a href="#cb228-2" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_drop_all_triggers()</span>
+<span id="cb228-3"><a href="#cb228-3" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb228-4"><a href="#cb228-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> test_cql_drop_legacy_triggers();</span>
+<span id="cb228-5"><a href="#cb228-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TRIGGER</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> trigger_one;</span>
+<span id="cb228-6"><a href="#cb228-6" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb228-7"><a href="#cb228-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb228-8"><a href="#cb228-8" aria-hidden="true" tabindex="-1"></a><span class="co">-- create all the triggers we know</span></span>
+<span id="cb228-9"><a href="#cb228-9" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_create_all_triggers()</span>
+<span id="cb228-10"><a href="#cb228-10" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb228-11"><a href="#cb228-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">TRIGGER</span> trigger_one</span>
+<span id="cb228-12"><a href="#cb228-12" aria-hidden="true" tabindex="-1"></a>    <span class="kw">AFTER</span> <span class="kw">INSERT</span> <span class="kw">ON</span> foo</span>
+<span id="cb228-13"><a href="#cb228-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb228-14"><a href="#cb228-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DELETE</span> <span class="kw">FROM</span> table2 <span class="kw">WHERE</span> table2.<span class="kw">id</span> <span class="op">=</span> <span class="kw">new</span>.<span class="kw">id</span>;</span>
+<span id="cb228-15"><a href="#cb228-15" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb228-16"><a href="#cb228-16" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Triggers are always dropped before migration begins and are re-instated quite late in the processing as we will see below.</p>
 <h4 id="main-migration-script">Main Migration Script</h4>
 <p>The main script orchestrates everything. There are inline comments for all of it. The general order of events is:</p>
@@ -3673,209 +3805,209 @@ END;</code></pre>
 </ul>
 <p>These operations are done in <code>test_perform_needed_upgrades</code> * drop all views * drop condemned indices * fetch the current schema version * if version 0 then install the baseline schema (see below) * for each schema version with changes do the following: * create any tables that need to be created in this version * add any columns that need to be added in this version * run migration procs in this order: * create table * create column * delete trigger * delete view * delete index * delete column * delete table * drop any tables that need to be dropped in this version * mark schema upgraded to the current version so far, proceed to the next version * each partial step is also marked as completed so it can be skipped if the script is run again * create all the views * (re)create any indices that changed and are not dead * set the schema CRC to the current CRC</p>
 <p>That’s it… the details are below.</p>
-<div class="sourceCode" id="cb229"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb229-1"><a href="#cb229-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_perform_needed_upgrades()</span>
-<span id="cb229-2"><a href="#cb229-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb229-3"><a href="#cb229-3"></a>  <span class="kw">DECLARE</span> column_exists BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
-<span id="cb229-4"><a href="#cb229-4"></a>  <span class="kw">DECLARE</span> facet_version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
-<span id="cb229-5"><a href="#cb229-5"></a>  <span class="kw">DECLARE</span> schema_version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
-<span id="cb229-6"><a href="#cb229-6"></a></span>
-<span id="cb229-7"><a href="#cb229-7"></a>    <span class="co">-- save the current facets so we can diff them later --</span></span>
-<span id="cb229-8"><a href="#cb229-8"></a>    <span class="kw">CALL</span> test_save_cql_schema_facets();</span>
-<span id="cb229-9"><a href="#cb229-9"></a></span>
-<span id="cb229-10"><a href="#cb229-10"></a>    <span class="co">-- dropping all views --</span></span>
-<span id="cb229-11"><a href="#cb229-11"></a>    <span class="kw">CALL</span> test_cql_drop_all_views();</span>
-<span id="cb229-12"><a href="#cb229-12"></a></span>
-<span id="cb229-13"><a href="#cb229-13"></a>    <span class="co">-- dropping condemned or changing indices --</span></span>
-<span id="cb229-14"><a href="#cb229-14"></a>    <span class="kw">CALL</span> test_cql_drop_all_indices();</span>
-<span id="cb229-15"><a href="#cb229-15"></a></span>
-<span id="cb229-16"><a href="#cb229-16"></a>    <span class="co">-- dropping condemned or changing triggers --</span></span>
-<span id="cb229-17"><a href="#cb229-17"></a>    <span class="kw">CALL</span> test_cql_drop_all_triggers();</span>
-<span id="cb229-18"><a href="#cb229-18"></a></span>
-<span id="cb229-19"><a href="#cb229-19"></a>    <span class="co">-- fetch current schema version --</span></span>
-<span id="cb229-20"><a href="#cb229-20"></a>    <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;cql_schema_version&#39;</span>, schema_version);</span>
-<span id="cb229-21"><a href="#cb229-21"></a></span>
-<span id="cb229-22"><a href="#cb229-22"></a>    <span class="co">---- install baseline schema if needed ----</span></span>
-<span id="cb229-23"><a href="#cb229-23"></a></span>
-<span id="cb229-24"><a href="#cb229-24"></a>    <span class="cf">IF</span> schema_version <span class="op">==</span> <span class="op">-</span><span class="dv">1</span> <span class="cf">THEN</span></span>
-<span id="cb229-25"><a href="#cb229-25"></a>      <span class="kw">CALL</span> test_cql_drop_baseline_tables();</span>
-<span id="cb229-26"><a href="#cb229-26"></a>      <span class="kw">CALL</span> test_cql_install_baseline_schema();</span>
-<span id="cb229-27"><a href="#cb229-27"></a>      <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;cql_schema_version&#39;</span>, <span class="dv">0</span>);</span>
-<span id="cb229-28"><a href="#cb229-28"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-29"><a href="#cb229-29"></a></span>
-<span id="cb229-30"><a href="#cb229-30"></a>    <span class="co">---- upgrade to schema version 2 ----</span></span>
-<span id="cb229-31"><a href="#cb229-31"></a></span>
-<span id="cb229-32"><a href="#cb229-32"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">2</span>, schema_version);</span>
-<span id="cb229-33"><a href="#cb229-33"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="dv">5380988243166701961</span> <span class="cf">THEN</span></span>
-<span id="cb229-34"><a href="#cb229-34"></a>      <span class="co">-- altering table table2 to add column name1 TEXT;</span></span>
-<span id="cb229-35"><a href="#cb229-35"></a></span>
-<span id="cb229-36"><a href="#cb229-36"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name1 TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-37"><a href="#cb229-37"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-38"><a href="#cb229-38"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name1 TEXT;</span>
-<span id="cb229-39"><a href="#cb229-39"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-40"><a href="#cb229-40"></a></span>
-<span id="cb229-41"><a href="#cb229-41"></a>      <span class="co">-- altering table table2 to add column name2 TEXT;</span></span>
-<span id="cb229-42"><a href="#cb229-42"></a></span>
-<span id="cb229-43"><a href="#cb229-43"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name2 TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-44"><a href="#cb229-44"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-45"><a href="#cb229-45"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name2 TEXT;</span>
-<span id="cb229-46"><a href="#cb229-46"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-47"><a href="#cb229-47"></a></span>
-<span id="cb229-48"><a href="#cb229-48"></a>      <span class="co">-- altering table table2 to add column name3 TEXT;</span></span>
-<span id="cb229-49"><a href="#cb229-49"></a></span>
-<span id="cb229-50"><a href="#cb229-50"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name3 TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-51"><a href="#cb229-51"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-52"><a href="#cb229-52"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name3 TEXT;</span>
-<span id="cb229-53"><a href="#cb229-53"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-54"><a href="#cb229-54"></a></span>
-<span id="cb229-55"><a href="#cb229-55"></a>      <span class="co">-- altering table table2 to add column name4 TEXT;</span></span>
-<span id="cb229-56"><a href="#cb229-56"></a></span>
-<span id="cb229-57"><a href="#cb229-57"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name4 TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-58"><a href="#cb229-58"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-59"><a href="#cb229-59"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name4 TEXT;</span>
-<span id="cb229-60"><a href="#cb229-60"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-61"><a href="#cb229-61"></a></span>
-<span id="cb229-62"><a href="#cb229-62"></a>      <span class="co">-- data migration procedures</span></span>
-<span id="cb229-63"><a href="#cb229-63"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;CreateName1Proc&#39;</span>, facet_version);</span>
-<span id="cb229-64"><a href="#cb229-64"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
-<span id="cb229-65"><a href="#cb229-65"></a>        <span class="kw">CALL</span> CreateName1Proc();</span>
-<span id="cb229-66"><a href="#cb229-66"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;CreateName1Proc&#39;</span>, <span class="dv">2</span>);</span>
-<span id="cb229-67"><a href="#cb229-67"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-68"><a href="#cb229-68"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;CreateName2Proc&#39;</span>, facet_version);</span>
-<span id="cb229-69"><a href="#cb229-69"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
-<span id="cb229-70"><a href="#cb229-70"></a>        <span class="kw">CALL</span> CreateName2Proc();</span>
-<span id="cb229-71"><a href="#cb229-71"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;CreateName2Proc&#39;</span>, <span class="dv">2</span>);</span>
-<span id="cb229-72"><a href="#cb229-72"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-73"><a href="#cb229-73"></a></span>
-<span id="cb229-74"><a href="#cb229-74"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">2</span>, <span class="dv">5380988243166701961</span>);</span>
-<span id="cb229-75"><a href="#cb229-75"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-76"><a href="#cb229-76"></a></span>
-<span id="cb229-77"><a href="#cb229-77"></a>    <span class="co">---- upgrade to schema version 3 ----</span></span>
-<span id="cb229-78"><a href="#cb229-78"></a></span>
-<span id="cb229-79"><a href="#cb229-79"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">3</span>, schema_version);</span>
-<span id="cb229-80"><a href="#cb229-80"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="op">-</span><span class="dv">1945462407517765645</span> <span class="cf">THEN</span></span>
-<span id="cb229-81"><a href="#cb229-81"></a>      <span class="co">-- creating table added_table</span></span>
-<span id="cb229-82"><a href="#cb229-82"></a></span>
-<span id="cb229-83"><a href="#cb229-83"></a>      <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> added_table(</span>
-<span id="cb229-84"><a href="#cb229-84"></a>        <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb229-85"><a href="#cb229-85"></a>        name1 TEXT</span>
-<span id="cb229-86"><a href="#cb229-86"></a>      );</span>
-<span id="cb229-87"><a href="#cb229-87"></a></span>
-<span id="cb229-88"><a href="#cb229-88"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">3</span>, <span class="op">-</span><span class="dv">1945462407517765645</span>);</span>
-<span id="cb229-89"><a href="#cb229-89"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-90"><a href="#cb229-90"></a></span>
-<span id="cb229-91"><a href="#cb229-91"></a>    <span class="co">---- upgrade to schema version 4 ----</span></span>
-<span id="cb229-92"><a href="#cb229-92"></a></span>
-<span id="cb229-93"><a href="#cb229-93"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">4</span>, schema_version);</span>
-<span id="cb229-94"><a href="#cb229-94"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="op">-</span><span class="dv">4889894059346952297</span> <span class="cf">THEN</span></span>
-<span id="cb229-95"><a href="#cb229-95"></a>      <span class="co">-- altering table added_table to add column name2 TEXT;</span></span>
-<span id="cb229-96"><a href="#cb229-96"></a></span>
-<span id="cb229-97"><a href="#cb229-97"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;added_table&#39;</span>, <span class="st">&#39;*[( ]name2 TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-98"><a href="#cb229-98"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-99"><a href="#cb229-99"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> added_table <span class="kw">ADD</span> <span class="kw">COLUMN</span> name2 TEXT;</span>
-<span id="cb229-100"><a href="#cb229-100"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-101"><a href="#cb229-101"></a></span>
-<span id="cb229-102"><a href="#cb229-102"></a>      <span class="co">-- altering table foo to add column id2 INTEGER;</span></span>
-<span id="cb229-103"><a href="#cb229-103"></a></span>
-<span id="cb229-104"><a href="#cb229-104"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;foo&#39;</span>, <span class="st">&#39;*[( ]id2 INTEGER*&#39;</span>, column_exists);</span>
-<span id="cb229-105"><a href="#cb229-105"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-106"><a href="#cb229-106"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> foo <span class="kw">ADD</span> <span class="kw">COLUMN</span> id2 <span class="dt">INTEGER</span> <span class="kw">DEFAULT</span> <span class="dv">12345</span>;</span>
-<span id="cb229-107"><a href="#cb229-107"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-108"><a href="#cb229-108"></a></span>
-<span id="cb229-109"><a href="#cb229-109"></a>      <span class="co">-- logical delete of column rate_2 from foo; -- no ddl</span></span>
-<span id="cb229-110"><a href="#cb229-110"></a></span>
-<span id="cb229-111"><a href="#cb229-111"></a>      <span class="co">-- data migration procedures</span></span>
-<span id="cb229-112"><a href="#cb229-112"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;CreateId2Proc&#39;</span>, facet_version);</span>
-<span id="cb229-113"><a href="#cb229-113"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
-<span id="cb229-114"><a href="#cb229-114"></a>        <span class="kw">CALL</span> CreateId2Proc();</span>
-<span id="cb229-115"><a href="#cb229-115"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;CreateId2Proc&#39;</span>, <span class="dv">4</span>);</span>
-<span id="cb229-116"><a href="#cb229-116"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-117"><a href="#cb229-117"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;DeleteRate2Proc&#39;</span>, facet_version);</span>
-<span id="cb229-118"><a href="#cb229-118"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
-<span id="cb229-119"><a href="#cb229-119"></a>        <span class="kw">CALL</span> DeleteRate2Proc();</span>
-<span id="cb229-120"><a href="#cb229-120"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;DeleteRate2Proc&#39;</span>, <span class="dv">4</span>);</span>
-<span id="cb229-121"><a href="#cb229-121"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-122"><a href="#cb229-122"></a></span>
-<span id="cb229-123"><a href="#cb229-123"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">4</span>, <span class="op">-</span><span class="dv">4889894059346952297</span>);</span>
-<span id="cb229-124"><a href="#cb229-124"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-125"><a href="#cb229-125"></a></span>
-<span id="cb229-126"><a href="#cb229-126"></a>    <span class="co">---- upgrade to schema version 5 ----</span></span>
-<span id="cb229-127"><a href="#cb229-127"></a></span>
-<span id="cb229-128"><a href="#cb229-128"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">5</span>, schema_version);</span>
-<span id="cb229-129"><a href="#cb229-129"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="dv">5720357430811880771</span> <span class="cf">THEN</span></span>
-<span id="cb229-130"><a href="#cb229-130"></a>      <span class="co">-- altering table foo to add column name TEXT;</span></span>
-<span id="cb229-131"><a href="#cb229-131"></a></span>
-<span id="cb229-132"><a href="#cb229-132"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;foo&#39;</span>, <span class="st">&#39;*[( ]name TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-133"><a href="#cb229-133"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-134"><a href="#cb229-134"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> foo <span class="kw">ADD</span> <span class="kw">COLUMN</span> name TEXT;</span>
-<span id="cb229-135"><a href="#cb229-135"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-136"><a href="#cb229-136"></a></span>
-<span id="cb229-137"><a href="#cb229-137"></a>      <span class="co">-- logical delete of column rate from foo; -- no ddl</span></span>
-<span id="cb229-138"><a href="#cb229-138"></a></span>
-<span id="cb229-139"><a href="#cb229-139"></a>      <span class="co">-- dropping table added_table</span></span>
-<span id="cb229-140"><a href="#cb229-140"></a></span>
-<span id="cb229-141"><a href="#cb229-141"></a>      <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> added_table;</span>
-<span id="cb229-142"><a href="#cb229-142"></a></span>
-<span id="cb229-143"><a href="#cb229-143"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">5</span>, <span class="dv">5720357430811880771</span>);</span>
-<span id="cb229-144"><a href="#cb229-144"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-145"><a href="#cb229-145"></a></span>
-<span id="cb229-146"><a href="#cb229-146"></a>    <span class="co">---- upgrade to schema version 6 ----</span></span>
-<span id="cb229-147"><a href="#cb229-147"></a></span>
-<span id="cb229-148"><a href="#cb229-148"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">6</span>, schema_version);</span>
-<span id="cb229-149"><a href="#cb229-149"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="dv">3572608284749506390</span> <span class="cf">THEN</span></span>
-<span id="cb229-150"><a href="#cb229-150"></a>      <span class="co">-- altering table foo to add column name_2 TEXT;</span></span>
-<span id="cb229-151"><a href="#cb229-151"></a></span>
-<span id="cb229-152"><a href="#cb229-152"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;foo&#39;</span>, <span class="st">&#39;*[( ]name_2 TEXT*&#39;</span>, column_exists);</span>
-<span id="cb229-153"><a href="#cb229-153"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
-<span id="cb229-154"><a href="#cb229-154"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> foo <span class="kw">ADD</span> <span class="kw">COLUMN</span> name_2 TEXT;</span>
-<span id="cb229-155"><a href="#cb229-155"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-156"><a href="#cb229-156"></a></span>
-<span id="cb229-157"><a href="#cb229-157"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">6</span>, <span class="dv">3572608284749506390</span>);</span>
-<span id="cb229-158"><a href="#cb229-158"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb229-159"><a href="#cb229-159"></a></span>
-<span id="cb229-160"><a href="#cb229-160"></a>    <span class="kw">CALL</span> test_cql_create_all_views();</span>
-<span id="cb229-161"><a href="#cb229-161"></a>    <span class="kw">CALL</span> test_cql_create_all_indices();</span>
-<span id="cb229-162"><a href="#cb229-162"></a>    <span class="kw">CALL</span> test_cql_create_all_triggers();</span>
-<span id="cb229-163"><a href="#cb229-163"></a>    <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;cql_schema_version&#39;</span>, <span class="dv">6</span>);</span>
-<span id="cb229-164"><a href="#cb229-164"></a>    <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;cql_schema_crc&#39;</span>, <span class="op">-</span><span class="dv">7714030317354747478</span>);</span>
-<span id="cb229-165"><a href="#cb229-165"></a></span>
-<span id="cb229-166"><a href="#cb229-166"></a>    <span class="co">-- finally produce the list of differences</span></span>
-<span id="cb229-167"><a href="#cb229-167"></a>    <span class="kw">SELECT</span> T1.facet <span class="kw">FROM</span></span>
-<span id="cb229-168"><a href="#cb229-168"></a>      test_cql_schema_facets T1</span>
-<span id="cb229-169"><a href="#cb229-169"></a>      <span class="kw">LEFT</span> <span class="kw">OUTER</span> <span class="kw">JOIN</span> test_cql_schema_facets_saved T2</span>
-<span id="cb229-170"><a href="#cb229-170"></a>        <span class="kw">ON</span> T1.facet <span class="op">=</span> T2.facet</span>
-<span id="cb229-171"><a href="#cb229-171"></a>      <span class="kw">WHERE</span> T1.version <span class="kw">is</span> <span class="kw">not</span> T2.version;</span>
-<span id="cb229-172"><a href="#cb229-172"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb229"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb229-1"><a href="#cb229-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_perform_needed_upgrades()</span>
+<span id="cb229-2"><a href="#cb229-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb229-3"><a href="#cb229-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> column_exists BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb229-4"><a href="#cb229-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> facet_version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb229-5"><a href="#cb229-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> schema_version <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb229-6"><a href="#cb229-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-7"><a href="#cb229-7" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- save the current facets so we can diff them later --</span></span>
+<span id="cb229-8"><a href="#cb229-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_save_cql_schema_facets();</span>
+<span id="cb229-9"><a href="#cb229-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-10"><a href="#cb229-10" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- dropping all views --</span></span>
+<span id="cb229-11"><a href="#cb229-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_drop_all_views();</span>
+<span id="cb229-12"><a href="#cb229-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-13"><a href="#cb229-13" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- dropping condemned or changing indices --</span></span>
+<span id="cb229-14"><a href="#cb229-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_drop_all_indices();</span>
+<span id="cb229-15"><a href="#cb229-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-16"><a href="#cb229-16" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- dropping condemned or changing triggers --</span></span>
+<span id="cb229-17"><a href="#cb229-17" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_drop_all_triggers();</span>
+<span id="cb229-18"><a href="#cb229-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-19"><a href="#cb229-19" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- fetch current schema version --</span></span>
+<span id="cb229-20"><a href="#cb229-20" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;cql_schema_version&#39;</span>, schema_version);</span>
+<span id="cb229-21"><a href="#cb229-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-22"><a href="#cb229-22" aria-hidden="true" tabindex="-1"></a>    <span class="co">---- install baseline schema if needed ----</span></span>
+<span id="cb229-23"><a href="#cb229-23" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-24"><a href="#cb229-24" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> schema_version <span class="op">==</span> <span class="op">-</span><span class="dv">1</span> <span class="cf">THEN</span></span>
+<span id="cb229-25"><a href="#cb229-25" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_drop_baseline_tables();</span>
+<span id="cb229-26"><a href="#cb229-26" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_install_baseline_schema();</span>
+<span id="cb229-27"><a href="#cb229-27" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;cql_schema_version&#39;</span>, <span class="dv">0</span>);</span>
+<span id="cb229-28"><a href="#cb229-28" aria-hidden="true" tabindex="-1"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-29"><a href="#cb229-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-30"><a href="#cb229-30" aria-hidden="true" tabindex="-1"></a>    <span class="co">---- upgrade to schema version 2 ----</span></span>
+<span id="cb229-31"><a href="#cb229-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-32"><a href="#cb229-32" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">2</span>, schema_version);</span>
+<span id="cb229-33"><a href="#cb229-33" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="dv">5380988243166701961</span> <span class="cf">THEN</span></span>
+<span id="cb229-34"><a href="#cb229-34" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table table2 to add column name1 TEXT;</span></span>
+<span id="cb229-35"><a href="#cb229-35" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-36"><a href="#cb229-36" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name1 TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-37"><a href="#cb229-37" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-38"><a href="#cb229-38" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name1 TEXT;</span>
+<span id="cb229-39"><a href="#cb229-39" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-40"><a href="#cb229-40" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-41"><a href="#cb229-41" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table table2 to add column name2 TEXT;</span></span>
+<span id="cb229-42"><a href="#cb229-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-43"><a href="#cb229-43" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name2 TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-44"><a href="#cb229-44" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-45"><a href="#cb229-45" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name2 TEXT;</span>
+<span id="cb229-46"><a href="#cb229-46" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-47"><a href="#cb229-47" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-48"><a href="#cb229-48" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table table2 to add column name3 TEXT;</span></span>
+<span id="cb229-49"><a href="#cb229-49" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-50"><a href="#cb229-50" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name3 TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-51"><a href="#cb229-51" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-52"><a href="#cb229-52" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name3 TEXT;</span>
+<span id="cb229-53"><a href="#cb229-53" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-54"><a href="#cb229-54" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-55"><a href="#cb229-55" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table table2 to add column name4 TEXT;</span></span>
+<span id="cb229-56"><a href="#cb229-56" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-57"><a href="#cb229-57" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;table2&#39;</span>, <span class="st">&#39;*[( ]name4 TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-58"><a href="#cb229-58" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-59"><a href="#cb229-59" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> table2 <span class="kw">ADD</span> <span class="kw">COLUMN</span> name4 TEXT;</span>
+<span id="cb229-60"><a href="#cb229-60" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-61"><a href="#cb229-61" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-62"><a href="#cb229-62" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- data migration procedures</span></span>
+<span id="cb229-63"><a href="#cb229-63" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;CreateName1Proc&#39;</span>, facet_version);</span>
+<span id="cb229-64"><a href="#cb229-64" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
+<span id="cb229-65"><a href="#cb229-65" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> CreateName1Proc();</span>
+<span id="cb229-66"><a href="#cb229-66" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;CreateName1Proc&#39;</span>, <span class="dv">2</span>);</span>
+<span id="cb229-67"><a href="#cb229-67" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-68"><a href="#cb229-68" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;CreateName2Proc&#39;</span>, facet_version);</span>
+<span id="cb229-69"><a href="#cb229-69" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
+<span id="cb229-70"><a href="#cb229-70" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> CreateName2Proc();</span>
+<span id="cb229-71"><a href="#cb229-71" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;CreateName2Proc&#39;</span>, <span class="dv">2</span>);</span>
+<span id="cb229-72"><a href="#cb229-72" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-73"><a href="#cb229-73" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-74"><a href="#cb229-74" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">2</span>, <span class="dv">5380988243166701961</span>);</span>
+<span id="cb229-75"><a href="#cb229-75" aria-hidden="true" tabindex="-1"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-76"><a href="#cb229-76" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-77"><a href="#cb229-77" aria-hidden="true" tabindex="-1"></a>    <span class="co">---- upgrade to schema version 3 ----</span></span>
+<span id="cb229-78"><a href="#cb229-78" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-79"><a href="#cb229-79" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">3</span>, schema_version);</span>
+<span id="cb229-80"><a href="#cb229-80" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="op">-</span><span class="dv">1945462407517765645</span> <span class="cf">THEN</span></span>
+<span id="cb229-81"><a href="#cb229-81" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- creating table added_table</span></span>
+<span id="cb229-82"><a href="#cb229-82" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-83"><a href="#cb229-83" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> added_table(</span>
+<span id="cb229-84"><a href="#cb229-84" aria-hidden="true" tabindex="-1"></a>        <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb229-85"><a href="#cb229-85" aria-hidden="true" tabindex="-1"></a>        name1 TEXT</span>
+<span id="cb229-86"><a href="#cb229-86" aria-hidden="true" tabindex="-1"></a>      );</span>
+<span id="cb229-87"><a href="#cb229-87" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-88"><a href="#cb229-88" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">3</span>, <span class="op">-</span><span class="dv">1945462407517765645</span>);</span>
+<span id="cb229-89"><a href="#cb229-89" aria-hidden="true" tabindex="-1"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-90"><a href="#cb229-90" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-91"><a href="#cb229-91" aria-hidden="true" tabindex="-1"></a>    <span class="co">---- upgrade to schema version 4 ----</span></span>
+<span id="cb229-92"><a href="#cb229-92" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-93"><a href="#cb229-93" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">4</span>, schema_version);</span>
+<span id="cb229-94"><a href="#cb229-94" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="op">-</span><span class="dv">4889894059346952297</span> <span class="cf">THEN</span></span>
+<span id="cb229-95"><a href="#cb229-95" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table added_table to add column name2 TEXT;</span></span>
+<span id="cb229-96"><a href="#cb229-96" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-97"><a href="#cb229-97" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;added_table&#39;</span>, <span class="st">&#39;*[( ]name2 TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-98"><a href="#cb229-98" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-99"><a href="#cb229-99" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> added_table <span class="kw">ADD</span> <span class="kw">COLUMN</span> name2 TEXT;</span>
+<span id="cb229-100"><a href="#cb229-100" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-101"><a href="#cb229-101" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-102"><a href="#cb229-102" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table foo to add column id2 INTEGER;</span></span>
+<span id="cb229-103"><a href="#cb229-103" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-104"><a href="#cb229-104" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;foo&#39;</span>, <span class="st">&#39;*[( ]id2 INTEGER*&#39;</span>, column_exists);</span>
+<span id="cb229-105"><a href="#cb229-105" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-106"><a href="#cb229-106" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> foo <span class="kw">ADD</span> <span class="kw">COLUMN</span> id2 <span class="dt">INTEGER</span> <span class="kw">DEFAULT</span> <span class="dv">12345</span>;</span>
+<span id="cb229-107"><a href="#cb229-107" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-108"><a href="#cb229-108" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-109"><a href="#cb229-109" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- logical delete of column rate_2 from foo; -- no ddl</span></span>
+<span id="cb229-110"><a href="#cb229-110" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-111"><a href="#cb229-111" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- data migration procedures</span></span>
+<span id="cb229-112"><a href="#cb229-112" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;CreateId2Proc&#39;</span>, facet_version);</span>
+<span id="cb229-113"><a href="#cb229-113" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
+<span id="cb229-114"><a href="#cb229-114" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> CreateId2Proc();</span>
+<span id="cb229-115"><a href="#cb229-115" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;CreateId2Proc&#39;</span>, <span class="dv">4</span>);</span>
+<span id="cb229-116"><a href="#cb229-116" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-117"><a href="#cb229-117" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;DeleteRate2Proc&#39;</span>, facet_version);</span>
+<span id="cb229-118"><a href="#cb229-118" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> facet_version <span class="op">=</span> <span class="dv">0</span> <span class="cf">THEN</span></span>
+<span id="cb229-119"><a href="#cb229-119" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> DeleteRate2Proc();</span>
+<span id="cb229-120"><a href="#cb229-120" aria-hidden="true" tabindex="-1"></a>        <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;DeleteRate2Proc&#39;</span>, <span class="dv">4</span>);</span>
+<span id="cb229-121"><a href="#cb229-121" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-122"><a href="#cb229-122" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-123"><a href="#cb229-123" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">4</span>, <span class="op">-</span><span class="dv">4889894059346952297</span>);</span>
+<span id="cb229-124"><a href="#cb229-124" aria-hidden="true" tabindex="-1"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-125"><a href="#cb229-125" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-126"><a href="#cb229-126" aria-hidden="true" tabindex="-1"></a>    <span class="co">---- upgrade to schema version 5 ----</span></span>
+<span id="cb229-127"><a href="#cb229-127" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-128"><a href="#cb229-128" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">5</span>, schema_version);</span>
+<span id="cb229-129"><a href="#cb229-129" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="dv">5720357430811880771</span> <span class="cf">THEN</span></span>
+<span id="cb229-130"><a href="#cb229-130" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table foo to add column name TEXT;</span></span>
+<span id="cb229-131"><a href="#cb229-131" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-132"><a href="#cb229-132" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;foo&#39;</span>, <span class="st">&#39;*[( ]name TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-133"><a href="#cb229-133" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-134"><a href="#cb229-134" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> foo <span class="kw">ADD</span> <span class="kw">COLUMN</span> name TEXT;</span>
+<span id="cb229-135"><a href="#cb229-135" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-136"><a href="#cb229-136" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-137"><a href="#cb229-137" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- logical delete of column rate from foo; -- no ddl</span></span>
+<span id="cb229-138"><a href="#cb229-138" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-139"><a href="#cb229-139" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- dropping table added_table</span></span>
+<span id="cb229-140"><a href="#cb229-140" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-141"><a href="#cb229-141" aria-hidden="true" tabindex="-1"></a>      <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> added_table;</span>
+<span id="cb229-142"><a href="#cb229-142" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-143"><a href="#cb229-143" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">5</span>, <span class="dv">5720357430811880771</span>);</span>
+<span id="cb229-144"><a href="#cb229-144" aria-hidden="true" tabindex="-1"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-145"><a href="#cb229-145" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-146"><a href="#cb229-146" aria-hidden="true" tabindex="-1"></a>    <span class="co">---- upgrade to schema version 6 ----</span></span>
+<span id="cb229-147"><a href="#cb229-147" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-148"><a href="#cb229-148" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_get_version_crc(<span class="dv">6</span>, schema_version);</span>
+<span id="cb229-149"><a href="#cb229-149" aria-hidden="true" tabindex="-1"></a>    <span class="cf">IF</span> schema_version <span class="op">!=</span> <span class="dv">3572608284749506390</span> <span class="cf">THEN</span></span>
+<span id="cb229-150"><a href="#cb229-150" aria-hidden="true" tabindex="-1"></a>      <span class="co">-- altering table foo to add column name_2 TEXT;</span></span>
+<span id="cb229-151"><a href="#cb229-151" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-152"><a href="#cb229-152" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_check_column_exists(<span class="st">&#39;foo&#39;</span>, <span class="st">&#39;*[( ]name_2 TEXT*&#39;</span>, column_exists);</span>
+<span id="cb229-153"><a href="#cb229-153" aria-hidden="true" tabindex="-1"></a>      <span class="cf">IF</span> <span class="kw">NOT</span> column_exists <span class="cf">THEN</span></span>
+<span id="cb229-154"><a href="#cb229-154" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ALTER</span> <span class="kw">TABLE</span> foo <span class="kw">ADD</span> <span class="kw">COLUMN</span> name_2 TEXT;</span>
+<span id="cb229-155"><a href="#cb229-155" aria-hidden="true" tabindex="-1"></a>      <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-156"><a href="#cb229-156" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-157"><a href="#cb229-157" aria-hidden="true" tabindex="-1"></a>      <span class="kw">CALL</span> test_cql_set_version_crc(<span class="dv">6</span>, <span class="dv">3572608284749506390</span>);</span>
+<span id="cb229-158"><a href="#cb229-158" aria-hidden="true" tabindex="-1"></a>    <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb229-159"><a href="#cb229-159" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-160"><a href="#cb229-160" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_create_all_views();</span>
+<span id="cb229-161"><a href="#cb229-161" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_create_all_indices();</span>
+<span id="cb229-162"><a href="#cb229-162" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_create_all_triggers();</span>
+<span id="cb229-163"><a href="#cb229-163" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;cql_schema_version&#39;</span>, <span class="dv">6</span>);</span>
+<span id="cb229-164"><a href="#cb229-164" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_cql_set_facet_version(<span class="st">&#39;cql_schema_crc&#39;</span>, <span class="op">-</span><span class="dv">7714030317354747478</span>);</span>
+<span id="cb229-165"><a href="#cb229-165" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb229-166"><a href="#cb229-166" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- finally produce the list of differences</span></span>
+<span id="cb229-167"><a href="#cb229-167" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SELECT</span> T1.facet <span class="kw">FROM</span></span>
+<span id="cb229-168"><a href="#cb229-168" aria-hidden="true" tabindex="-1"></a>      test_cql_schema_facets T1</span>
+<span id="cb229-169"><a href="#cb229-169" aria-hidden="true" tabindex="-1"></a>      <span class="kw">LEFT</span> <span class="kw">OUTER</span> <span class="kw">JOIN</span> test_cql_schema_facets_saved T2</span>
+<span id="cb229-170"><a href="#cb229-170" aria-hidden="true" tabindex="-1"></a>        <span class="kw">ON</span> T1.facet <span class="op">=</span> T2.facet</span>
+<span id="cb229-171"><a href="#cb229-171" aria-hidden="true" tabindex="-1"></a>      <span class="kw">WHERE</span> T1.version <span class="kw">is</span> <span class="kw">not</span> T2.version;</span>
+<span id="cb229-172"><a href="#cb229-172" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>This is the main function for upgrades, it checks only the master schema version. This function is separate so that the normal startup path doesn’t have to have the code for the full upgrade case in it. This lets linker order files do a superior job (since full upgrade is the rare case).</p>
-<div class="sourceCode" id="cb230"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb230-1"><a href="#cb230-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test()</span>
-<span id="cb230-2"><a href="#cb230-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb230-3"><a href="#cb230-3"></a>  <span class="kw">DECLARE</span> schema_crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
-<span id="cb230-4"><a href="#cb230-4"></a></span>
-<span id="cb230-5"><a href="#cb230-5"></a>  <span class="co">-- create schema facets information table --</span></span>
-<span id="cb230-6"><a href="#cb230-6"></a>  <span class="kw">CALL</span> test_create_cql_schema_facets_if_needed();</span>
-<span id="cb230-7"><a href="#cb230-7"></a></span>
-<span id="cb230-8"><a href="#cb230-8"></a>  <span class="co">-- fetch the last known schema crc, if it&#39;s different do the upgrade --</span></span>
-<span id="cb230-9"><a href="#cb230-9"></a>  <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;cql_schema_crc&#39;</span>, schema_crc);</span>
-<span id="cb230-10"><a href="#cb230-10"></a></span>
-<span id="cb230-11"><a href="#cb230-11"></a>  <span class="cf">IF</span> schema_crc <span class="op">&lt;&gt;</span> <span class="op">-</span><span class="dv">7714030317354747478</span> <span class="cf">THEN</span></span>
-<span id="cb230-12"><a href="#cb230-12"></a>    <span class="co">-- save the current facets so we can diff them later --</span></span>
-<span id="cb230-13"><a href="#cb230-13"></a>    <span class="kw">CALL</span> test_perform_needed_upgrades();</span>
-<span id="cb230-14"><a href="#cb230-14"></a>  <span class="cf">ELSE</span></span>
-<span id="cb230-15"><a href="#cb230-15"></a>    <span class="co">-- some canonical result for no differences --</span></span>
-<span id="cb230-16"><a href="#cb230-16"></a>    <span class="kw">SELECT</span> <span class="st">&#39;no differences&#39;</span> facet;</span>
-<span id="cb230-17"><a href="#cb230-17"></a>  <span class="cf">END</span> <span class="cf">IF</span>;</span>
-<span id="cb230-18"><a href="#cb230-18"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb230"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb230-1"><a href="#cb230-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test()</span>
+<span id="cb230-2"><a href="#cb230-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb230-3"><a href="#cb230-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> schema_crc <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>;</span>
+<span id="cb230-4"><a href="#cb230-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb230-5"><a href="#cb230-5" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- create schema facets information table --</span></span>
+<span id="cb230-6"><a href="#cb230-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> test_create_cql_schema_facets_if_needed();</span>
+<span id="cb230-7"><a href="#cb230-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb230-8"><a href="#cb230-8" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- fetch the last known schema crc, if it&#39;s different do the upgrade --</span></span>
+<span id="cb230-9"><a href="#cb230-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> test_cql_get_facet_version(<span class="st">&#39;cql_schema_crc&#39;</span>, schema_crc);</span>
+<span id="cb230-10"><a href="#cb230-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb230-11"><a href="#cb230-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">IF</span> schema_crc <span class="op">&lt;&gt;</span> <span class="op">-</span><span class="dv">7714030317354747478</span> <span class="cf">THEN</span></span>
+<span id="cb230-12"><a href="#cb230-12" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- save the current facets so we can diff them later --</span></span>
+<span id="cb230-13"><a href="#cb230-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">CALL</span> test_perform_needed_upgrades();</span>
+<span id="cb230-14"><a href="#cb230-14" aria-hidden="true" tabindex="-1"></a>  <span class="cf">ELSE</span></span>
+<span id="cb230-15"><a href="#cb230-15" aria-hidden="true" tabindex="-1"></a>    <span class="co">-- some canonical result for no differences --</span></span>
+<span id="cb230-16"><a href="#cb230-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">SELECT</span> <span class="st">&#39;no differences&#39;</span> facet;</span>
+<span id="cb230-17"><a href="#cb230-17" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span> <span class="cf">IF</span>;</span>
+<span id="cb230-18"><a href="#cb230-18" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <h4 id="temp-tables">Temp Tables</h4>
 <p>We had no temporary tables in this schema, but if there were some they get added to the schema after the upgrade check.</p>
 <p>A procedure like this one is generated:</p>
-<div class="sourceCode" id="cb231"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb231-1"><a href="#cb231-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_install_temp_schema()</span>
-<span id="cb231-2"><a href="#cb231-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb231-3"><a href="#cb231-3"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> tempy(</span>
-<span id="cb231-4"><a href="#cb231-4"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span></span>
-<span id="cb231-5"><a href="#cb231-5"></a>  );</span>
-<span id="cb231-6"><a href="#cb231-6"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb231"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb231-1"><a href="#cb231-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_cql_install_temp_schema()</span>
+<span id="cb231-2"><a href="#cb231-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb231-3"><a href="#cb231-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> tempy(</span>
+<span id="cb231-4"><a href="#cb231-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span></span>
+<span id="cb231-5"><a href="#cb231-5" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb231-6"><a href="#cb231-6" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>This entry point can be used any time you need the temp tables. But normally it is automatically invoked.</p>
-<div class="sourceCode" id="cb232"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb232-1"><a href="#cb232-1"></a>  <span class="co">---- install temp schema after upgrade is complete ----</span></span>
-<span id="cb232-2"><a href="#cb232-2"></a>  <span class="kw">CALL</span> test_cql_install_temp_schema();</span></code></pre></div>
+<div class="sourceCode" id="cb232"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb232-1"><a href="#cb232-1" aria-hidden="true" tabindex="-1"></a>  <span class="co">---- install temp schema after upgrade is complete ----</span></span>
+<span id="cb232-2"><a href="#cb232-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CALL</span> test_cql_install_temp_schema();</span></code></pre></div>
 <p>That logic is emitted at the end of the test procedure.</p>
 <h3 id="schema-regions">Schema Regions</h3>
 <p>Schema Regions are designed to let you declare your schema in logical regions whose dependencies are specified. It enforces the dependencies you specify creating errors if you attempt to break the declared rules. Schema regions allow you to generate upgrade scripts for parts of your schema that can compose and be guaranteed to remain self-consistent.</p>
@@ -3901,117 +4033,117 @@ END;</code></pre>
 <p>If you’re making a library with database support, your customers likely want to be able to create databases that have only features they want; you will want logical parts within your schema that can be separated for cleanliness and distribution.</p>
 <h4 id="declaring-regions-and-dependencies">Declaring Regions and Dependencies</h4>
 <p>Schema Regions let you create logical groupings, you simply declare the regions you want and then start putting things into those regions. The regions form a directed acyclic graph – just like C++ base classes. You create regions like this:</p>
-<div class="sourceCode" id="cb233"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb233-1"><a href="#cb233-1"></a><span class="ot">@declare_schema_region root;</span></span>
-<span id="cb233-2"><a href="#cb233-2"></a></span>
-<span id="cb233-3"><a href="#cb233-3"></a><span class="ot">@declare_schema_region extra using root;</span></span></code></pre></div>
+<div class="sourceCode" id="cb233"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb233-1"><a href="#cb233-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region root;</span></span>
+<span id="cb233-2"><a href="#cb233-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb233-3"><a href="#cb233-3" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region extra using root;</span></span></code></pre></div>
 <p>The above simply declares the region, it doesn’t put anything into them. In this case we now have a <code>root</code> region and an <code>extra</code> region. The <code>root</code> schema items will not be allowed to refer to anything in <code>extra</code>.</p>
 <p>Without regions, you could also ensure that the above is true by putting all the <code>extra</code> items afer the <code>root</code> in the input file but things can get more complicated than that in general, and the schema might also be in several files, complicating ordering as the option. Also relying on order could be problematic as it is quite easy to put things in the wrong place (e.g. add a new <code>root</code> item after the <code>extra</code> items). Making this a bit more complicated, we could have:</p>
-<div class="sourceCode" id="cb234"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb234-1"><a href="#cb234-1"></a><span class="ot">@declare_schema_region feature1 using extra;</span></span>
-<span id="cb234-2"><a href="#cb234-2"></a><span class="ot">@declare_schema_region feature2 using extra;</span></span>
-<span id="cb234-3"><a href="#cb234-3"></a><span class="ot">@declare_schema_region everything using feature1, feature2;</span></span></code></pre></div>
+<div class="sourceCode" id="cb234"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb234-1"><a href="#cb234-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region feature1 using extra;</span></span>
+<span id="cb234-2"><a href="#cb234-2" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region feature2 using extra;</span></span>
+<span id="cb234-3"><a href="#cb234-3" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region everything using feature1, feature2;</span></span></code></pre></div>
 <p>And now there are many paths to <code>root</code> from the <code>everything</code> region; that’s ok but certainly it will be tricky to do all that with ordering.</p>
 <h4 id="using-regions">Using Regions</h4>
 <p>An illustrative example, using the regions defined above:</p>
-<div class="sourceCode" id="cb235"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb235-1"><a href="#cb235-1"></a><span class="ot">@begin_schema_region root;</span></span>
-<span id="cb235-2"><a href="#cb235-2"></a></span>
-<span id="cb235-3"><a href="#cb235-3"></a><span class="kw">create</span> <span class="kw">table</span> main(</span>
-<span id="cb235-4"><a href="#cb235-4"></a>  <span class="kw">id</span> <span class="dt">integer</span>,</span>
-<span id="cb235-5"><a href="#cb235-5"></a>  name text</span>
-<span id="cb235-6"><a href="#cb235-6"></a>);</span>
-<span id="cb235-7"><a href="#cb235-7"></a></span>
-<span id="cb235-8"><a href="#cb235-8"></a><span class="kw">create</span> <span class="kw">view</span> names <span class="kw">as</span> <span class="kw">select</span> name <span class="kw">from</span> main <span class="kw">order</span> <span class="kw">by</span> name;</span>
-<span id="cb235-9"><a href="#cb235-9"></a></span>
-<span id="cb235-10"><a href="#cb235-10"></a><span class="ot">@end_schema_region;</span></span>
-<span id="cb235-11"><a href="#cb235-11"></a></span>
-<span id="cb235-12"><a href="#cb235-12"></a><span class="ot">@begin_schema_region extra;</span></span>
-<span id="cb235-13"><a href="#cb235-13"></a></span>
-<span id="cb235-14"><a href="#cb235-14"></a><span class="kw">create</span> <span class="kw">table</span> details(</span>
-<span id="cb235-15"><a href="#cb235-15"></a>   <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">references</span> main(<span class="kw">id</span>),</span>
-<span id="cb235-16"><a href="#cb235-16"></a>   details text</span>
-<span id="cb235-17"><a href="#cb235-17"></a>);</span>
-<span id="cb235-18"><a href="#cb235-18"></a></span>
-<span id="cb235-19"><a href="#cb235-19"></a><span class="kw">create</span> proc get_detail(<span class="dt">integer</span> id_)</span>
-<span id="cb235-20"><a href="#cb235-20"></a><span class="cf">begin</span></span>
-<span id="cb235-21"><a href="#cb235-21"></a>  <span class="kw">select</span> T1.<span class="kw">id</span>, T1.details, T2.name <span class="kw">from</span> details T1</span>
-<span id="cb235-22"><a href="#cb235-22"></a>  <span class="kw">inner</span> <span class="kw">join</span> main T2 <span class="kw">on</span> T1.<span class="kw">id</span> <span class="op">=</span> T2.<span class="kw">id</span></span>
-<span id="cb235-23"><a href="#cb235-23"></a>  <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb235-24"><a href="#cb235-24"></a><span class="cf">end</span>;</span>
-<span id="cb235-25"><a href="#cb235-25"></a></span>
-<span id="cb235-26"><a href="#cb235-26"></a><span class="ot">@end_schema_region;</span></span>
-<span id="cb235-27"><a href="#cb235-27"></a></span>
-<span id="cb235-28"><a href="#cb235-28"></a><span class="ot">@begin_schema_region feature1;</span></span>
-<span id="cb235-29"><a href="#cb235-29"></a></span>
-<span id="cb235-30"><a href="#cb235-30"></a><span class="kw">create</span> <span class="kw">table</span> f1(</span>
-<span id="cb235-31"><a href="#cb235-31"></a>   <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">references</span> details(<span class="kw">id</span>),</span>
-<span id="cb235-32"><a href="#cb235-32"></a>   f1_info text</span>
-<span id="cb235-33"><a href="#cb235-33"></a>);</span>
-<span id="cb235-34"><a href="#cb235-34"></a></span>
-<span id="cb235-35"><a href="#cb235-35"></a><span class="kw">create</span> proc get_detail(<span class="dt">integer</span> id_)</span>
-<span id="cb235-36"><a href="#cb235-36"></a><span class="cf">begin</span></span>
-<span id="cb235-37"><a href="#cb235-37"></a>  <span class="kw">select</span> T1.<span class="kw">id</span>, T1.details, T2.name, f1_info <span class="kw">from</span> details T1</span>
-<span id="cb235-38"><a href="#cb235-38"></a>  <span class="kw">inner</span> <span class="kw">join</span> f T2 <span class="kw">on</span> T1.<span class="kw">id</span> <span class="op">=</span> T2.<span class="kw">id</span></span>
-<span id="cb235-39"><a href="#cb235-39"></a>  <span class="kw">inner</span> <span class="kw">join</span> f1 <span class="kw">on</span> f1.<span class="kw">id</span> <span class="op">=</span> T1.<span class="kw">id</span></span>
-<span id="cb235-40"><a href="#cb235-40"></a>  <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">=</span> id_;</span>
-<span id="cb235-41"><a href="#cb235-41"></a><span class="cf">end</span>;</span>
-<span id="cb235-42"><a href="#cb235-42"></a></span>
-<span id="cb235-43"><a href="#cb235-43"></a><span class="ot">@end_schema_region;</span></span>
-<span id="cb235-44"><a href="#cb235-44"></a></span>
-<span id="cb235-45"><a href="#cb235-45"></a><span class="ot">@begin_schema_region feature2;</span></span>
-<span id="cb235-46"><a href="#cb235-46"></a>  <span class="co">-- you can use details, and main but not f1</span></span>
-<span id="cb235-47"><a href="#cb235-47"></a><span class="ot">@end_schema_region;</span></span></code></pre></div>
+<div class="sourceCode" id="cb235"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb235-1"><a href="#cb235-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region root;</span></span>
+<span id="cb235-2"><a href="#cb235-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-3"><a href="#cb235-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> main(</span>
+<span id="cb235-4"><a href="#cb235-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span>,</span>
+<span id="cb235-5"><a href="#cb235-5" aria-hidden="true" tabindex="-1"></a>  name text</span>
+<span id="cb235-6"><a href="#cb235-6" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb235-7"><a href="#cb235-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-8"><a href="#cb235-8" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> names <span class="kw">as</span> <span class="kw">select</span> name <span class="kw">from</span> main <span class="kw">order</span> <span class="kw">by</span> name;</span>
+<span id="cb235-9"><a href="#cb235-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-10"><a href="#cb235-10" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span>
+<span id="cb235-11"><a href="#cb235-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-12"><a href="#cb235-12" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region extra;</span></span>
+<span id="cb235-13"><a href="#cb235-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-14"><a href="#cb235-14" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> details(</span>
+<span id="cb235-15"><a href="#cb235-15" aria-hidden="true" tabindex="-1"></a>   <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">references</span> main(<span class="kw">id</span>),</span>
+<span id="cb235-16"><a href="#cb235-16" aria-hidden="true" tabindex="-1"></a>   details text</span>
+<span id="cb235-17"><a href="#cb235-17" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb235-18"><a href="#cb235-18" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-19"><a href="#cb235-19" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc get_detail(<span class="dt">integer</span> id_)</span>
+<span id="cb235-20"><a href="#cb235-20" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb235-21"><a href="#cb235-21" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> T1.<span class="kw">id</span>, T1.details, T2.name <span class="kw">from</span> details T1</span>
+<span id="cb235-22"><a href="#cb235-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">inner</span> <span class="kw">join</span> main T2 <span class="kw">on</span> T1.<span class="kw">id</span> <span class="op">=</span> T2.<span class="kw">id</span></span>
+<span id="cb235-23"><a href="#cb235-23" aria-hidden="true" tabindex="-1"></a>  <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb235-24"><a href="#cb235-24" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span>
+<span id="cb235-25"><a href="#cb235-25" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-26"><a href="#cb235-26" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span>
+<span id="cb235-27"><a href="#cb235-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-28"><a href="#cb235-28" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region feature1;</span></span>
+<span id="cb235-29"><a href="#cb235-29" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-30"><a href="#cb235-30" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> f1(</span>
+<span id="cb235-31"><a href="#cb235-31" aria-hidden="true" tabindex="-1"></a>   <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">references</span> details(<span class="kw">id</span>),</span>
+<span id="cb235-32"><a href="#cb235-32" aria-hidden="true" tabindex="-1"></a>   f1_info text</span>
+<span id="cb235-33"><a href="#cb235-33" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb235-34"><a href="#cb235-34" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-35"><a href="#cb235-35" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc get_detail(<span class="dt">integer</span> id_)</span>
+<span id="cb235-36"><a href="#cb235-36" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb235-37"><a href="#cb235-37" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> T1.<span class="kw">id</span>, T1.details, T2.name, f1_info <span class="kw">from</span> details T1</span>
+<span id="cb235-38"><a href="#cb235-38" aria-hidden="true" tabindex="-1"></a>  <span class="kw">inner</span> <span class="kw">join</span> f T2 <span class="kw">on</span> T1.<span class="kw">id</span> <span class="op">=</span> T2.<span class="kw">id</span></span>
+<span id="cb235-39"><a href="#cb235-39" aria-hidden="true" tabindex="-1"></a>  <span class="kw">inner</span> <span class="kw">join</span> f1 <span class="kw">on</span> f1.<span class="kw">id</span> <span class="op">=</span> T1.<span class="kw">id</span></span>
+<span id="cb235-40"><a href="#cb235-40" aria-hidden="true" tabindex="-1"></a>  <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">=</span> id_;</span>
+<span id="cb235-41"><a href="#cb235-41" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span>
+<span id="cb235-42"><a href="#cb235-42" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-43"><a href="#cb235-43" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span>
+<span id="cb235-44"><a href="#cb235-44" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb235-45"><a href="#cb235-45" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region feature2;</span></span>
+<span id="cb235-46"><a href="#cb235-46" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- you can use details, and main but not f1</span></span>
+<span id="cb235-47"><a href="#cb235-47" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span></code></pre></div>
 <p>With the structure above specified, even if a new contribution to the <code>root</code> schema appears later, the rules enforce that this region cannot refer to anything other other things in <code>root</code>. This can be very important if schema is being included via <code>#include</code> and might get pulled into the compilation in various orders. A feature area might also have a named public region that others things can depend on (e.g. some views) and private regions (e.g. some tables, or whatever).</p>
 <h4 id="region-visibility">Region Visibility</h4>
 <p>Schema region do not provide additional name spaces, the names of objects should be unique across all regions. i.e. regions do not hide or scope entity names, rather they create errors if inappropriate names are used.</p>
 <p>Case 1: The second line will fail semantic validation because table <code>A</code> already exists</p>
-<div class="sourceCode" id="cb236"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb236-1"><a href="#cb236-1"></a><span class="co">-- obvious standard name conflict</span></span>
-<span id="cb236-2"><a href="#cb236-2"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb236-3"><a href="#cb236-3"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>, name text);</span></code></pre></div>
+<div class="sourceCode" id="cb236"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb236-1"><a href="#cb236-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- obvious standard name conflict</span></span>
+<span id="cb236-2"><a href="#cb236-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb236-3"><a href="#cb236-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>, name text);</span></code></pre></div>
 <p>Case 2: This fails for the same reason as case #1. Table <code>A</code> already exists</p>
-<div class="sourceCode" id="cb237"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb237-1"><a href="#cb237-1"></a><span class="ot">@declare_region root;</span></span>
-<span id="cb237-2"><a href="#cb237-2"></a><span class="co">-- table A is in no region</span></span>
-<span id="cb237-3"><a href="#cb237-3"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb237-4"><a href="#cb237-4"></a><span class="ot">@begin_region root:</span></span>
-<span id="cb237-5"><a href="#cb237-5"></a><span class="co">-- this table A is in the root region, still an error</span></span>
-<span id="cb237-6"><a href="#cb237-6"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>, name text);</span>
-<span id="cb237-7"><a href="#cb237-7"></a><span class="ot">@end_region;</span></span></code></pre></div>
+<div class="sourceCode" id="cb237"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb237-1"><a href="#cb237-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_region root;</span></span>
+<span id="cb237-2"><a href="#cb237-2" aria-hidden="true" tabindex="-1"></a><span class="co">-- table A is in no region</span></span>
+<span id="cb237-3"><a href="#cb237-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb237-4"><a href="#cb237-4" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_region root:</span></span>
+<span id="cb237-5"><a href="#cb237-5" aria-hidden="true" tabindex="-1"></a><span class="co">-- this table A is in the root region, still an error</span></span>
+<span id="cb237-6"><a href="#cb237-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>, name text);</span>
+<span id="cb237-7"><a href="#cb237-7" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_region;</span></span></code></pre></div>
 <p>Case 3: Again fails for the same reason as case #1. Table <code>A</code> already exist in region <code>extra</code>, you can not define another table with the same name in another region.</p>
-<div class="sourceCode" id="cb238"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb238-1"><a href="#cb238-1"></a><span class="ot">@declare_region root;</span></span>
-<span id="cb238-2"><a href="#cb238-2"></a><span class="ot">@declare_region extra;</span></span>
-<span id="cb238-3"><a href="#cb238-3"></a></span>
-<span id="cb238-4"><a href="#cb238-4"></a><span class="ot">@begin_region extra;</span></span>
-<span id="cb238-5"><a href="#cb238-5"></a><span class="co">-- so far so good</span></span>
-<span id="cb238-6"><a href="#cb238-6"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb238-7"><a href="#cb238-7"></a><span class="ot">@end_region;</span></span>
-<span id="cb238-8"><a href="#cb238-8"></a></span>
-<span id="cb238-9"><a href="#cb238-9"></a><span class="ot">@begin_region root;</span></span>
-<span id="cb238-10"><a href="#cb238-10"></a><span class="co">-- no joy, this A conflicts with the previous A</span></span>
-<span id="cb238-11"><a href="#cb238-11"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>, name text);</span>
-<span id="cb238-12"><a href="#cb238-12"></a><span class="ot">@end_region;</span></span></code></pre></div>
+<div class="sourceCode" id="cb238"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb238-1"><a href="#cb238-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_region root;</span></span>
+<span id="cb238-2"><a href="#cb238-2" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_region extra;</span></span>
+<span id="cb238-3"><a href="#cb238-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb238-4"><a href="#cb238-4" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_region extra;</span></span>
+<span id="cb238-5"><a href="#cb238-5" aria-hidden="true" tabindex="-1"></a><span class="co">-- so far so good</span></span>
+<span id="cb238-6"><a href="#cb238-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb238-7"><a href="#cb238-7" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_region;</span></span>
+<span id="cb238-8"><a href="#cb238-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb238-9"><a href="#cb238-9" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_region root;</span></span>
+<span id="cb238-10"><a href="#cb238-10" aria-hidden="true" tabindex="-1"></a><span class="co">-- no joy, this A conflicts with the previous A</span></span>
+<span id="cb238-11"><a href="#cb238-11" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="kw">id</span> <span class="dt">integer</span>, name text);</span>
+<span id="cb238-12"><a href="#cb238-12" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_region;</span></span></code></pre></div>
 <p>Really the visibility rules couldn’t be anything other than the above, SQLite has no knowledge of regions at all and so any exotic name resolution would just doom SQLite statements to fail when they finally run.</p>
 <h5 id="exception-for-...-like-table-statement">Exception for <code>"... LIKE &lt;table&gt;"</code> statement</h5>
 <p>The rules above are enforced for all constructs except for where the syntactic sugar <code>... LIKE &lt;table&gt;</code> forms, which can happen in a variety of statement. This form doesn’t create a dependence on the table (but does create a dependence on its shape). When CQL generates output the <code>LIKE</code> construct is replaced with the actual names of columns it refers to. But these are independent columns, so this is simply a typing-saver. The table (or view, cursor, etc.) reference will be gone.</p>
 <p>These cases below will succeed.</p>
-<div class="sourceCode" id="cb239"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb239-1"><a href="#cb239-1"></a><span class="ot">@declare_region root;</span></span>
-<span id="cb239-2"><a href="#cb239-2"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="op">..</span>.);</span>
-<span id="cb239-3"><a href="#cb239-3"></a><span class="kw">create</span> <span class="kw">view</span> B (<span class="op">....</span>);</span>
-<span id="cb239-4"><a href="#cb239-4"></a><span class="kw">create</span> <span class="kw">procedure</span> C {<span class="op">..</span>.}</span>
-<span id="cb239-5"><a href="#cb239-5"></a></span>
-<span id="cb239-6"><a href="#cb239-6"></a><span class="ot">@begin_region root;</span></span>
-<span id="cb239-7"><a href="#cb239-7"></a><span class="kw">create</span> <span class="kw">table</span> AA(<span class="kw">LIKE</span> A);</span>
-<span id="cb239-8"><a href="#cb239-8"></a><span class="kw">create</span> <span class="kw">table</span> BB(<span class="kw">LIKE</span> B);</span>
-<span id="cb239-9"><a href="#cb239-9"></a><span class="kw">create</span> <span class="kw">table</span> CC(<span class="kw">LIKE</span> C);</span>
-<span id="cb239-10"><a href="#cb239-10"></a><span class="ot">@end_region;</span></span></code></pre></div>
+<div class="sourceCode" id="cb239"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb239-1"><a href="#cb239-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_region root;</span></span>
+<span id="cb239-2"><a href="#cb239-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> A (<span class="op">..</span>.);</span>
+<span id="cb239-3"><a href="#cb239-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> B (<span class="op">....</span>);</span>
+<span id="cb239-4"><a href="#cb239-4" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> C {<span class="op">..</span>.}</span>
+<span id="cb239-5"><a href="#cb239-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb239-6"><a href="#cb239-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_region root;</span></span>
+<span id="cb239-7"><a href="#cb239-7" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> AA(<span class="kw">LIKE</span> A);</span>
+<span id="cb239-8"><a href="#cb239-8" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> BB(<span class="kw">LIKE</span> B);</span>
+<span id="cb239-9"><a href="#cb239-9" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> CC(<span class="kw">LIKE</span> C);</span>
+<span id="cb239-10"><a href="#cb239-10" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_region;</span></span></code></pre></div>
 <p>Note: this exception may end up causing maintenance problems and so it might be revisited in the future.</p>
 <h4 id="maintaining-schema-in-pieces">Maintaining Schema in Pieces</h4>
 <p>When creating upgrade scripts using the <code>--rt schema_upgrade</code> flags you can add region options <code>--include_regions a b c</code> and <code>--exclude_regions d e f</code> per the following:</p>
 <p>Included regions: * included regions must be valid region names, the base types are walked to compute all the regions that are “in” * declarations are emitted in the upgrade for all of the “in” objects, “exclude” does not affect the declarations</p>
 <p>Excluded regions: * excluded regions must be valid region names and indicate parts of schema that are upgraded elsewhere, perhaps with a seperate CQL run, a different automatic upgrade, or even a manual mechanism * upgrade code will be generated for all the included schema, but not for the excluded regions and their contents</p>
 <p>Example: Referring to the regions above you might do something like this</p>
-<div class="sourceCode" id="cb240"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb240-1"><a href="#cb240-1"></a></span>
-<span id="cb240-2"><a href="#cb240-2"></a> <span class="co"># All of these also need a --global_proc param for the entry point but that&#39;s not relevant here</span></span>
-<span id="cb240-3"><a href="#cb240-3"></a><span class="ex">cql</span> --in schema.sql --cg shared.sql --rt schema_upgrade  --include_regions extra</span>
-<span id="cb240-4"><a href="#cb240-4"></a><span class="ex">cql</span> --in schema.sql --cg f1.cql --rt schema_upgrade --include_regions feature1 --exclude_regions extra</span>
-<span id="cb240-5"><a href="#cb240-5"></a><span class="ex">cql</span> --in schema.sql --cg f2.cql --rt schema_upgrade --include_regions feature2 --exclude_regions extra</span></code></pre></div>
+<div class="sourceCode" id="cb240"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb240-1"><a href="#cb240-1" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb240-2"><a href="#cb240-2" aria-hidden="true" tabindex="-1"></a> <span class="co"># All of these also need a --global_proc param for the entry point but that&#39;s not relevant here</span></span>
+<span id="cb240-3"><a href="#cb240-3" aria-hidden="true" tabindex="-1"></a><span class="ex">cql</span> <span class="at">--in</span> schema.sql <span class="at">--cg</span> shared.sql <span class="at">--rt</span> schema_upgrade  <span class="at">--include_regions</span> extra</span>
+<span id="cb240-4"><a href="#cb240-4" aria-hidden="true" tabindex="-1"></a><span class="ex">cql</span> <span class="at">--in</span> schema.sql <span class="at">--cg</span> f1.cql <span class="at">--rt</span> schema_upgrade <span class="at">--include_regions</span> feature1 <span class="at">--exclude_regions</span> extra</span>
+<span id="cb240-5"><a href="#cb240-5" aria-hidden="true" tabindex="-1"></a><span class="ex">cql</span> <span class="at">--in</span> schema.sql <span class="at">--cg</span> f2.cql <span class="at">--rt</span> schema_upgrade <span class="at">--include_regions</span> feature2 <span class="at">--exclude_regions</span> extra</span></code></pre></div>
 <p>The first command generates all the shared schema for regions <code>root</code> and <code>extra</code> because <code>extra</code> contains <code>root</code></p>
 <p>The second command declares all of <code>root</code> and <code>extra</code> so that the <code>feature1</code> things can refer to them, however the upgrade code for these shared regions is not emitted. Only the upgrade for schema in <code>feature1</code> is emitted. <code>feature2</code> is completely absent. This will be ok because we know <code>feature1</code> cannot depend on <code>feature2</code> and <code>extra</code> is assumed to be upgraded elsewhere (such as in the previous line).</p>
 <p>The third command declares all of <code>root</code> and <code>extra</code> so that the <code>feature2</code> things can refer to them, however the upgrade code for these shared regions is not emitted. Only the upgrade for schema in <code>feature2</code> is emitted. <code>feature1</code> is completely absent.</p>
@@ -4058,27 +4190,27 @@ Master Deployment 2
 <h4 id="private-regions">Private Regions</h4>
 <p>The above constructs create a good basis for creating and composing regions, but a key missing aspect is the ability to hide internal details in the logical groups. This becomes increasingly important as your desire to modularize schema grows; you will want to have certain parts that can change without worrying about breaking others and without fear that there are foreign keys and so forth to them.</p>
 <p>To accomplish this CQL provides the ability to compose schema regions with the optional <code>private</code> keyword. In the following example there will be three regions creatively named <code>r1</code>, <code>r2</code>, and <code>r3</code>. Region <code>r2</code> consumes <code>r1</code> privately and therefore <code>r3</code> is not allowed to use things in <code>r1</code> even though it consumes <code>r2</code>. When creating an upgrade script for <code>r3</code> you will still need (and will get) all of <code>r2</code> and <code>r1</code>, but from a visibility perspective <code>r3</code> can only directly depend on <code>r2</code>.</p>
-<div class="sourceCode" id="cb242"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb242-1"><a href="#cb242-1"></a><span class="ot">@declare_schema_region r1;</span></span>
-<span id="cb242-2"><a href="#cb242-2"></a><span class="ot">@declare_schema_region r2 using r1 private;</span></span>
-<span id="cb242-3"><a href="#cb242-3"></a><span class="ot">@declare_schema_region r3 using r2;</span></span>
-<span id="cb242-4"><a href="#cb242-4"></a></span>
-<span id="cb242-5"><a href="#cb242-5"></a><span class="ot">@begin_schema_region r1;</span></span>
-<span id="cb242-6"><a href="#cb242-6"></a><span class="kw">create</span> <span class="kw">table</span> r1_table(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span>);</span>
-<span id="cb242-7"><a href="#cb242-7"></a><span class="ot">@end_schema_region;</span></span>
-<span id="cb242-8"><a href="#cb242-8"></a></span>
-<span id="cb242-9"><a href="#cb242-9"></a><span class="ot">@begin_schema_region r2;</span></span>
-<span id="cb242-10"><a href="#cb242-10"></a><span class="kw">create</span> <span class="kw">table</span> r2_table(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span> <span class="kw">references</span> r1_table(<span class="kw">id</span>));</span>
-<span id="cb242-11"><a href="#cb242-11"></a><span class="ot">@end_schema_region;</span></span>
-<span id="cb242-12"><a href="#cb242-12"></a></span>
-<span id="cb242-13"><a href="#cb242-13"></a><span class="ot">@begin_schema_region r3;</span></span>
-<span id="cb242-14"><a href="#cb242-14"></a></span>
-<span id="cb242-15"><a href="#cb242-15"></a><span class="co">-- this is OK</span></span>
-<span id="cb242-16"><a href="#cb242-16"></a><span class="kw">create</span> <span class="kw">table</span> r3_table_2(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span> <span class="kw">references</span> r2_table(<span class="kw">id</span>));</span>
-<span id="cb242-17"><a href="#cb242-17"></a></span>
-<span id="cb242-18"><a href="#cb242-18"></a><span class="co">-- this is an error, no peeking into r1</span></span>
-<span id="cb242-19"><a href="#cb242-19"></a><span class="kw">create</span> <span class="kw">table</span> r3_table_1(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span> <span class="kw">references</span> r1_table(<span class="kw">id</span>));</span>
-<span id="cb242-20"><a href="#cb242-20"></a></span>
-<span id="cb242-21"><a href="#cb242-21"></a><span class="ot">@end_schema_region;</span></span></code></pre></div>
+<div class="sourceCode" id="cb242"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb242-1"><a href="#cb242-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region r1;</span></span>
+<span id="cb242-2"><a href="#cb242-2" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region r2 using r1 private;</span></span>
+<span id="cb242-3"><a href="#cb242-3" aria-hidden="true" tabindex="-1"></a><span class="ot">@declare_schema_region r3 using r2;</span></span>
+<span id="cb242-4"><a href="#cb242-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-5"><a href="#cb242-5" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region r1;</span></span>
+<span id="cb242-6"><a href="#cb242-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> r1_table(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span>);</span>
+<span id="cb242-7"><a href="#cb242-7" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span>
+<span id="cb242-8"><a href="#cb242-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-9"><a href="#cb242-9" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region r2;</span></span>
+<span id="cb242-10"><a href="#cb242-10" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> r2_table(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span> <span class="kw">references</span> r1_table(<span class="kw">id</span>));</span>
+<span id="cb242-11"><a href="#cb242-11" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span>
+<span id="cb242-12"><a href="#cb242-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-13"><a href="#cb242-13" aria-hidden="true" tabindex="-1"></a><span class="ot">@begin_schema_region r3;</span></span>
+<span id="cb242-14"><a href="#cb242-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-15"><a href="#cb242-15" aria-hidden="true" tabindex="-1"></a><span class="co">-- this is OK</span></span>
+<span id="cb242-16"><a href="#cb242-16" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> r3_table_2(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span> <span class="kw">references</span> r2_table(<span class="kw">id</span>));</span>
+<span id="cb242-17"><a href="#cb242-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-18"><a href="#cb242-18" aria-hidden="true" tabindex="-1"></a><span class="co">-- this is an error, no peeking into r1</span></span>
+<span id="cb242-19"><a href="#cb242-19" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> r3_table_1(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">primary</span> <span class="kw">key</span> <span class="kw">references</span> r1_table(<span class="kw">id</span>));</span>
+<span id="cb242-20"><a href="#cb242-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb242-21"><a href="#cb242-21" aria-hidden="true" tabindex="-1"></a><span class="ot">@end_schema_region;</span></span></code></pre></div>
 <p>As expected <code>r2</code> is still allowed to use <code>r1</code> because your private regions are not private from yourself. So you may think it’s easy to work around this privacy by simply declaring a direct dependency on r1 wherever you need it.</p>
 <pre><code>@declare_schema_region my_sneaky_region using r1, other_stuff_I_need;</code></pre>
 <p>That would seem to make it all moot. However, this is where deployable regions come in. Once you bundle your logical regions in a deployable region there’s no more peeking inside the the deployable region. So we could strengthen the above to:</p>
@@ -4125,354 +4257,354 @@ Master Deployment 2
 <h3 id="basic-usage">Basic Usage</h3>
 <p>The normal way that you do previous schema validation is to create an input file that provides both schema.</p>
 <p>This file looks maybe something like this:</p>
-<div class="sourceCode" id="cb245"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb245-1"><a href="#cb245-1"></a><span class="co">-- prev_check.sql</span></span>
-<span id="cb245-2"><a href="#cb245-2"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
-<span id="cb245-3"><a href="#cb245-3"></a>  <span class="kw">id</span> <span class="dt">integer</span>,</span>
-<span id="cb245-4"><a href="#cb245-4"></a>  new_field text @create(<span class="dv">1</span>)</span>
-<span id="cb245-5"><a href="#cb245-5"></a>);</span>
-<span id="cb245-6"><a href="#cb245-6"></a></span>
-<span id="cb245-7"><a href="#cb245-7"></a><span class="ot">@previous_schema;</span></span>
-<span id="cb245-8"><a href="#cb245-8"></a></span>
-<span id="cb245-9"><a href="#cb245-9"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
-<span id="cb245-10"><a href="#cb245-10"></a>  <span class="kw">id</span> <span class="dt">integer</span></span>
-<span id="cb245-11"><a href="#cb245-11"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb245"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb245-1"><a href="#cb245-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- prev_check.sql</span></span>
+<span id="cb245-2"><a href="#cb245-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
+<span id="cb245-3"><a href="#cb245-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span>,</span>
+<span id="cb245-4"><a href="#cb245-4" aria-hidden="true" tabindex="-1"></a>  new_field text @create(<span class="dv">1</span>)</span>
+<span id="cb245-5"><a href="#cb245-5" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb245-6"><a href="#cb245-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb245-7"><a href="#cb245-7" aria-hidden="true" tabindex="-1"></a><span class="ot">@previous_schema;</span></span>
+<span id="cb245-8"><a href="#cb245-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb245-9"><a href="#cb245-9" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
+<span id="cb245-10"><a href="#cb245-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span></span>
+<span id="cb245-11"><a href="#cb245-11" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>So here the old version of <code>foo</code> will be validated against the new version and all is well. A new nullable text field was added at the end.</p>
 <p>In practice these comparisons are liklely to be done in a somewhat more maintainable way, like this:</p>
-<div class="sourceCode" id="cb246"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb246-1"><a href="#cb246-1"></a><span class="co">-- prev_check.sql</span></span>
-<span id="cb246-2"><a href="#cb246-2"></a>#include <span class="ot">&quot;table1.sql&quot;</span></span>
-<span id="cb246-3"><a href="#cb246-3"></a>#include <span class="ot">&quot;table2.sql&quot;</span></span>
-<span id="cb246-4"><a href="#cb246-4"></a>#include <span class="ot">&quot;table3.sql&quot;</span></span>
-<span id="cb246-5"><a href="#cb246-5"></a></span>
-<span id="cb246-6"><a href="#cb246-6"></a><span class="ot">@previous_schema;</span></span>
-<span id="cb246-7"><a href="#cb246-7"></a></span>
-<span id="cb246-8"><a href="#cb246-8"></a>#include <span class="ot">&quot;previous.sql&quot;</span></span></code></pre></div>
+<div class="sourceCode" id="cb246"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb246-1"><a href="#cb246-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- prev_check.sql</span></span>
+<span id="cb246-2"><a href="#cb246-2" aria-hidden="true" tabindex="-1"></a>#include <span class="ot">&quot;table1.sql&quot;</span></span>
+<span id="cb246-3"><a href="#cb246-3" aria-hidden="true" tabindex="-1"></a>#include <span class="ot">&quot;table2.sql&quot;</span></span>
+<span id="cb246-4"><a href="#cb246-4" aria-hidden="true" tabindex="-1"></a>#include <span class="ot">&quot;table3.sql&quot;</span></span>
+<span id="cb246-5"><a href="#cb246-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb246-6"><a href="#cb246-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@previous_schema;</span></span>
+<span id="cb246-7"><a href="#cb246-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb246-8"><a href="#cb246-8" aria-hidden="true" tabindex="-1"></a>#include <span class="ot">&quot;previous.sql&quot;</span></span></code></pre></div>
 <p>Now importantly in this configuration, everything that follows the <code>@previous_schema</code> directive does not actually contribute to the declared schema. Which means the <code>--rt schema</code> result type will not see it. Because of this you can do your checking operation like so:</p>
-<div class="sourceCode" id="cb247"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb247-1"><a href="#cb247-1"></a><span class="fu">cc</span> -E -x c prev_check.sql <span class="kw">|</span> <span class="ex">cql</span> --cg new_previous_schema.sql --rt schema </span></code></pre></div>
+<div class="sourceCode" id="cb247"><pre class="sourceCode bash"><code class="sourceCode bash"><span id="cb247-1"><a href="#cb247-1" aria-hidden="true" tabindex="-1"></a><span class="fu">cc</span> <span class="at">-E</span> <span class="at">-x</span> c prev_check.sql <span class="kw">|</span> <span class="ex">cql</span> <span class="at">--cg</span> new_previous_schema.sql <span class="at">--rt</span> schema </span></code></pre></div>
 <p>The above command will generate the schema in new_previous_schema and, if this command succeeds, it’s safe to replace the existing <code>previous.sql</code> with <code>new_previous_schema</code>.</p>
 <p>NOTE: you can bootstrap the above by leaving off the <code>@previous_schema</code> and what follows to get your first previous schema from the command above.</p>
 <p>Now as, you can imagine, comparing against the previous schema allows many more kinds of errors to be discovered. What follows is a large chuck of the CQL tests for this area taken from the test files themselves.<br />
 For easy visibility I have brought each fragment of current and previous schema close to each other and I show the errors that are reported. We start with a valid fragment and go from there.</p>
 <h4 id="case-1-no-problemo">Case 1 : No problemo</h4>
-<div class="sourceCode" id="cb248"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb248-1"><a href="#cb248-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
-<span id="cb248-2"><a href="#cb248-2"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb248-3"><a href="#cb248-3"></a>  rate <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">5</span>, deletor),</span>
-<span id="cb248-4"><a href="#cb248-4"></a>  rate_2 <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">4</span>),</span>
-<span id="cb248-5"><a href="#cb248-5"></a>  id2 <span class="dt">integer</span> @create(<span class="dv">4</span>),</span>
-<span id="cb248-6"><a href="#cb248-6"></a>  name text @create(<span class="dv">5</span>),</span>
-<span id="cb248-7"><a href="#cb248-7"></a>  name_2 text @create(<span class="dv">6</span>)</span>
-<span id="cb248-8"><a href="#cb248-8"></a>);</span>
-<span id="cb248-9"><a href="#cb248-9"></a><span class="co">-------</span></span>
-<span id="cb248-10"><a href="#cb248-10"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
-<span id="cb248-11"><a href="#cb248-11"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb248-12"><a href="#cb248-12"></a>  rate <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">5</span>, deletor),</span>
-<span id="cb248-13"><a href="#cb248-13"></a>  rate_2 <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">4</span>),</span>
-<span id="cb248-14"><a href="#cb248-14"></a>  id2 <span class="dt">integer</span> @create(<span class="dv">4</span>),</span>
-<span id="cb248-15"><a href="#cb248-15"></a>  name text @create(<span class="dv">5</span>),</span>
-<span id="cb248-16"><a href="#cb248-16"></a>  name_2 text @create(<span class="dv">6</span>)</span>
-<span id="cb248-17"><a href="#cb248-17"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb248"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb248-1"><a href="#cb248-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
+<span id="cb248-2"><a href="#cb248-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb248-3"><a href="#cb248-3" aria-hidden="true" tabindex="-1"></a>  rate <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">5</span>, deletor),</span>
+<span id="cb248-4"><a href="#cb248-4" aria-hidden="true" tabindex="-1"></a>  rate_2 <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">4</span>),</span>
+<span id="cb248-5"><a href="#cb248-5" aria-hidden="true" tabindex="-1"></a>  id2 <span class="dt">integer</span> @create(<span class="dv">4</span>),</span>
+<span id="cb248-6"><a href="#cb248-6" aria-hidden="true" tabindex="-1"></a>  name text @create(<span class="dv">5</span>),</span>
+<span id="cb248-7"><a href="#cb248-7" aria-hidden="true" tabindex="-1"></a>  name_2 text @create(<span class="dv">6</span>)</span>
+<span id="cb248-8"><a href="#cb248-8" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb248-9"><a href="#cb248-9" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb248-10"><a href="#cb248-10" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
+<span id="cb248-11"><a href="#cb248-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb248-12"><a href="#cb248-12" aria-hidden="true" tabindex="-1"></a>  rate <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">5</span>, deletor),</span>
+<span id="cb248-13"><a href="#cb248-13" aria-hidden="true" tabindex="-1"></a>  rate_2 <span class="dt">long</span> <span class="dt">int</span> @delete(<span class="dv">4</span>),</span>
+<span id="cb248-14"><a href="#cb248-14" aria-hidden="true" tabindex="-1"></a>  id2 <span class="dt">integer</span> @create(<span class="dv">4</span>),</span>
+<span id="cb248-15"><a href="#cb248-15" aria-hidden="true" tabindex="-1"></a>  name text @create(<span class="dv">5</span>),</span>
+<span id="cb248-16"><a href="#cb248-16" aria-hidden="true" tabindex="-1"></a>  name_2 text @create(<span class="dv">6</span>)</span>
+<span id="cb248-17"><a href="#cb248-17" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <p>The table <code>foo</code> is the same! Doesn’t get any easier than that.</p>
 <h4 id="case-2-table-create-version-changed">Case 2 : table create version changed</h4>
-<div class="sourceCode" id="cb249"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb249-1"><a href="#cb249-1"></a><span class="kw">create</span> <span class="kw">table</span> t_create_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>);</span>
-<span id="cb249-2"><a href="#cb249-2"></a><span class="co">-------</span></span>
-<span id="cb249-3"><a href="#cb249-3"></a><span class="kw">create</span> <span class="kw">table</span> t_create_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">2</span>);</span>
-<span id="cb249-4"><a href="#cb249-4"></a></span>
-<span id="cb249-5"><a href="#cb249-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:15</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
-<span id="cb249-6"><a href="#cb249-6"></a><span class="kw">previous</span> <span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;t_create_verison_changed&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb249"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb249-1"><a href="#cb249-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_create_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>);</span>
+<span id="cb249-2"><a href="#cb249-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb249-3"><a href="#cb249-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_create_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">2</span>);</span>
+<span id="cb249-4"><a href="#cb249-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb249-5"><a href="#cb249-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:15</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
+<span id="cb249-6"><a href="#cb249-6" aria-hidden="true" tabindex="-1"></a><span class="kw">previous</span> <span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;t_create_verison_changed&#39;</span></span></code></pre></div>
 <p>You can’t change the version a table was created in. Here the new schema says it appeared in version 1. The old schema says 2.</p>
 <h4 id="case-3-table-delete-version-changed">Case 3 : table delete version changed</h4>
-<div class="sourceCode" id="cb250"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb250-1"><a href="#cb250-1"></a><span class="kw">create</span> <span class="kw">table</span> t_delete_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>);</span>
-<span id="cb250-2"><a href="#cb250-2"></a><span class="co">-------</span></span>
-<span id="cb250-3"><a href="#cb250-3"></a><span class="kw">create</span> <span class="kw">table</span> t_delete_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">2</span>);</span>
-<span id="cb250-4"><a href="#cb250-4"></a></span>
-<span id="cb250-5"><a href="#cb250-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:18</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">delete</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
-<span id="cb250-6"><a href="#cb250-6"></a><span class="kw">previous</span> <span class="kw">delete</span> version <span class="cf">for</span> <span class="st">&#39;t_delete_verison_changed&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb250"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb250-1"><a href="#cb250-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_delete_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>);</span>
+<span id="cb250-2"><a href="#cb250-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb250-3"><a href="#cb250-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_delete_verison_changed(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">2</span>);</span>
+<span id="cb250-4"><a href="#cb250-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb250-5"><a href="#cb250-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:18</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">delete</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
+<span id="cb250-6"><a href="#cb250-6" aria-hidden="true" tabindex="-1"></a><span class="kw">previous</span> <span class="kw">delete</span> version <span class="cf">for</span> <span class="st">&#39;t_delete_verison_changed&#39;</span></span></code></pre></div>
 <p>You can’t change the version a table was deleted in. Here the new schema says it was gone in version 1. The old schema says 2.</p>
 <h4 id="case-4-table-not-present-in-new-schema">Case 4 : table not present in new schema</h4>
-<div class="sourceCode" id="cb251"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb251-1"><a href="#cb251-1"></a><span class="co">-- t_not_present_in_new_schema is gone</span></span>
-<span id="cb251-2"><a href="#cb251-2"></a><span class="co">-------</span></span>
-<span id="cb251-3"><a href="#cb251-3"></a><span class="kw">create</span> <span class="kw">table</span> t_not_present_in_new_schema(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb251-4"><a href="#cb251-4"></a></span>
-<span id="cb251-5"><a href="#cb251-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:176</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">table</span> was <span class="kw">present</span> but now it</span>
-<span id="cb251-6"><a href="#cb251-6"></a>does <span class="kw">not</span> exist (<span class="kw">use</span> @delete <span class="kw">instead</span>) <span class="st">&#39;t_not_present_in_new_schema&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb251"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb251-1"><a href="#cb251-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- t_not_present_in_new_schema is gone</span></span>
+<span id="cb251-2"><a href="#cb251-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb251-3"><a href="#cb251-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_not_present_in_new_schema(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb251-4"><a href="#cb251-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb251-5"><a href="#cb251-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:176</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">table</span> was <span class="kw">present</span> but now it</span>
+<span id="cb251-6"><a href="#cb251-6" aria-hidden="true" tabindex="-1"></a>does <span class="kw">not</span> exist (<span class="kw">use</span> @delete <span class="kw">instead</span>) <span class="st">&#39;t_not_present_in_new_schema&#39;</span></span></code></pre></div>
 <p>So here <code>t_not_present_in_new_schema</code> was removed, it should have been marked with <code>@delete</code>. You don’t remove tables.</p>
 <h4 id="case-5-table-is-now-a-view">Case 5 : table is now a view</h4>
-<div class="sourceCode" id="cb252"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb252-1"><a href="#cb252-1"></a><span class="kw">create</span> <span class="kw">view</span> t_became_a_view <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span> @create(<span class="dv">6</span>);</span>
-<span id="cb252-2"><a href="#cb252-2"></a><span class="co">-------</span></span>
-<span id="cb252-3"><a href="#cb252-3"></a><span class="kw">create</span> <span class="kw">table</span> t_became_a_view(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb252-4"><a href="#cb252-4"></a></span>
-<span id="cb252-5"><a href="#cb252-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:24</span> : <span class="kw">in</span> create_view_stmt : <span class="dt">object</span> was a <span class="kw">table</span> but <span class="kw">is</span> now a</span>
-<span id="cb252-6"><a href="#cb252-6"></a><span class="kw">view</span> <span class="st">&#39;t_became_a_view&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb252"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb252-1"><a href="#cb252-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> t_became_a_view <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span> @create(<span class="dv">6</span>);</span>
+<span id="cb252-2"><a href="#cb252-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb252-3"><a href="#cb252-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_became_a_view(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb252-4"><a href="#cb252-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb252-5"><a href="#cb252-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:24</span> : <span class="kw">in</span> create_view_stmt : <span class="dt">object</span> was a <span class="kw">table</span> but <span class="kw">is</span> now a</span>
+<span id="cb252-6"><a href="#cb252-6" aria-hidden="true" tabindex="-1"></a><span class="kw">view</span> <span class="st">&#39;t_became_a_view&#39;</span></span></code></pre></div>
 <p>Tables can’t become views…</p>
 <h4 id="case-6-table-was-in-base-schema-now-created">Case 6 : table was in base schema, now created</h4>
-<div class="sourceCode" id="cb253"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb253-1"><a href="#cb253-1"></a><span class="kw">create</span> <span class="kw">table</span> t_created_in_wrong_version(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>);</span>
-<span id="cb253-2"><a href="#cb253-2"></a><span class="co">-------</span></span>
-<span id="cb253-3"><a href="#cb253-3"></a><span class="kw">create</span> <span class="kw">table</span> t_created_in_wrong_version(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb253-4"><a href="#cb253-4"></a></span>
-<span id="cb253-5"><a href="#cb253-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:27</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span> <span class="kw">previous</span></span>
-<span id="cb253-6"><a href="#cb253-6"></a><span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;t_created_in_wrong_version&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb253"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb253-1"><a href="#cb253-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_created_in_wrong_version(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>);</span>
+<span id="cb253-2"><a href="#cb253-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb253-3"><a href="#cb253-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_created_in_wrong_version(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb253-4"><a href="#cb253-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb253-5"><a href="#cb253-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:27</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span> <span class="kw">previous</span></span>
+<span id="cb253-6"><a href="#cb253-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;t_created_in_wrong_version&#39;</span></span></code></pre></div>
 <p>Here a version annotation is added after the fact. This item was already in the base schema.</p>
 <h4 id="case-7-table-was-in-base-schema-now-deleted-ok">Case 7: table was in base schema, now deleted (ok)</h4>
-<div class="sourceCode" id="cb254"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb254-1"><a href="#cb254-1"></a><span class="kw">create</span> <span class="kw">table</span> t_was_correctly_deleted(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>);</span>
-<span id="cb254-2"><a href="#cb254-2"></a><span class="co">-------</span></span>
-<span id="cb254-3"><a href="#cb254-3"></a><span class="kw">create</span> <span class="kw">table</span> t_was_correctly_deleted(<span class="kw">id</span> <span class="dt">integer</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb254"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb254-1"><a href="#cb254-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_was_correctly_deleted(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>);</span>
+<span id="cb254-2"><a href="#cb254-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb254-3"><a href="#cb254-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_was_correctly_deleted(<span class="kw">id</span> <span class="dt">integer</span>);</span></code></pre></div>
 <p>No errors here, regular delete.</p>
 <h4 id="case-8-column-name-changed">Case 8: column name changed</h4>
-<div class="sourceCode" id="cb255"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb255-1"><a href="#cb255-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_name_changed(id_ <span class="dt">integer</span>);</span>
-<span id="cb255-2"><a href="#cb255-2"></a><span class="co">-------</span></span>
-<span id="cb255-3"><a href="#cb255-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_name_changed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb255-4"><a href="#cb255-4"></a></span>
-<span id="cb255-5"><a href="#cb255-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:33</span> : <span class="kw">in</span> str : <span class="kw">column</span> name <span class="kw">is</span> different <span class="kw">between</span> <span class="kw">previous</span> <span class="kw">and</span></span>
-<span id="cb255-6"><a href="#cb255-6"></a><span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;id_&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb255"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb255-1"><a href="#cb255-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_name_changed(id_ <span class="dt">integer</span>);</span>
+<span id="cb255-2"><a href="#cb255-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb255-3"><a href="#cb255-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_name_changed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb255-4"><a href="#cb255-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb255-5"><a href="#cb255-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:33</span> : <span class="kw">in</span> str : <span class="kw">column</span> name <span class="kw">is</span> different <span class="kw">between</span> <span class="kw">previous</span> <span class="kw">and</span></span>
+<span id="cb255-6"><a href="#cb255-6" aria-hidden="true" tabindex="-1"></a><span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;id_&#39;</span></span></code></pre></div>
 <p>You can’t rename columns. We could support this but it’s a bit of maintenance nightmare and logical renames are possible easily without doing physical renames.</p>
 <h4 id="case-9-column-type-changed">Case 9 : column type changed</h4>
-<div class="sourceCode" id="cb256"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb256-1"><a href="#cb256-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_type_changed(<span class="kw">id</span> <span class="dt">real</span>);</span>
-<span id="cb256-2"><a href="#cb256-2"></a><span class="co">-------</span></span>
-<span id="cb256-3"><a href="#cb256-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_type_changed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb256-4"><a href="#cb256-4"></a></span>
-<span id="cb256-5"><a href="#cb256-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:36</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">type</span> <span class="kw">is</span> different <span class="kw">between</span> <span class="kw">previous</span></span>
-<span id="cb256-6"><a href="#cb256-6"></a><span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;id&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb256"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb256-1"><a href="#cb256-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_type_changed(<span class="kw">id</span> <span class="dt">real</span>);</span>
+<span id="cb256-2"><a href="#cb256-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb256-3"><a href="#cb256-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_type_changed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb256-4"><a href="#cb256-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb256-5"><a href="#cb256-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:36</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">type</span> <span class="kw">is</span> different <span class="kw">between</span> <span class="kw">previous</span></span>
+<span id="cb256-6"><a href="#cb256-6" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;id&#39;</span></span></code></pre></div>
 <p>Can’t change the type of a column.</p>
 <h4 id="case-10-column-attribute-changed">Case 10 : column attribute changed</h4>
-<div class="sourceCode" id="cb257"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb257-1"><a href="#cb257-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_attribute_changed(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb257-2"><a href="#cb257-2"></a><span class="co">-------</span></span>
-<span id="cb257-3"><a href="#cb257-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_attribute_changed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb257-4"><a href="#cb257-4"></a></span>
-<span id="cb257-5"><a href="#cb257-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:39</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">type</span> <span class="kw">is</span> different <span class="kw">between</span> <span class="kw">previous</span></span>
-<span id="cb257-6"><a href="#cb257-6"></a><span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;id&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb257"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb257-1"><a href="#cb257-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_attribute_changed(<span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb257-2"><a href="#cb257-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb257-3"><a href="#cb257-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_attribute_changed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb257-4"><a href="#cb257-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb257-5"><a href="#cb257-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:39</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">type</span> <span class="kw">is</span> different <span class="kw">between</span> <span class="kw">previous</span></span>
+<span id="cb257-6"><a href="#cb257-6" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;id&#39;</span></span></code></pre></div>
 <p>Change of column attributes counts as a change of type.</p>
 <h4 id="case-11-column-version-changed-for-delete">Case 11: column version changed for delete</h4>
-<div class="sourceCode" id="cb258"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb258-1"><a href="#cb258-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_delete_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @delete(<span class="dv">1</span>));</span>
-<span id="cb258-2"><a href="#cb258-2"></a><span class="co">-------</span></span>
-<span id="cb258-3"><a href="#cb258-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_delete_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @delete(<span class="dv">2</span>));</span>
-<span id="cb258-4"><a href="#cb258-4"></a></span>
-<span id="cb258-5"><a href="#cb258-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:42</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">current</span> <span class="kw">delete</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
-<span id="cb258-6"><a href="#cb258-6"></a><span class="kw">previous</span> <span class="kw">delete</span> version <span class="st">&#39;id2&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb258"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb258-1"><a href="#cb258-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_delete_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @delete(<span class="dv">1</span>));</span>
+<span id="cb258-2"><a href="#cb258-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb258-3"><a href="#cb258-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_delete_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @delete(<span class="dv">2</span>));</span>
+<span id="cb258-4"><a href="#cb258-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb258-5"><a href="#cb258-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:42</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">current</span> <span class="kw">delete</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
+<span id="cb258-6"><a href="#cb258-6" aria-hidden="true" tabindex="-1"></a><span class="kw">previous</span> <span class="kw">delete</span> version <span class="st">&#39;id2&#39;</span></span></code></pre></div>
 <p>You can’t change the delete version after it has been set.</p>
 <h4 id="case-12-column-version-changed-for-create">Case 12 : column version changed for create</h4>
-<div class="sourceCode" id="cb259"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb259-1"><a href="#cb259-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_create_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @create(<span class="dv">1</span>));</span>
-<span id="cb259-2"><a href="#cb259-2"></a><span class="co">-------</span></span>
-<span id="cb259-3"><a href="#cb259-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_create_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @create(<span class="dv">2</span>));</span>
-<span id="cb259-4"><a href="#cb259-4"></a></span>
-<span id="cb259-5"><a href="#cb259-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:45</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
-<span id="cb259-6"><a href="#cb259-6"></a><span class="kw">previous</span> <span class="kw">create</span> version <span class="st">&#39;id2&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb259"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb259-1"><a href="#cb259-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_create_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @create(<span class="dv">1</span>));</span>
+<span id="cb259-2"><a href="#cb259-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb259-3"><a href="#cb259-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_create_version_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> @create(<span class="dv">2</span>));</span>
+<span id="cb259-4"><a href="#cb259-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb259-5"><a href="#cb259-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:45</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span></span>
+<span id="cb259-6"><a href="#cb259-6" aria-hidden="true" tabindex="-1"></a><span class="kw">previous</span> <span class="kw">create</span> version <span class="st">&#39;id2&#39;</span></span></code></pre></div>
 <p>You can’t change the create version after it has been set.</p>
 <h4 id="case-13-column-default-value-changed">Case 13 : column default value changed</h4>
-<div class="sourceCode" id="cb260"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb260-1"><a href="#cb260-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">2</span>);</span>
-<span id="cb260-2"><a href="#cb260-2"></a><span class="co">-------</span></span>
-<span id="cb260-3"><a href="#cb260-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">1</span>);</span>
-<span id="cb260-4"><a href="#cb260-4"></a></span>
-<span id="cb260-5"><a href="#cb260-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:48</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">current</span> <span class="kw">default</span> <span class="fu">value</span> <span class="kw">not</span> equal <span class="kw">to</span></span>
-<span id="cb260-6"><a href="#cb260-6"></a><span class="kw">previous</span> <span class="kw">default</span> <span class="fu">value</span> <span class="st">&#39;id2&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb260"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb260-1"><a href="#cb260-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">2</span>);</span>
+<span id="cb260-2"><a href="#cb260-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb260-3"><a href="#cb260-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_changed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">1</span>);</span>
+<span id="cb260-4"><a href="#cb260-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb260-5"><a href="#cb260-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:48</span> : <span class="kw">in</span> str : <span class="kw">column</span> <span class="kw">current</span> <span class="kw">default</span> <span class="fu">value</span> <span class="kw">not</span> equal <span class="kw">to</span></span>
+<span id="cb260-6"><a href="#cb260-6" aria-hidden="true" tabindex="-1"></a><span class="kw">previous</span> <span class="kw">default</span> <span class="fu">value</span> <span class="st">&#39;id2&#39;</span></span></code></pre></div>
 <p>You can’t change the default value after the fact. There’s no alter statement that would allow this even though it makes some logical sense.</p>
 <h4 id="case-14-column-default-value-did-not-change-ok">Case 14 : column default value did not change (ok)</h4>
-<div class="sourceCode" id="cb261"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb261-1"><a href="#cb261-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_ok(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">1</span>);</span>
-<span id="cb261-2"><a href="#cb261-2"></a><span class="co">-------</span></span>
-<span id="cb261-3"><a href="#cb261-3"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_ok(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb261"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb261-1"><a href="#cb261-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_ok(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">1</span>);</span>
+<span id="cb261-2"><a href="#cb261-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb261-3"><a href="#cb261-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_column_default_value_ok(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span> <span class="kw">default</span> <span class="dv">1</span>);</span></code></pre></div>
 <p>No change. No error here.</p>
 <h4 id="case-15-create-table-with-additional-attribute-present-and-matching-ok">Case 15 : create table with additional attribute present and matching (ok)</h4>
-<div class="sourceCode" id="cb262"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb262-1"><a href="#cb262-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_present(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span> (a,b));</span>
-<span id="cb262-2"><a href="#cb262-2"></a><span class="co">-------</span></span>
-<span id="cb262-3"><a href="#cb262-3"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_present(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span> (a,b));</span></code></pre></div>
+<div class="sourceCode" id="cb262"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb262-1"><a href="#cb262-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_present(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span> (a,b));</span>
+<span id="cb262-2"><a href="#cb262-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb262-3"><a href="#cb262-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_present(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span> (a,b));</span></code></pre></div>
 <p>No change. No error here.</p>
 <h4 id="case-16-create-table-with-additional-attribute-doesnt-match">Case 16 : create table with additional attribute (doesn’t match)</h4>
-<div class="sourceCode" id="cb263"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb263-1"><a href="#cb263-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_mismatch(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">primary</span> <span class="kw">key</span> (a));</span>
-<span id="cb263-2"><a href="#cb263-2"></a><span class="co">-------</span></span>
-<span id="cb263-3"><a href="#cb263-3"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_mismatch(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span> (a,b));</span>
-<span id="cb263-4"><a href="#cb263-4"></a></span>
-<span id="cb263-5"><a href="#cb263-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:57</span> : <span class="kw">in</span> pk_def : a <span class="kw">table</span> facet <span class="kw">is</span> different <span class="kw">in</span> <span class="kw">the</span> <span class="kw">previous</span></span>
-<span id="cb263-6"><a href="#cb263-6"></a><span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span></span></code></pre></div>
+<div class="sourceCode" id="cb263"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb263-1"><a href="#cb263-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_mismatch(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">primary</span> <span class="kw">key</span> (a));</span>
+<span id="cb263-2"><a href="#cb263-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb263-3"><a href="#cb263-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_attribute_mismatch(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span> (a,b));</span>
+<span id="cb263-4"><a href="#cb263-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb263-5"><a href="#cb263-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:57</span> : <span class="kw">in</span> pk_def : a <span class="kw">table</span> facet <span class="kw">is</span> different <span class="kw">in</span> <span class="kw">the</span> <span class="kw">previous</span></span>
+<span id="cb263-6"><a href="#cb263-6" aria-hidden="true" tabindex="-1"></a><span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span></span></code></pre></div>
 <h4 id="case-17-column-removed">Case 17 : column removed</h4>
-<div class="sourceCode" id="cb264"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb264-1"><a href="#cb264-1"></a><span class="kw">create</span> <span class="kw">table</span> t_columns_removed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
-<span id="cb264-2"><a href="#cb264-2"></a><span class="co">-------</span></span>
-<span id="cb264-3"><a href="#cb264-3"></a><span class="kw">create</span> <span class="kw">table</span> t_columns_removed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span>);</span>
-<span id="cb264-4"><a href="#cb264-4"></a></span>
-<span id="cb264-5"><a href="#cb264-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:255</span> : <span class="kw">in</span> col_def : items have been removed <span class="kw">from</span> <span class="kw">the</span> <span class="kw">table</span></span>
-<span id="cb264-6"><a href="#cb264-6"></a>rather <span class="kw">than</span> marked <span class="kw">with</span> @delete <span class="st">&#39;t_columns_removed&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb264"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb264-1"><a href="#cb264-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_columns_removed(<span class="kw">id</span> <span class="dt">integer</span>);</span>
+<span id="cb264-2"><a href="#cb264-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb264-3"><a href="#cb264-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_columns_removed(<span class="kw">id</span> <span class="dt">integer</span>, id2 <span class="dt">integer</span>);</span>
+<span id="cb264-4"><a href="#cb264-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb264-5"><a href="#cb264-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:255</span> : <span class="kw">in</span> col_def : items have been removed <span class="kw">from</span> <span class="kw">the</span> <span class="kw">table</span></span>
+<span id="cb264-6"><a href="#cb264-6" aria-hidden="true" tabindex="-1"></a>rather <span class="kw">than</span> marked <span class="kw">with</span> @delete <span class="st">&#39;t_columns_removed&#39;</span></span></code></pre></div>
 <p>You can’t remove columns from tables. You have to mark them with <code>@delete</code> instead.</p>
 <h4 id="case-18-create-table-with-added-facet-not-present-in-the-previous">Case 18 : create table with added facet not present in the previous</h4>
-<div class="sourceCode" id="cb265"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb265-1"><a href="#cb265-1"></a><span class="kw">create</span> <span class="kw">table</span> t_attribute_added(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">primary</span> <span class="kw">key</span> (a));</span>
-<span id="cb265-2"><a href="#cb265-2"></a><span class="co">-------</span></span>
-<span id="cb265-3"><a href="#cb265-3"></a><span class="kw">create</span> <span class="kw">table</span> t_attribute_added(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb265-4"><a href="#cb265-4"></a></span>
-<span id="cb265-5"><a href="#cb265-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:63</span> : <span class="kw">in</span> pk_def : <span class="kw">table</span> has a facet that <span class="kw">is</span> different <span class="kw">in</span> <span class="kw">the</span></span>
-<span id="cb265-6"><a href="#cb265-6"></a><span class="kw">previous</span> <span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;t_attribute_added&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb265"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb265-1"><a href="#cb265-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_attribute_added(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, <span class="kw">primary</span> <span class="kw">key</span> (a));</span>
+<span id="cb265-2"><a href="#cb265-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb265-3"><a href="#cb265-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_attribute_added(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb265-4"><a href="#cb265-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb265-5"><a href="#cb265-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:63</span> : <span class="kw">in</span> pk_def : <span class="kw">table</span> has a facet that <span class="kw">is</span> different <span class="kw">in</span> <span class="kw">the</span></span>
+<span id="cb265-6"><a href="#cb265-6" aria-hidden="true" tabindex="-1"></a><span class="kw">previous</span> <span class="kw">and</span> <span class="kw">current</span> <span class="kw">schema</span> <span class="st">&#39;t_attribute_added&#39;</span></span></code></pre></div>
 <p>Table facets like primary keys cannot be added after the fact. There is no way to do this in sqlite.</p>
 <h4 id="case-19-create-table-with-additional-column-and-no-create">Case 19 : create table with additional column and no <code>@create</code></h4>
-<div class="sourceCode" id="cb266"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb266-1"><a href="#cb266-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
-<span id="cb266-2"><a href="#cb266-2"></a><span class="co">-------</span></span>
-<span id="cb266-3"><a href="#cb266-3"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb266-4"><a href="#cb266-4"></a></span>
-<span id="cb266-5"><a href="#cb266-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:66</span> : <span class="kw">in</span> col_def : <span class="kw">table</span> has <span class="kw">columns</span> added <span class="kw">without</span> marking</span>
-<span id="cb266-6"><a href="#cb266-6"></a>them @create <span class="st">&#39;t_additional_column&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb266"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb266-1"><a href="#cb266-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
+<span id="cb266-2"><a href="#cb266-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb266-3"><a href="#cb266-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb266-4"><a href="#cb266-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb266-5"><a href="#cb266-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:66</span> : <span class="kw">in</span> col_def : <span class="kw">table</span> has <span class="kw">columns</span> added <span class="kw">without</span> marking</span>
+<span id="cb266-6"><a href="#cb266-6" aria-hidden="true" tabindex="-1"></a>them @create <span class="st">&#39;t_additional_column&#39;</span></span></code></pre></div>
 <p>If you add a new column like <code>b</code> above you have to mark it with <code>@create</code> in a suitable version.</p>
 <h4 id="case-20-create-table-with-additional-column-and-create-ok">Case 20 : create table with additional column and `<code>@create</code> (ok)</h4>
-<div class="sourceCode" id="cb267"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb267-1"><a href="#cb267-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column_ok(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">2</span>), c <span class="dt">int</span> @create(<span class="dv">6</span>));</span>
-<span id="cb267-2"><a href="#cb267-2"></a><span class="co">-------</span></span>
-<span id="cb267-3"><a href="#cb267-3"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column_ok(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">2</span>));</span></code></pre></div>
+<div class="sourceCode" id="cb267"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb267-1"><a href="#cb267-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column_ok(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">2</span>), c <span class="dt">int</span> @create(<span class="dv">6</span>));</span>
+<span id="cb267-2"><a href="#cb267-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb267-3"><a href="#cb267-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_additional_column_ok(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">2</span>));</span></code></pre></div>
 <p>Column properly created. No errors here.</p>
 <h4 id="case-21-create-table-with-different-flags-like-temp">Case 21 : create table with different flags (like TEMP)</h4>
-<div class="sourceCode" id="cb268"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb268-1"><a href="#cb268-1"></a><span class="kw">create</span> TEMP <span class="kw">table</span> t_becomes_temp_table(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
-<span id="cb268-2"><a href="#cb268-2"></a><span class="co">-------</span></span>
-<span id="cb268-3"><a href="#cb268-3"></a><span class="kw">create</span> <span class="kw">table</span> t_becomes_temp_table(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
-<span id="cb268-4"><a href="#cb268-4"></a></span>
-<span id="cb268-5"><a href="#cb268-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:72</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">table</span> <span class="kw">create</span> statement <span class="kw">attributes</span></span>
-<span id="cb268-6"><a href="#cb268-6"></a>different <span class="kw">than</span> <span class="kw">previous</span> version <span class="st">&#39;t_becomes_temp_table&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb268"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb268-1"><a href="#cb268-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> TEMP <span class="kw">table</span> t_becomes_temp_table(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
+<span id="cb268-2"><a href="#cb268-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb268-3"><a href="#cb268-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_becomes_temp_table(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
+<span id="cb268-4"><a href="#cb268-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb268-5"><a href="#cb268-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:72</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">table</span> <span class="kw">create</span> statement <span class="kw">attributes</span></span>
+<span id="cb268-6"><a href="#cb268-6" aria-hidden="true" tabindex="-1"></a>different <span class="kw">than</span> <span class="kw">previous</span> version <span class="st">&#39;t_becomes_temp_table&#39;</span></span></code></pre></div>
 <p>Table became a TEMP table, there is no way to generate an alter statement for that. Not allowed.</p>
 <h4 id="case-22-create-table-and-apply-annotation-ok">Case 22 : create table and apply annotation (ok)</h4>
-<div class="sourceCode" id="cb269"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb269-1"><a href="#cb269-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_ok(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>) @create(<span class="dv">6</span>);</span>
-<span id="cb269-2"><a href="#cb269-2"></a><span class="co">-------</span></span>
-<span id="cb269-3"><a href="#cb269-3"></a><span class="co">-- no previous version </span></span></code></pre></div>
+<div class="sourceCode" id="cb269"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb269-1"><a href="#cb269-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_ok(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>) @create(<span class="dv">6</span>);</span>
+<span id="cb269-2"><a href="#cb269-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb269-3"><a href="#cb269-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- no previous version </span></span></code></pre></div>
 <p>No errors here, properly created new table.</p>
 <h4 id="case-23-create-new-table-without-annotation-error">Case 23 : create new table without annotation (error)</h4>
-<div class="sourceCode" id="cb270"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb270-1"><a href="#cb270-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_no_annotation(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
-<span id="cb270-2"><a href="#cb270-2"></a><span class="co">-------</span></span>
-<span id="cb270-3"><a href="#cb270-3"></a><span class="co">-- no previous version </span></span>
-<span id="cb270-4"><a href="#cb270-4"></a></span>
-<span id="cb270-5"><a href="#cb270-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:85</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">new</span> <span class="kw">table</span> must be added <span class="kw">with</span></span>
-<span id="cb270-6"><a href="#cb270-6"></a><span class="ot">@create(6) or later &#39;t_new_table_no_annotation&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb270"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb270-1"><a href="#cb270-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_no_annotation(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>);</span>
+<span id="cb270-2"><a href="#cb270-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb270-3"><a href="#cb270-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- no previous version </span></span>
+<span id="cb270-4"><a href="#cb270-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb270-5"><a href="#cb270-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:85</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">new</span> <span class="kw">table</span> must be added <span class="kw">with</span></span>
+<span id="cb270-6"><a href="#cb270-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@create(6) or later &#39;t_new_table_no_annotation&#39;</span></span></code></pre></div>
 <p>This table was added with no annotation. It has to have an <span class="citation" data-cites="create">@create</span> and be at least version 6, the current largest.</p>
 <h4 id="case-24-create-new-table-stale-annotation-error">Case 24 : create new table stale annotation (error)</h4>
-<div class="sourceCode" id="cb271"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb271-1"><a href="#cb271-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_stale_annotation(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>) @create(<span class="dv">2</span>);</span>
-<span id="cb271-2"><a href="#cb271-2"></a><span class="co">-------</span></span>
-<span id="cb271-3"><a href="#cb271-3"></a><span class="co">-- no previous version </span></span>
-<span id="cb271-4"><a href="#cb271-4"></a></span>
-<span id="cb271-5"><a href="#cb271-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:91</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">new</span> <span class="kw">table</span> must be added <span class="kw">with</span></span>
-<span id="cb271-6"><a href="#cb271-6"></a><span class="ot">@create(6) or later &#39;t_new_table_stale_annotation&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb271"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb271-1"><a href="#cb271-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_stale_annotation(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span>) @create(<span class="dv">2</span>);</span>
+<span id="cb271-2"><a href="#cb271-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb271-3"><a href="#cb271-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- no previous version </span></span>
+<span id="cb271-4"><a href="#cb271-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb271-5"><a href="#cb271-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:91</span> : <span class="kw">in</span> create_table_stmt : <span class="kw">new</span> <span class="kw">table</span> must be added <span class="kw">with</span></span>
+<span id="cb271-6"><a href="#cb271-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@create(6) or later &#39;t_new_table_stale_annotation&#39;</span></span></code></pre></div>
 <p>The schema is already up to version 6. You can’t then add a table in the past at version 2.</p>
 <h4 id="case-25-add-columns-to-table-marked-create-and-delete">Case 25 : add columns to table, marked <code>@create</code> and <code>@delete</code></h4>
-<div class="sourceCode" id="cb272"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb272-1"><a href="#cb272-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_create_and_delete(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">6</span>) @delete(<span class="dv">7</span>));</span>
-<span id="cb272-2"><a href="#cb272-2"></a><span class="co">-------</span></span>
-<span id="cb272-3"><a href="#cb272-3"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_create_and_delete(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb272-4"><a href="#cb272-4"></a></span>
-<span id="cb272-5"><a href="#cb272-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:96</span> : <span class="kw">in</span> col_def : <span class="kw">table</span> has newly added <span class="kw">columns</span> that are</span>
-<span id="cb272-6"><a href="#cb272-6"></a>marked <span class="kw">both</span> @create <span class="kw">and</span> @delete <span class="st">&#39;t_new_table_create_and_delete&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb272"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb272-1"><a href="#cb272-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_create_and_delete(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">6</span>) @delete(<span class="dv">7</span>));</span>
+<span id="cb272-2"><a href="#cb272-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb272-3"><a href="#cb272-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_table_create_and_delete(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb272-4"><a href="#cb272-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb272-5"><a href="#cb272-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:96</span> : <span class="kw">in</span> col_def : <span class="kw">table</span> has newly added <span class="kw">columns</span> that are</span>
+<span id="cb272-6"><a href="#cb272-6" aria-hidden="true" tabindex="-1"></a>marked <span class="kw">both</span> @create <span class="kw">and</span> @delete <span class="st">&#39;t_new_table_create_and_delete&#39;</span></span></code></pre></div>
 <p>Adding a column in the new version and marking it both create and delete is … weird… don’t do that. You can do it but you have to do it one step at a time.</p>
 <h4 id="case-26-add-columns-to-table-marked-create-correctly">Case 26 : add columns to table, marked <code>@create</code> correctly</h4>
-<div class="sourceCode" id="cb273"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb273-1"><a href="#cb273-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_legit_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">6</span>));</span>
-<span id="cb273-2"><a href="#cb273-2"></a><span class="co">-------</span></span>
-<span id="cb273-3"><a href="#cb273-3"></a><span class="kw">create</span> <span class="kw">table</span> t_new_legit_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb273"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb273-1"><a href="#cb273-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_legit_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>, b <span class="dt">int</span> @create(<span class="dv">6</span>));</span>
+<span id="cb273-2"><a href="#cb273-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb273-3"><a href="#cb273-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t_new_legit_column(a <span class="dt">int</span> <span class="kw">not</span> <span class="kw">null</span>);</span></code></pre></div>
 <p>No errors here, new column added in legit version.</p>
 <h4 id="case-27-create-table-with-a-create-migration-proc-where-there-was-none">Case 27 : create table with a create migration proc where there was none</h4>
-<div class="sourceCode" id="cb274"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb274-1"><a href="#cb274-1"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>, ACreateMigrator);</span>
-<span id="cb274-2"><a href="#cb274-2"></a><span class="co">-------</span></span>
-<span id="cb274-3"><a href="#cb274-3"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>);</span>
-<span id="cb274-4"><a href="#cb274-4"></a></span>
-<span id="cb274-5"><a href="#cb274-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:104</span> : <span class="kw">in</span> str : @create <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
-<span id="cb274-6"><a href="#cb274-6"></a><span class="st">&#39;with_create_migrator&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb274"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb274-1"><a href="#cb274-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>, ACreateMigrator);</span>
+<span id="cb274-2"><a href="#cb274-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb274-3"><a href="#cb274-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>);</span>
+<span id="cb274-4"><a href="#cb274-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb274-5"><a href="#cb274-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:104</span> : <span class="kw">in</span> str : @create <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
+<span id="cb274-6"><a href="#cb274-6" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;with_create_migrator&#39;</span></span></code></pre></div>
 <p>You can’t add a create migration proc after the fact.</p>
 <h4 id="case-28-create-table-with-a-different-create-migration-proc">Case 28 : create table with a different create migration proc</h4>
-<div class="sourceCode" id="cb275"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb275-1"><a href="#cb275-1"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>, ACreateMigrator);</span>
-<span id="cb275-2"><a href="#cb275-2"></a><span class="co">-------</span></span>
-<span id="cb275-3"><a href="#cb275-3"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>, ADifferentCreateMigrator);</span>
-<span id="cb275-4"><a href="#cb275-4"></a></span>
-<span id="cb275-5"><a href="#cb275-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:104</span> : <span class="kw">in</span> str : @create <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
-<span id="cb275-6"><a href="#cb275-6"></a><span class="st">&#39;with_create_migrator&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb275"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb275-1"><a href="#cb275-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>, ACreateMigrator);</span>
+<span id="cb275-2"><a href="#cb275-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb275-3"><a href="#cb275-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_create_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @create(<span class="dv">1</span>, ADifferentCreateMigrator);</span>
+<span id="cb275-4"><a href="#cb275-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb275-5"><a href="#cb275-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:104</span> : <span class="kw">in</span> str : @create <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
+<span id="cb275-6"><a href="#cb275-6" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;with_create_migrator&#39;</span></span></code></pre></div>
 <p>You can’t change a create migration proc after the fact.</p>
 <h4 id="case-29-create-table-with-a-delete-migration-proc-where-there-was-none">Case 29 : create table with a delete migration proc where there was none</h4>
-<div class="sourceCode" id="cb276"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb276-1"><a href="#cb276-1"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>, ADeleteMigrator);</span>
-<span id="cb276-2"><a href="#cb276-2"></a><span class="co">-------</span></span>
-<span id="cb276-3"><a href="#cb276-3"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>);</span>
-<span id="cb276-4"><a href="#cb276-4"></a></span>
-<span id="cb276-5"><a href="#cb276-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:107</span> : <span class="kw">in</span> str : @delete <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
-<span id="cb276-6"><a href="#cb276-6"></a><span class="st">&#39;with_delete_migrator&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb276"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb276-1"><a href="#cb276-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>, ADeleteMigrator);</span>
+<span id="cb276-2"><a href="#cb276-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb276-3"><a href="#cb276-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>);</span>
+<span id="cb276-4"><a href="#cb276-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb276-5"><a href="#cb276-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:107</span> : <span class="kw">in</span> str : @delete <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
+<span id="cb276-6"><a href="#cb276-6" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;with_delete_migrator&#39;</span></span></code></pre></div>
 <p>You can’t add a delete migration proc after the fact.</p>
 <h4 id="case-30-create-table-with-a-different-delete-migration-proc">Case 30 : create table with a different delete migration proc</h4>
-<div class="sourceCode" id="cb277"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb277-1"><a href="#cb277-1"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>, ADeleteMigrator);</span>
-<span id="cb277-2"><a href="#cb277-2"></a><span class="co">-------</span></span>
-<span id="cb277-3"><a href="#cb277-3"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>, ADifferentDeleteMigrator);</span>
-<span id="cb277-4"><a href="#cb277-4"></a></span>
-<span id="cb277-5"><a href="#cb277-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:107</span> : <span class="kw">in</span> str : @delete <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
-<span id="cb277-6"><a href="#cb277-6"></a><span class="st">&#39;with_delete_migrator&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb277"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb277-1"><a href="#cb277-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>, ADeleteMigrator);</span>
+<span id="cb277-2"><a href="#cb277-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb277-3"><a href="#cb277-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> with_delete_migrator(<span class="kw">id</span> <span class="dt">integer</span>) @delete(<span class="dv">1</span>, ADifferentDeleteMigrator);</span>
+<span id="cb277-4"><a href="#cb277-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb277-5"><a href="#cb277-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:107</span> : <span class="kw">in</span> str : @delete <span class="kw">procedure</span> changed <span class="kw">in</span> <span class="dt">object</span></span>
+<span id="cb277-6"><a href="#cb277-6" aria-hidden="true" tabindex="-1"></a><span class="st">&#39;with_delete_migrator&#39;</span></span></code></pre></div>
 <p>You can’t change a delete migration proc after the fact.</p>
 <h4 id="case-31-create-a-table-which-was-a-view-in-the-previous-schema">Case 31 : create a table which was a view in the previous schema</h4>
-<div class="sourceCode" id="cb278"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb278-1"><a href="#cb278-1"></a><span class="kw">create</span> <span class="kw">table</span> view_becomes_a_table(<span class="kw">id</span> <span class="dt">int</span>);</span>
-<span id="cb278-2"><a href="#cb278-2"></a><span class="co">-------</span></span>
-<span id="cb278-3"><a href="#cb278-3"></a><span class="kw">create</span> <span class="kw">view</span> view_becomes_a_table <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
-<span id="cb278-4"><a href="#cb278-4"></a></span>
-<span id="cb278-5"><a href="#cb278-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:110</span> : <span class="kw">in</span> create_table_stmt : <span class="dt">object</span> was a <span class="kw">view</span> but <span class="kw">is</span> now a</span>
-<span id="cb278-6"><a href="#cb278-6"></a><span class="kw">table</span> <span class="st">&#39;view_becomes_a_table&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb278"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb278-1"><a href="#cb278-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> view_becomes_a_table(<span class="kw">id</span> <span class="dt">int</span>);</span>
+<span id="cb278-2"><a href="#cb278-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb278-3"><a href="#cb278-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> view_becomes_a_table <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
+<span id="cb278-4"><a href="#cb278-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb278-5"><a href="#cb278-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:110</span> : <span class="kw">in</span> create_table_stmt : <span class="dt">object</span> was a <span class="kw">view</span> but <span class="kw">is</span> now a</span>
+<span id="cb278-6"><a href="#cb278-6" aria-hidden="true" tabindex="-1"></a><span class="kw">table</span> <span class="st">&#39;view_becomes_a_table&#39;</span></span></code></pre></div>
 <p>Converting views to tables is not allowed.</p>
 <h4 id="case-32-delete-a-view-without-marking-it-deleted">Case 32 : delete a view without marking it deleted</h4>
-<div class="sourceCode" id="cb279"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb279-1"><a href="#cb279-1"></a><span class="co">--- no matching view in current schema</span></span>
-<span id="cb279-2"><a href="#cb279-2"></a><span class="co">-------</span></span>
-<span id="cb279-3"><a href="#cb279-3"></a><span class="kw">create</span> <span class="kw">view</span> view_was_zomg_deleted <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
-<span id="cb279-4"><a href="#cb279-4"></a></span>
-<span id="cb279-5"><a href="#cb279-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:333</span> : <span class="kw">in</span> create_view_stmt : <span class="kw">view</span> was <span class="kw">present</span> but now it does</span>
-<span id="cb279-6"><a href="#cb279-6"></a><span class="kw">not</span> exist (<span class="kw">use</span> @delete <span class="kw">instead</span>) <span class="st">&#39;view_was_zomg_deleted&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb279"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb279-1"><a href="#cb279-1" aria-hidden="true" tabindex="-1"></a><span class="co">--- no matching view in current schema</span></span>
+<span id="cb279-2"><a href="#cb279-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb279-3"><a href="#cb279-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> view_was_zomg_deleted <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
+<span id="cb279-4"><a href="#cb279-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb279-5"><a href="#cb279-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:333</span> : <span class="kw">in</span> create_view_stmt : <span class="kw">view</span> was <span class="kw">present</span> but now it does</span>
+<span id="cb279-6"><a href="#cb279-6" aria-hidden="true" tabindex="-1"></a><span class="kw">not</span> exist (<span class="kw">use</span> @delete <span class="kw">instead</span>) <span class="st">&#39;view_was_zomg_deleted&#39;</span></span></code></pre></div>
 <p>Here the view was deleted rather than marking it with <code>@delete</code>.</p>
 <h4 id="case-33-create-a-new-version-of-this-view-that-is-not-temp">Case 33 : create a new version of this view that is not temp</h4>
-<div class="sourceCode" id="cb280"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb280-1"><a href="#cb280-1"></a><span class="kw">create</span> <span class="kw">view</span> view_was_temp_but_now_it_is_not <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
-<span id="cb280-2"><a href="#cb280-2"></a><span class="co">-------</span></span>
-<span id="cb280-3"><a href="#cb280-3"></a><span class="kw">create</span> temp <span class="kw">view</span> view_was_temp_but_now_it_is_not <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
-<span id="cb280-4"><a href="#cb280-4"></a></span>
-<span id="cb280-5"><a href="#cb280-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:339</span> : <span class="kw">in</span> create_view_stmt : TEMP property changed <span class="kw">in</span> <span class="kw">new</span></span>
-<span id="cb280-6"><a href="#cb280-6"></a><span class="kw">schema</span> <span class="cf">for</span> <span class="kw">view</span> <span class="st">&#39;view_was_temp_but_now_it_is_not&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb280"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb280-1"><a href="#cb280-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> view_was_temp_but_now_it_is_not <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
+<span id="cb280-2"><a href="#cb280-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb280-3"><a href="#cb280-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> temp <span class="kw">view</span> view_was_temp_but_now_it_is_not <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
+<span id="cb280-4"><a href="#cb280-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb280-5"><a href="#cb280-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:339</span> : <span class="kw">in</span> create_view_stmt : TEMP property changed <span class="kw">in</span> <span class="kw">new</span></span>
+<span id="cb280-6"><a href="#cb280-6" aria-hidden="true" tabindex="-1"></a><span class="kw">schema</span> <span class="cf">for</span> <span class="kw">view</span> <span class="st">&#39;view_was_temp_but_now_it_is_not&#39;</span></span></code></pre></div>
 <p>A temp view became a view. This flag is not allowed to change. Side note: temp views are weird.</p>
 <h4 id="case-34-create-a-new-version-of-this-view-that-was-created-in-a-different-version">Case 34 : create a new version of this view that was created in a different version</h4>
-<div class="sourceCode" id="cb281"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb281-1"><a href="#cb281-1"></a><span class="kw">create</span> <span class="kw">view</span> view_with_different_create_version <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X @create(<span class="dv">3</span>);</span>
-<span id="cb281-2"><a href="#cb281-2"></a><span class="co">-------</span></span>
-<span id="cb281-3"><a href="#cb281-3"></a><span class="kw">create</span> <span class="kw">view</span> view_with_different_create_version <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X @create(<span class="dv">2</span>);</span>
-<span id="cb281-4"><a href="#cb281-4"></a></span>
-<span id="cb281-5"><a href="#cb281-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:116</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span> <span class="kw">previous</span></span>
-<span id="cb281-6"><a href="#cb281-6"></a><span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;view_with_different_create_version&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb281"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb281-1"><a href="#cb281-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> view_with_different_create_version <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X @create(<span class="dv">3</span>);</span>
+<span id="cb281-2"><a href="#cb281-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb281-3"><a href="#cb281-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> view_with_different_create_version <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X @create(<span class="dv">2</span>);</span>
+<span id="cb281-4"><a href="#cb281-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb281-5"><a href="#cb281-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:116</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span> <span class="kw">previous</span></span>
+<span id="cb281-6"><a href="#cb281-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;view_with_different_create_version&#39;</span></span></code></pre></div>
 <p>You can’t change the create version of a view after the fact.</p>
 <h4 id="case-35-create-an-index-that-is-now-totally-gone-in-the-new-schema">Case 35 : create an index that is now totally gone in the new schema</h4>
-<div class="sourceCode" id="cb282"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb282-1"><a href="#cb282-1"></a><span class="co">--- no matching index in current schema</span></span>
-<span id="cb282-2"><a href="#cb282-2"></a><span class="co">-------</span></span>
-<span id="cb282-3"><a href="#cb282-3"></a><span class="kw">create</span> <span class="kw">index</span> this_index_was_deleted_with_no_annotation <span class="kw">on</span> foo(<span class="kw">id</span>);</span>
-<span id="cb282-4"><a href="#cb282-4"></a></span>
-<span id="cb282-5"><a href="#cb282-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:349</span> : <span class="kw">in</span> create_index_stmt : <span class="kw">index</span> was <span class="kw">present</span> but now it</span>
-<span id="cb282-6"><a href="#cb282-6"></a>does <span class="kw">not</span> exist (<span class="kw">use</span> @delete <span class="kw">instead</span>) <span class="st">&#39;this_index_was_deleted_with_no_annotation&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb282"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb282-1"><a href="#cb282-1" aria-hidden="true" tabindex="-1"></a><span class="co">--- no matching index in current schema</span></span>
+<span id="cb282-2"><a href="#cb282-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb282-3"><a href="#cb282-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">index</span> this_index_was_deleted_with_no_annotation <span class="kw">on</span> foo(<span class="kw">id</span>);</span>
+<span id="cb282-4"><a href="#cb282-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb282-5"><a href="#cb282-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:349</span> : <span class="kw">in</span> create_index_stmt : <span class="kw">index</span> was <span class="kw">present</span> but now it</span>
+<span id="cb282-6"><a href="#cb282-6" aria-hidden="true" tabindex="-1"></a>does <span class="kw">not</span> exist (<span class="kw">use</span> @delete <span class="kw">instead</span>) <span class="st">&#39;this_index_was_deleted_with_no_annotation&#39;</span></span></code></pre></div>
 <p>You have to use <code>@delete</code> on indices to remove them correctly.</p>
 <h4 id="case-36-create-a-view-with-no-annotation-that-is-not-in-the-previous-schema">Case 36 : create a view with no annotation that is not in the previous schema</h4>
-<div class="sourceCode" id="cb283"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb283-1"><a href="#cb283-1"></a><span class="kw">create</span> <span class="kw">view</span> view_created_with_no_annotation <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
-<span id="cb283-2"><a href="#cb283-2"></a><span class="co">-------</span></span>
-<span id="cb283-3"><a href="#cb283-3"></a><span class="co">--- there is no previous version</span></span>
-<span id="cb283-4"><a href="#cb283-4"></a></span>
-<span id="cb283-5"><a href="#cb283-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:122</span> : <span class="kw">in</span> create_view_stmt : <span class="kw">new</span> <span class="kw">view</span> must be added <span class="kw">with</span></span>
-<span id="cb283-6"><a href="#cb283-6"></a><span class="ot">@create(6) or later &#39;view_created_with_no_annotation&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb283"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb283-1"><a href="#cb283-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">view</span> view_created_with_no_annotation <span class="kw">as</span> <span class="kw">select</span> <span class="dv">1</span> X;</span>
+<span id="cb283-2"><a href="#cb283-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb283-3"><a href="#cb283-3" aria-hidden="true" tabindex="-1"></a><span class="co">--- there is no previous version</span></span>
+<span id="cb283-4"><a href="#cb283-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb283-5"><a href="#cb283-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:122</span> : <span class="kw">in</span> create_view_stmt : <span class="kw">new</span> <span class="kw">view</span> must be added <span class="kw">with</span></span>
+<span id="cb283-6"><a href="#cb283-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@create(6) or later &#39;view_created_with_no_annotation&#39;</span></span></code></pre></div>
 <p>You have to use <code>@create</code> on views to create them correctly.</p>
 <h4 id="case-37-index-created-in-different-version">Case 37 : index created in different version</h4>
-<div class="sourceCode" id="cb284"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb284-1"><a href="#cb284-1"></a><span class="kw">create</span> <span class="kw">index</span> this_index_has_a_changed_attribute <span class="kw">on</span> foo(<span class="kw">id</span>) @create(<span class="dv">2</span>);</span>
-<span id="cb284-2"><a href="#cb284-2"></a><span class="co">-------</span></span>
-<span id="cb284-3"><a href="#cb284-3"></a><span class="kw">create</span> <span class="kw">index</span> this_index_has_a_changed_attribute <span class="kw">on</span> foo(<span class="kw">id</span>) @create(<span class="dv">1</span>);</span>
-<span id="cb284-4"><a href="#cb284-4"></a></span>
-<span id="cb284-5"><a href="#cb284-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:125</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span> <span class="kw">previous</span></span>
-<span id="cb284-6"><a href="#cb284-6"></a><span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;this_index_has_a_changed_attribute&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb284"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb284-1"><a href="#cb284-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">index</span> this_index_has_a_changed_attribute <span class="kw">on</span> foo(<span class="kw">id</span>) @create(<span class="dv">2</span>);</span>
+<span id="cb284-2"><a href="#cb284-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb284-3"><a href="#cb284-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">index</span> this_index_has_a_changed_attribute <span class="kw">on</span> foo(<span class="kw">id</span>) @create(<span class="dv">1</span>);</span>
+<span id="cb284-4"><a href="#cb284-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb284-5"><a href="#cb284-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:125</span> : <span class="kw">in</span> str : <span class="kw">current</span> <span class="kw">create</span> version <span class="kw">not</span> equal <span class="kw">to</span> <span class="kw">previous</span></span>
+<span id="cb284-6"><a href="#cb284-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> version <span class="cf">for</span> <span class="st">&#39;this_index_has_a_changed_attribute&#39;</span></span></code></pre></div>
 <p>You can’t change the <code>@create</code> version of an index.</p>
 <h4 id="case-38-create-a-new-index-but-with-no-create-annotation">Case 38 : create a new index but with no <code>@create</code> annotation</h4>
-<div class="sourceCode" id="cb285"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb285-1"><a href="#cb285-1"></a><span class="kw">create</span> <span class="kw">index</span> this_index_was_created_with_no_annotation <span class="kw">on</span> foo(<span class="kw">id</span>);</span>
-<span id="cb285-2"><a href="#cb285-2"></a><span class="co">-------</span></span>
-<span id="cb285-3"><a href="#cb285-3"></a><span class="co">--- there is no previous version</span></span>
-<span id="cb285-4"><a href="#cb285-4"></a></span>
-<span id="cb285-5"><a href="#cb285-5"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:130</span> : <span class="kw">in</span> create_index_stmt : <span class="kw">new</span> <span class="kw">index</span> must be added <span class="kw">with</span></span>
-<span id="cb285-6"><a href="#cb285-6"></a><span class="ot">@create(6) or later &#39;this_index_was_created_with_no_annotation&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb285"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb285-1"><a href="#cb285-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">index</span> this_index_was_created_with_no_annotation <span class="kw">on</span> foo(<span class="kw">id</span>);</span>
+<span id="cb285-2"><a href="#cb285-2" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb285-3"><a href="#cb285-3" aria-hidden="true" tabindex="-1"></a><span class="co">--- there is no previous version</span></span>
+<span id="cb285-4"><a href="#cb285-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb285-5"><a href="#cb285-5" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:130</span> : <span class="kw">in</span> create_index_stmt : <span class="kw">new</span> <span class="kw">index</span> must be added <span class="kw">with</span></span>
+<span id="cb285-6"><a href="#cb285-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@create(6) or later &#39;this_index_was_created_with_no_annotation&#39;</span></span></code></pre></div>
 <p>You have to use <code>@create</code> on indices to make new ones.</p>
 <h4 id="case-39-create-a-table-with-a-column-def-that-has-a-different-create-migrator-proc">Case 39 : create a table with a column def that has a different create migrator proc</h4>
-<div class="sourceCode" id="cb286"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb286-1"><a href="#cb286-1"></a><span class="kw">create</span> <span class="kw">table</span> create_column_migrate_test(</span>
-<span id="cb286-2"><a href="#cb286-2"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
-<span id="cb286-3"><a href="#cb286-3"></a> id2 <span class="dt">int</span> @create(<span class="dv">2</span>, ChangedColumnCreateMigrator)</span>
-<span id="cb286-4"><a href="#cb286-4"></a>);</span>
-<span id="cb286-5"><a href="#cb286-5"></a><span class="co">-------</span></span>
-<span id="cb286-6"><a href="#cb286-6"></a><span class="kw">create</span> <span class="kw">table</span> create_column_migrate_test(</span>
-<span id="cb286-7"><a href="#cb286-7"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
-<span id="cb286-8"><a href="#cb286-8"></a> id2 <span class="dt">int</span> @create(<span class="dv">2</span>, PreviousColumnCreateMigrator)</span>
-<span id="cb286-9"><a href="#cb286-9"></a>);</span>
-<span id="cb286-10"><a href="#cb286-10"></a></span>
-<span id="cb286-11"><a href="#cb286-11"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:136</span> : <span class="kw">in</span> str : <span class="kw">column</span> @create <span class="kw">procedure</span> changed <span class="st">&#39;id2&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb286"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb286-1"><a href="#cb286-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> create_column_migrate_test(</span>
+<span id="cb286-2"><a href="#cb286-2" aria-hidden="true" tabindex="-1"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
+<span id="cb286-3"><a href="#cb286-3" aria-hidden="true" tabindex="-1"></a> id2 <span class="dt">int</span> @create(<span class="dv">2</span>, ChangedColumnCreateMigrator)</span>
+<span id="cb286-4"><a href="#cb286-4" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb286-5"><a href="#cb286-5" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb286-6"><a href="#cb286-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> create_column_migrate_test(</span>
+<span id="cb286-7"><a href="#cb286-7" aria-hidden="true" tabindex="-1"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
+<span id="cb286-8"><a href="#cb286-8" aria-hidden="true" tabindex="-1"></a> id2 <span class="dt">int</span> @create(<span class="dv">2</span>, PreviousColumnCreateMigrator)</span>
+<span id="cb286-9"><a href="#cb286-9" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb286-10"><a href="#cb286-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb286-11"><a href="#cb286-11" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:136</span> : <span class="kw">in</span> str : <span class="kw">column</span> @create <span class="kw">procedure</span> changed <span class="st">&#39;id2&#39;</span></span></code></pre></div>
 <p>You can’t change the <code>@create</code> migration stored proc on columns.</p>
 <h4 id="case-40-create-a-table-with-a-column-def-that-has-a-different-delete-migrator-proc">Case 40 : create a table with a column def that has a different delete migrator proc</h4>
-<div class="sourceCode" id="cb287"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb287-1"><a href="#cb287-1"></a><span class="kw">create</span> <span class="kw">table</span> delete_column_migrate_test(</span>
-<span id="cb287-2"><a href="#cb287-2"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
-<span id="cb287-3"><a href="#cb287-3"></a> id2 <span class="dt">int</span> @delete(<span class="dv">2</span>, ChangedColumnDeleteMigrator)</span>
-<span id="cb287-4"><a href="#cb287-4"></a>);</span>
-<span id="cb287-5"><a href="#cb287-5"></a><span class="co">-------</span></span>
-<span id="cb287-6"><a href="#cb287-6"></a><span class="kw">create</span> <span class="kw">table</span> delete_column_migrate_test(</span>
-<span id="cb287-7"><a href="#cb287-7"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
-<span id="cb287-8"><a href="#cb287-8"></a> id2 <span class="dt">int</span> @delete(<span class="dv">2</span>, PreviousColumnDeleteMigrator)</span>
-<span id="cb287-9"><a href="#cb287-9"></a>);</span>
-<span id="cb287-10"><a href="#cb287-10"></a></span>
-<span id="cb287-11"><a href="#cb287-11"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:142</span> : <span class="kw">in</span> str : <span class="kw">column</span> @delete <span class="kw">procedure</span> changed <span class="st">&#39;id2&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb287"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb287-1"><a href="#cb287-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> delete_column_migrate_test(</span>
+<span id="cb287-2"><a href="#cb287-2" aria-hidden="true" tabindex="-1"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
+<span id="cb287-3"><a href="#cb287-3" aria-hidden="true" tabindex="-1"></a> id2 <span class="dt">int</span> @delete(<span class="dv">2</span>, ChangedColumnDeleteMigrator)</span>
+<span id="cb287-4"><a href="#cb287-4" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb287-5"><a href="#cb287-5" aria-hidden="true" tabindex="-1"></a><span class="co">-------</span></span>
+<span id="cb287-6"><a href="#cb287-6" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> delete_column_migrate_test(</span>
+<span id="cb287-7"><a href="#cb287-7" aria-hidden="true" tabindex="-1"></a> <span class="kw">id</span> <span class="dt">int</span>,</span>
+<span id="cb287-8"><a href="#cb287-8" aria-hidden="true" tabindex="-1"></a> id2 <span class="dt">int</span> @delete(<span class="dv">2</span>, PreviousColumnDeleteMigrator)</span>
+<span id="cb287-9"><a href="#cb287-9" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb287-10"><a href="#cb287-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb287-11"><a href="#cb287-11" aria-hidden="true" tabindex="-1"></a>Error <span class="kw">at</span> sem_test_prev.sql<span class="ch">:142</span> : <span class="kw">in</span> str : <span class="kw">column</span> @delete <span class="kw">procedure</span> changed <span class="st">&#39;id2&#39;</span></span></code></pre></div>
 <p>You can’t change the <code>@delete</code> migration stored proc on columns.</p>
 <p>NOTE: in addition to these errors, there are many more that do not require the previous schema which are also checked (not shown here). These comprise things like making sure the delete version is greater than the create version on any item. There is a lot of sensibility checking that can happen without reference to the previous schema.</p>
 <h2 id="chapter-12-testability-features">Chapter 12: Testability Features</h2>
@@ -4488,37 +4620,37 @@ For easy visibility I have brought each fragment of current and previous schema 
 In many cases the actual data values are completely uninteresting to the test – any values would do. There are several strategies you can use to get good dummy data into your database in a more maintainable way.</p>
 <h4 id="simple-inserts-with-dummy-data">Simple Inserts With Dummy Data</h4>
 <p>The simplest form uses a variant of the insert statement that fills in any missing columns with a seed value. An example might be something like the below:</p>
-<div class="sourceCode" id="cb288"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb288-1"><a href="#cb288-1"></a><span class="kw">create</span> proc dummy_user()</span>
-<span id="cb288-2"><a href="#cb288-2"></a><span class="cf">begin</span></span>
-<span id="cb288-3"><a href="#cb288-3"></a>  <span class="kw">insert</span> <span class="kw">into</span> users () <span class="kw">values</span> () @dummy_seed(<span class="dv">123</span>) </span>
-<span id="cb288-4"><a href="#cb288-4"></a>     @dummy_nullables @dummy_defaults;</span>
-<span id="cb288-5"><a href="#cb288-5"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb288"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb288-1"><a href="#cb288-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc dummy_user()</span>
+<span id="cb288-2"><a href="#cb288-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb288-3"><a href="#cb288-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">insert</span> <span class="kw">into</span> users () <span class="kw">values</span> () @dummy_seed(<span class="dv">123</span>) </span>
+<span id="cb288-4"><a href="#cb288-4" aria-hidden="true" tabindex="-1"></a>     @dummy_nullables @dummy_defaults;</span>
+<span id="cb288-5"><a href="#cb288-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This statement causes all values including columns that are nullable or have a default value to get the value <code>123</code> for any numeric type and <code>'column_name_123'</code> for any text.</p>
 <p>If you omit the <code>@dummy_nullables</code> then any nullable fields will be null as usual. And likewise if you omit <code>@dummy_defaults</code> then any fields with a default value will use thatt value as usual. You might want any combination of those for your tests (null values are handy in your tests and default behavior is also handy).</p>
 <p>The <code>@dummy_seed</code> expression provided can be anything that resolves to a non-null integer value, so it can be pretty flexible. You might use a <code>while</code> loop to insert a bunch of rows with the seed value being computed from the <code>while</code> loop variable.</p>
 <p>The form above is sort of like <code>insert * into table</code> in that it is giving dummy values for all columns but you can also specify some of the columns while using the seed value for others. Importantly, you can specify values you particularly want to control either for purposes of creating a more tailored test or because you need them to match existing or created rows in a table referenced by a foreign key.</p>
 <p>As an example:</p>
-<div class="sourceCode" id="cb289"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb289-1"><a href="#cb289-1"></a><span class="kw">insert</span> <span class="kw">into</span> users (<span class="kw">id</span>) <span class="kw">values</span> (<span class="dv">1234</span>) @dummy_seed(<span class="dv">123</span>)</span>
-<span id="cb289-2"><a href="#cb289-2"></a>   @dummy_nullables @dummy_defaults;</span></code></pre></div>
+<div class="sourceCode" id="cb289"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb289-1"><a href="#cb289-1" aria-hidden="true" tabindex="-1"></a><span class="kw">insert</span> <span class="kw">into</span> users (<span class="kw">id</span>) <span class="kw">values</span> (<span class="dv">1234</span>) @dummy_seed(<span class="dv">123</span>)</span>
+<span id="cb289-2"><a href="#cb289-2" aria-hidden="true" tabindex="-1"></a>   @dummy_nullables @dummy_defaults;</span></code></pre></div>
 <p>Will provide dummy values for everything but the <code>id</code> column.</p>
 <h4 id="using-with-recursive">Using <code>WITH RECURSIVE</code></h4>
 <p>Sometimes what you want to do is create a dummy result set without necessarly popuplating the database at all. If you have code that consumes a result set of a particular shape it’s easy enough to create a fake result set with a pattern something like this:</p>
-<div class="sourceCode" id="cb290"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb290-1"><a href="#cb290-1"></a><span class="kw">create</span> <span class="kw">procedure</span> dummy_stuff(lim <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb290-2"><a href="#cb290-2"></a><span class="cf">begin</span></span>
-<span id="cb290-3"><a href="#cb290-3"></a>  <span class="kw">WITH</span> RECURSIVE</span>
-<span id="cb290-4"><a href="#cb290-4"></a>  dummy(x) <span class="kw">AS</span> (</span>
-<span id="cb290-5"><a href="#cb290-5"></a>     <span class="kw">SELECT</span> <span class="dv">1</span></span>
-<span id="cb290-6"><a href="#cb290-6"></a>     <span class="kw">UNION</span> <span class="kw">ALL</span></span>
-<span id="cb290-7"><a href="#cb290-7"></a>     <span class="kw">SELECT</span> x<span class="op">+</span><span class="dv">1</span> <span class="kw">FROM</span> dummy <span class="kw">WHERE</span> x <span class="op">&lt;</span> lim)</span>
-<span id="cb290-8"><a href="#cb290-8"></a>  <span class="kw">SELECT</span></span>
-<span id="cb290-9"><a href="#cb290-9"></a>    x <span class="kw">id</span>,</span>
-<span id="cb290-10"><a href="#cb290-10"></a>    printf(<span class="ot">&quot;name_%d&quot;</span>, x) name,</span>
-<span id="cb290-11"><a href="#cb290-11"></a>    <span class="fu">cast</span>(x % <span class="dv">2</span> <span class="kw">as</span> bool) is_cool,</span>
-<span id="cb290-12"><a href="#cb290-12"></a>    x <span class="op">*</span> <span class="fl">1.3</span> <span class="kw">as</span> rate,</span>
-<span id="cb290-13"><a href="#cb290-13"></a>    x etc1,</span>
-<span id="cb290-14"><a href="#cb290-14"></a>    x etc2</span>
-<span id="cb290-15"><a href="#cb290-15"></a>  <span class="kw">FROM</span> dummy;</span>
-<span id="cb290-16"><a href="#cb290-16"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb290"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb290-1"><a href="#cb290-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">procedure</span> dummy_stuff(lim <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb290-2"><a href="#cb290-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb290-3"><a href="#cb290-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">WITH</span> RECURSIVE</span>
+<span id="cb290-4"><a href="#cb290-4" aria-hidden="true" tabindex="-1"></a>  dummy(x) <span class="kw">AS</span> (</span>
+<span id="cb290-5"><a href="#cb290-5" aria-hidden="true" tabindex="-1"></a>     <span class="kw">SELECT</span> <span class="dv">1</span></span>
+<span id="cb290-6"><a href="#cb290-6" aria-hidden="true" tabindex="-1"></a>     <span class="kw">UNION</span> <span class="kw">ALL</span></span>
+<span id="cb290-7"><a href="#cb290-7" aria-hidden="true" tabindex="-1"></a>     <span class="kw">SELECT</span> x<span class="op">+</span><span class="dv">1</span> <span class="kw">FROM</span> dummy <span class="kw">WHERE</span> x <span class="op">&lt;</span> lim)</span>
+<span id="cb290-8"><a href="#cb290-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span></span>
+<span id="cb290-9"><a href="#cb290-9" aria-hidden="true" tabindex="-1"></a>    x <span class="kw">id</span>,</span>
+<span id="cb290-10"><a href="#cb290-10" aria-hidden="true" tabindex="-1"></a>    printf(<span class="ot">&quot;name_%d&quot;</span>, x) name,</span>
+<span id="cb290-11"><a href="#cb290-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">cast</span>(x % <span class="dv">2</span> <span class="kw">as</span> bool) is_cool,</span>
+<span id="cb290-12"><a href="#cb290-12" aria-hidden="true" tabindex="-1"></a>    x <span class="op">*</span> <span class="fl">1.3</span> <span class="kw">as</span> rate,</span>
+<span id="cb290-13"><a href="#cb290-13" aria-hidden="true" tabindex="-1"></a>    x etc1,</span>
+<span id="cb290-14"><a href="#cb290-14" aria-hidden="true" tabindex="-1"></a>    x etc2</span>
+<span id="cb290-15"><a href="#cb290-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">FROM</span> dummy;</span>
+<span id="cb290-16"><a href="#cb290-16" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The first part of the above creates a series of numbers from 1 to <code>lim</code>. The second uses those values to create dummy columns.<br />
 Any result shape can be generated in this fashion.</p>
 <p>You get data like this from the above:</p>
@@ -4536,65 +4668,65 @@ Any result shape can be generated in this fashion.</p>
 <h4 id="using-temporary-tables">Using Temporary Tables</h4>
 <p>If you need an API to create very flexible dummy data with values of your choice you can use temporary tables and a series of helper procedures.</p>
 <p>First, create a table to hold the results. You can of course make this table however you need to but the <code>like</code> construct in the table creation is especially helpful; it creates columns in the table that match the name and type of the named object. For instance <code>like my_proc</code> is shorthand for the column names ands of the shape that <code>my_proc</code> returns. This is perfect for emulating the results of <code>my_proc</code>.</p>
-<div class="sourceCode" id="cb292"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb292-1"><a href="#cb292-1"></a><span class="kw">create</span> proc begin_dummy()</span>
-<span id="cb292-2"><a href="#cb292-2"></a><span class="cf">begin</span></span>
-<span id="cb292-3"><a href="#cb292-3"></a>   <span class="kw">drop</span> <span class="kw">table</span> <span class="cf">if</span> <span class="kw">exists</span> my_dummy_data;</span>
-<span id="cb292-4"><a href="#cb292-4"></a>   </span>
-<span id="cb292-5"><a href="#cb292-5"></a>   <span class="co">-- the shape of my_dummy_data matches the columns </span></span>
-<span id="cb292-6"><a href="#cb292-6"></a>   <span class="co">-- returned by proc_I_want_to_emulate</span></span>
-<span id="cb292-7"><a href="#cb292-7"></a>   <span class="kw">create</span> temp <span class="kw">table</span> my_dummy_data(</span>
-<span id="cb292-8"><a href="#cb292-8"></a>     <span class="kw">like</span> proc_I_want_to_emulate;</span>
-<span id="cb292-9"><a href="#cb292-9"></a>   );</span>
-<span id="cb292-10"><a href="#cb292-10"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb292"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb292-1"><a href="#cb292-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc begin_dummy()</span>
+<span id="cb292-2"><a href="#cb292-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb292-3"><a href="#cb292-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">drop</span> <span class="kw">table</span> <span class="cf">if</span> <span class="kw">exists</span> my_dummy_data;</span>
+<span id="cb292-4"><a href="#cb292-4" aria-hidden="true" tabindex="-1"></a>   </span>
+<span id="cb292-5"><a href="#cb292-5" aria-hidden="true" tabindex="-1"></a>   <span class="co">-- the shape of my_dummy_data matches the columns </span></span>
+<span id="cb292-6"><a href="#cb292-6" aria-hidden="true" tabindex="-1"></a>   <span class="co">-- returned by proc_I_want_to_emulate</span></span>
+<span id="cb292-7"><a href="#cb292-7" aria-hidden="true" tabindex="-1"></a>   <span class="kw">create</span> temp <span class="kw">table</span> my_dummy_data(</span>
+<span id="cb292-8"><a href="#cb292-8" aria-hidden="true" tabindex="-1"></a>     <span class="kw">like</span> proc_I_want_to_emulate;</span>
+<span id="cb292-9"><a href="#cb292-9" aria-hidden="true" tabindex="-1"></a>   );</span>
+<span id="cb292-10"><a href="#cb292-10" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Next, you will need a procedure that accepts and writes a single row to your temp table. You can of course write this all explicitly but the testing support features provide more support to make things easier; In this example, arguments of the procedure will exactly match the output of the procedure we emulating, one argument for each column the proc returns. The <code>insert</code> statement gets its values from the arguments.</p>
-<div class="sourceCode" id="cb293"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb293-1"><a href="#cb293-1"></a><span class="kw">create</span> proc add_dummy(<span class="kw">like</span> proc_I_want_to_emulate)</span>
-<span id="cb293-2"><a href="#cb293-2"></a><span class="cf">begin</span></span>
-<span id="cb293-3"><a href="#cb293-3"></a>   <span class="kw">insert</span> <span class="kw">into</span> my_dummy_data <span class="kw">from</span> arguments;</span>
-<span id="cb293-4"><a href="#cb293-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb293"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb293-1"><a href="#cb293-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc add_dummy(<span class="kw">like</span> proc_I_want_to_emulate)</span>
+<span id="cb293-2"><a href="#cb293-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb293-3"><a href="#cb293-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">insert</span> <span class="kw">into</span> my_dummy_data <span class="kw">from</span> arguments;</span>
+<span id="cb293-4"><a href="#cb293-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This allows you to create the necessary helper methods automatically even if the procedure changes over time.</p>
 <p>Next we need a procedure to get our result set.</p>
-<div class="sourceCode" id="cb294"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb294-1"><a href="#cb294-1"></a><span class="kw">create</span> proc get_dummy()</span>
-<span id="cb294-2"><a href="#cb294-2"></a><span class="cf">begin</span></span>
-<span id="cb294-3"><a href="#cb294-3"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_dummy_data;</span>
-<span id="cb294-4"><a href="#cb294-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb294"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb294-1"><a href="#cb294-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc get_dummy()</span>
+<span id="cb294-2"><a href="#cb294-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb294-3"><a href="#cb294-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_dummy_data;</span>
+<span id="cb294-4"><a href="#cb294-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>And finally, some cleanup.</p>
-<div class="sourceCode" id="cb295"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb295-1"><a href="#cb295-1"></a><span class="kw">create</span> proc cleanup_dummy()</span>
-<span id="cb295-2"><a href="#cb295-2"></a><span class="cf">begin</span></span>
-<span id="cb295-3"><a href="#cb295-3"></a>   <span class="kw">drop</span> <span class="kw">table</span> <span class="cf">if</span> <span class="kw">exists</span> my_dummy_data;</span>
-<span id="cb295-4"><a href="#cb295-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb295"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb295-1"><a href="#cb295-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc cleanup_dummy()</span>
+<span id="cb295-2"><a href="#cb295-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb295-3"><a href="#cb295-3" aria-hidden="true" tabindex="-1"></a>   <span class="kw">drop</span> <span class="kw">table</span> <span class="cf">if</span> <span class="kw">exists</span> my_dummy_data;</span>
+<span id="cb295-4"><a href="#cb295-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Again the temp table could be combined with <code>INSERT INTO ...FROM SELECT...</code> to create dummy data in real tables.</p>
 <h4 id="other-considerations-1">Other Considerations</h4>
 <p>Wrapping your <code>insert</code> statements in <code>try/catch</code> can be very useful if there may be dummy data conflicts. In test code searching for a new suitable seed is pretty easy. Alternatively</p>
-<div class="sourceCode" id="cb296"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb296-1"><a href="#cb296-1"></a><span class="kw">set</span> seed <span class="op">:=</span> <span class="dv">1</span> <span class="op">+</span> (<span class="kw">select</span> <span class="fu">max</span>(<span class="kw">id</span>) <span class="kw">from</span> foo);</span></code></pre></div>
+<div class="sourceCode" id="cb296"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb296-1"><a href="#cb296-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> seed <span class="op">:=</span> <span class="dv">1</span> <span class="op">+</span> (<span class="kw">select</span> <span class="fu">max</span>(<span class="kw">id</span>) <span class="kw">from</span> foo);</span></code></pre></div>
 <p>Could be very useful. Many alternatives are possible.</p>
 <p>The dummy data features are not suitable for use in production code, only tests. But the LIKE features are generally useful for creating contract-like behavior in procs and there are reasonable uses for them in production code.</p>
 <h4 id="complex-result-set-example">Complex Result Set Example</h4>
 <p>Here’s a more complicated example that can be easily rewritten using the sugar features. This method is designed to return a single-row result set that can be used to mock a method. I’ve replaced the real fields with ‘f1, ’f2’ etc.</p>
-<div class="sourceCode" id="cb297"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb297-1"><a href="#cb297-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_my_subject(</span>
-<span id="cb297-2"><a href="#cb297-2"></a>  f1_ <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb297-3"><a href="#cb297-3"></a>  f2_ TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb297-4"><a href="#cb297-4"></a>  f3_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb297-5"><a href="#cb297-5"></a>  f4_ <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb297-6"><a href="#cb297-6"></a>  f5_ TEXT,</span>
-<span id="cb297-7"><a href="#cb297-7"></a>  f6_ TEXT,</span>
-<span id="cb297-8"><a href="#cb297-8"></a>  f7_ TEXT,</span>
-<span id="cb297-9"><a href="#cb297-9"></a>  f8_ BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
-<span id="cb297-10"><a href="#cb297-10"></a>  f9_ TEXT,</span>
-<span id="cb297-11"><a href="#cb297-11"></a>  f10_ TEXT</span>
-<span id="cb297-12"><a href="#cb297-12"></a>)</span>
-<span id="cb297-13"><a href="#cb297-13"></a><span class="cf">BEGIN</span></span>
-<span id="cb297-14"><a href="#cb297-14"></a>  <span class="kw">DECLARE</span> data_cursor <span class="kw">CURSOR</span> <span class="kw">LIKE</span> my_subject;</span>
-<span id="cb297-15"><a href="#cb297-15"></a>  FETCH data_cursor()</span>
-<span id="cb297-16"><a href="#cb297-16"></a>        <span class="kw">FROM</span> <span class="kw">VALUES</span> (f1_, f2_, f3_, f4_, f5_, f6_, f7_, f8_, f9_, f10);</span>
-<span id="cb297-17"><a href="#cb297-17"></a>  <span class="kw">OUT</span> data_cursor;</span>
-<span id="cb297-18"><a href="#cb297-18"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb297"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb297-1"><a href="#cb297-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_my_subject(</span>
+<span id="cb297-2"><a href="#cb297-2" aria-hidden="true" tabindex="-1"></a>  f1_ <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb297-3"><a href="#cb297-3" aria-hidden="true" tabindex="-1"></a>  f2_ TEXT <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb297-4"><a href="#cb297-4" aria-hidden="true" tabindex="-1"></a>  f3_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb297-5"><a href="#cb297-5" aria-hidden="true" tabindex="-1"></a>  f4_ <span class="dt">LONG</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb297-6"><a href="#cb297-6" aria-hidden="true" tabindex="-1"></a>  f5_ TEXT,</span>
+<span id="cb297-7"><a href="#cb297-7" aria-hidden="true" tabindex="-1"></a>  f6_ TEXT,</span>
+<span id="cb297-8"><a href="#cb297-8" aria-hidden="true" tabindex="-1"></a>  f7_ TEXT,</span>
+<span id="cb297-9"><a href="#cb297-9" aria-hidden="true" tabindex="-1"></a>  f8_ BOOL <span class="kw">NOT</span> <span class="kw">NULL</span>,</span>
+<span id="cb297-10"><a href="#cb297-10" aria-hidden="true" tabindex="-1"></a>  f9_ TEXT,</span>
+<span id="cb297-11"><a href="#cb297-11" aria-hidden="true" tabindex="-1"></a>  f10_ TEXT</span>
+<span id="cb297-12"><a href="#cb297-12" aria-hidden="true" tabindex="-1"></a>)</span>
+<span id="cb297-13"><a href="#cb297-13" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb297-14"><a href="#cb297-14" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> data_cursor <span class="kw">CURSOR</span> <span class="kw">LIKE</span> my_subject;</span>
+<span id="cb297-15"><a href="#cb297-15" aria-hidden="true" tabindex="-1"></a>  FETCH data_cursor()</span>
+<span id="cb297-16"><a href="#cb297-16" aria-hidden="true" tabindex="-1"></a>        <span class="kw">FROM</span> <span class="kw">VALUES</span> (f1_, f2_, f3_, f4_, f5_, f6_, f7_, f8_, f9_, f10);</span>
+<span id="cb297-17"><a href="#cb297-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> data_cursor;</span>
+<span id="cb297-18"><a href="#cb297-18" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>This can be written much more maintainably as:</p>
-<div class="sourceCode" id="cb298"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb298-1"><a href="#cb298-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_my_subject(<span class="kw">like</span> my_subject)</span>
-<span id="cb298-2"><a href="#cb298-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb298-3"><a href="#cb298-3"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="kw">LIKE</span> my_subject;</span>
-<span id="cb298-4"><a href="#cb298-4"></a>  FETCH C <span class="kw">FROM</span> ARGUMENTS;</span>
-<span id="cb298-5"><a href="#cb298-5"></a>  <span class="kw">OUT</span> C;</span>
-<span id="cb298-6"><a href="#cb298-6"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb298"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb298-1"><a href="#cb298-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> <span class="kw">PROCEDURE</span> test_my_subject(<span class="kw">like</span> my_subject)</span>
+<span id="cb298-2"><a href="#cb298-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb298-3"><a href="#cb298-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="kw">LIKE</span> my_subject;</span>
+<span id="cb298-4"><a href="#cb298-4" aria-hidden="true" tabindex="-1"></a>  FETCH C <span class="kw">FROM</span> ARGUMENTS;</span>
+<span id="cb298-5"><a href="#cb298-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> C;</span>
+<span id="cb298-6"><a href="#cb298-6" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Naturally real columns have much longer names and there are often a lot more than 10.</p>
 <h3 id="autotest-attributes">Autotest Attributes</h3>
 <p>Some of the patterns described above are so common that CQL offers a mechanism to automatically generate those test procedures.</p>
@@ -4602,36 +4734,36 @@ Any result shape can be generated in this fashion.</p>
 <p>The attributes dummy_table, dummy_insert, and dummy_select can be used together to create and populate temp tables.</p>
 <p>Example:</p>
 <p>To create a dummy row set for <code>sample_proc</code>, add the cql:autotest attribute with dummy_table, dummy_insert, and dummy_select values.</p>
-<div class="sourceCode" id="cb299"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb299-1"><a href="#cb299-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
-<span id="cb299-2"><a href="#cb299-2"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
-<span id="cb299-3"><a href="#cb299-3"></a>  name text <span class="kw">not</span> <span class="kw">null</span></span>
-<span id="cb299-4"><a href="#cb299-4"></a>);</span>
-<span id="cb299-5"><a href="#cb299-5"></a></span>
-<span id="cb299-6"><a href="#cb299-6"></a><span class="ot">@attribute(cql:autotest=(dummy_table, dummy_insert, dummy_select))</span></span>
-<span id="cb299-7"><a href="#cb299-7"></a><span class="kw">create</span> proc sample_proc(foo <span class="dt">int</span>)</span>
-<span id="cb299-8"><a href="#cb299-8"></a><span class="cf">begin</span></span>
-<span id="cb299-9"><a href="#cb299-9"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> Foo;</span>
-<span id="cb299-10"><a href="#cb299-10"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb299"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb299-1"><a href="#cb299-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> foo(</span>
+<span id="cb299-2"><a href="#cb299-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">id</span> <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>,</span>
+<span id="cb299-3"><a href="#cb299-3" aria-hidden="true" tabindex="-1"></a>  name text <span class="kw">not</span> <span class="kw">null</span></span>
+<span id="cb299-4"><a href="#cb299-4" aria-hidden="true" tabindex="-1"></a>);</span>
+<span id="cb299-5"><a href="#cb299-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb299-6"><a href="#cb299-6" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:autotest=(dummy_table, dummy_insert, dummy_select))</span></span>
+<span id="cb299-7"><a href="#cb299-7" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc sample_proc(foo <span class="dt">int</span>)</span>
+<span id="cb299-8"><a href="#cb299-8" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb299-9"><a href="#cb299-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> Foo;</span>
+<span id="cb299-10"><a href="#cb299-10" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p><code>dummy_table</code> generates procedures for creating and dropping a temp table with the same shape as <code>sample_proc</code>.</p>
-<div class="sourceCode" id="cb300"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb300-1"><a href="#cb300-1"></a><span class="kw">CREATE</span> PROC open_sample_proc()</span>
-<span id="cb300-2"><a href="#cb300-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb300-3"><a href="#cb300-3"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_sample_proc(<span class="kw">LIKE</span> sample_proc);</span>
-<span id="cb300-4"><a href="#cb300-4"></a><span class="cf">END</span>;</span>
-<span id="cb300-5"><a href="#cb300-5"></a></span>
-<span id="cb300-6"><a href="#cb300-6"></a><span class="kw">CREATE</span> PROC close_sample_proc()</span>
-<span id="cb300-7"><a href="#cb300-7"></a><span class="cf">BEGIN</span></span>
-<span id="cb300-8"><a href="#cb300-8"></a>  <span class="kw">DROP</span> test_sample_proc;</span>
-<span id="cb300-9"><a href="#cb300-9"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb300"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb300-1"><a href="#cb300-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC open_sample_proc()</span>
+<span id="cb300-2"><a href="#cb300-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb300-3"><a href="#cb300-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_sample_proc(<span class="kw">LIKE</span> sample_proc);</span>
+<span id="cb300-4"><a href="#cb300-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb300-5"><a href="#cb300-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb300-6"><a href="#cb300-6" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC close_sample_proc()</span>
+<span id="cb300-7"><a href="#cb300-7" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb300-8"><a href="#cb300-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> test_sample_proc;</span>
+<span id="cb300-9"><a href="#cb300-9" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>The <code>dummy_insert</code> attribute generates a procedure for inserting into the temp table.</p>
-<div class="sourceCode" id="cb301"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb301-1"><a href="#cb301-1"></a><span class="kw">CREATE</span> PROC insert_sample_proc(<span class="kw">LIKE</span> sample_proc)</span>
-<span id="cb301-2"><a href="#cb301-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb301-3"><a href="#cb301-3"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> test_sample_proc <span class="kw">FROM</span> ARGUMENTS;</span>
-<span id="cb301-4"><a href="#cb301-4"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb301"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb301-1"><a href="#cb301-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC insert_sample_proc(<span class="kw">LIKE</span> sample_proc)</span>
+<span id="cb301-2"><a href="#cb301-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb301-3"><a href="#cb301-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> test_sample_proc <span class="kw">FROM</span> ARGUMENTS;</span>
+<span id="cb301-4"><a href="#cb301-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>The <code>dummy_select</code> attribute generates procedures for selecting from the temp table.</p>
-<div class="sourceCode" id="cb302"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb302-1"><a href="#cb302-1"></a><span class="kw">CREATE</span> PROC select_sample_proc()</span>
-<span id="cb302-2"><a href="#cb302-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb302-3"><a href="#cb302-3"></a>  <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> test_sample_proc;</span>
-<span id="cb302-4"><a href="#cb302-4"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb302"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb302-1"><a href="#cb302-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC select_sample_proc()</span>
+<span id="cb302-2"><a href="#cb302-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb302-3"><a href="#cb302-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> test_sample_proc;</span>
+<span id="cb302-4"><a href="#cb302-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>It’s interesting to note that the generated test code does not ever need to mention the exact columns it is emulating because it can always use <code>like</code>, <code>*</code>, and <code>from arguments</code> in a generic way.</p>
 <p>When compiled, the above will create C methods that can create, drop, insert, and select from the temp table. They will have the following signatures:</p>
 <pre><code>CQL_WARN_UNUSED cql_code open_sample_proc(
@@ -4651,23 +4783,23 @@ CQL_WARN_UNUSED cql_code select_sample_proc_fetch_results(
 <h4 id="single-row-resultset">Single Row ResultSet</h4>
 <p>In some cases, using four APIs to generate fake data can be verbose. In the case that only a single row of data needs to be faked, the dummy_result_set attribute can be more convenient.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb304"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb304-1"><a href="#cb304-1"></a><span class="ot">@attribute(cql:autotest=(dummy_result_set))</span></span>
-<span id="cb304-2"><a href="#cb304-2"></a><span class="kw">create</span> proc sample_proc()</span>
-<span id="cb304-3"><a href="#cb304-3"></a><span class="cf">begin</span></span>
-<span id="cb304-4"><a href="#cb304-4"></a>  <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> Foo;</span>
-<span id="cb304-5"><a href="#cb304-5"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb304"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb304-1"><a href="#cb304-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:autotest=(dummy_result_set))</span></span>
+<span id="cb304-2"><a href="#cb304-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc sample_proc()</span>
+<span id="cb304-3"><a href="#cb304-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb304-4"><a href="#cb304-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> Foo;</span>
+<span id="cb304-5"><a href="#cb304-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Will generate the following procedure</p>
-<div class="sourceCode" id="cb305"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb305-1"><a href="#cb305-1"></a><span class="kw">CREATE</span> PROC generate_sample_proc_row(<span class="kw">LIKE</span> sample_proc)</span>
-<span id="cb305-2"><a href="#cb305-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb305-3"><a href="#cb305-3"></a>  <span class="kw">DECLARE</span> curs <span class="kw">CURSOR</span> <span class="kw">LIKE</span> sample_proc;</span>
-<span id="cb305-4"><a href="#cb305-4"></a>  FETCH curs <span class="kw">FROM</span> ARGUMENTS;</span>
-<span id="cb305-5"><a href="#cb305-5"></a>  <span class="kw">OUT</span> curs;</span>
-<span id="cb305-6"><a href="#cb305-6"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb305"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb305-1"><a href="#cb305-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC generate_sample_proc_row(<span class="kw">LIKE</span> sample_proc)</span>
+<span id="cb305-2"><a href="#cb305-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb305-3"><a href="#cb305-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> curs <span class="kw">CURSOR</span> <span class="kw">LIKE</span> sample_proc;</span>
+<span id="cb305-4"><a href="#cb305-4" aria-hidden="true" tabindex="-1"></a>  FETCH curs <span class="kw">FROM</span> ARGUMENTS;</span>
+<span id="cb305-5"><a href="#cb305-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> curs;</span>
+<span id="cb305-6"><a href="#cb305-6" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Which generates this C API:</p>
-<div class="sourceCode" id="cb306"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb306-1"><a href="#cb306-1"></a><span class="dt">void</span> generate_sample_proc_row_fetch_results(</span>
-<span id="cb306-2"><a href="#cb306-2"></a>    generate_sample_proc_row_rowset_ref _Nullable *_Nonnull result_set, </span>
-<span id="cb306-3"><a href="#cb306-3"></a>    string_ref _Nonnull foo_, </span>
-<span id="cb306-4"><a href="#cb306-4"></a>    <span class="dt">int64_t</span> bar_);</span></code></pre></div>
+<div class="sourceCode" id="cb306"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb306-1"><a href="#cb306-1" aria-hidden="true" tabindex="-1"></a><span class="dt">void</span> generate_sample_proc_row_fetch_results<span class="op">(</span></span>
+<span id="cb306-2"><a href="#cb306-2" aria-hidden="true" tabindex="-1"></a>    generate_sample_proc_row_rowset_ref _Nullable <span class="op">*</span>_Nonnull result_set<span class="op">,</span> </span>
+<span id="cb306-3"><a href="#cb306-3" aria-hidden="true" tabindex="-1"></a>    string_ref _Nonnull foo_<span class="op">,</span> </span>
+<span id="cb306-4"><a href="#cb306-4" aria-hidden="true" tabindex="-1"></a>    <span class="dt">int64_t</span> bar_<span class="op">);</span></span></code></pre></div>
 <p>These few test helpers are useful in a variety of scenarios and can save you a lot of typing and maintenance. They evolve automatically as the code changes, always matching the signature of the attributed procedure.</p>
 <h4 id="generalized-dummy-test-pattern">Generalized Dummy Test Pattern</h4>
 <p>The most flexible test helper is the <code>dummy_test</code> form. This is far more advanced than the simple helpers above. While the choices above were designed to help you create fake result sets pretty easily, <code>dummy_test</code> goes much further letting you set up arbitrary schema and data so that you can run your procedure on actual data. The <code>dummy_test</code> code generator uses the features above to do its job and like the other autotest options, it works by automatically generating CQL code from your procedure definition. However, you get a lot more code in this mode. It’s easiest to study an example so let’s begin there.</p>
@@ -4706,108 +4838,108 @@ end;</code></pre>
 <p>As you can see, we have two tables <code>foo</code> and <code>bar</code>; the <code>foo</code> table has a trigger; both <code>foo</code> and <code>bar</code> have indices. This schema is very simple, but of course it could be a lot more complicated, and real cases typically are.</p>
 <p>The procedure we want to test is creatively called <code>the_subject</code>. It has lots of test attributes on it. We’ve already discussed <code>dummy_table</code>, <code>dummy_insert</code>, <code>dummy_select</code>, and <code>dummy_result_set</code> above but as you can see they can be mixed in with <code>dummy_test</code>. Now let’s talk about <code>dummy_test</code>. First you’ll notice that annotation has additional sub-attributes; The attribute grammar is sufficiently flexible that, in principle, you could represent an arbitary LISP program, so the instructions can be very detailed. In this case the attribute provides table and column names, as well as sample data. We’ll discuss that when we get to the population code.</p>
 <p>First let’s dispense with the attributes we already discussed – since we had all the attributes, the output will include those helpers, too. Here they are again:</p>
-<div class="sourceCode" id="cb308"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb308-1"><a href="#cb308-1"></a><span class="co">-- note that the code does not actually call the test subject</span></span>
-<span id="cb308-2"><a href="#cb308-2"></a><span class="co">-- this declaration is used so that CQL will know the shape of the result</span></span>
-<span id="cb308-3"><a href="#cb308-3"></a><span class="kw">DECLARE</span> PROC the_subject () (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">data</span> TEXT);</span>
-<span id="cb308-4"><a href="#cb308-4"></a></span>
-<span id="cb308-5"><a href="#cb308-5"></a><span class="kw">CREATE</span> PROC open_the_subject()</span>
-<span id="cb308-6"><a href="#cb308-6"></a><span class="cf">BEGIN</span></span>
-<span id="cb308-7"><a href="#cb308-7"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_the_subject(<span class="kw">LIKE</span> the_subject);</span>
-<span id="cb308-8"><a href="#cb308-8"></a><span class="cf">END</span>;</span>
-<span id="cb308-9"><a href="#cb308-9"></a></span>
-<span id="cb308-10"><a href="#cb308-10"></a><span class="kw">CREATE</span> PROC close_the_subject()</span>
-<span id="cb308-11"><a href="#cb308-11"></a><span class="cf">BEGIN</span></span>
-<span id="cb308-12"><a href="#cb308-12"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> test_the_subject;</span>
-<span id="cb308-13"><a href="#cb308-13"></a><span class="cf">END</span>;</span>
-<span id="cb308-14"><a href="#cb308-14"></a></span>
-<span id="cb308-15"><a href="#cb308-15"></a><span class="kw">CREATE</span> PROC insert_the_subject(<span class="kw">LIKE</span> the_subject)</span>
-<span id="cb308-16"><a href="#cb308-16"></a><span class="cf">BEGIN</span></span>
-<span id="cb308-17"><a href="#cb308-17"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> test_the_subject <span class="kw">FROM</span> ARGUMENTS;</span>
-<span id="cb308-18"><a href="#cb308-18"></a><span class="cf">END</span>;</span>
-<span id="cb308-19"><a href="#cb308-19"></a></span>
-<span id="cb308-20"><a href="#cb308-20"></a><span class="kw">CREATE</span> PROC select_the_subject()</span>
-<span id="cb308-21"><a href="#cb308-21"></a><span class="cf">BEGIN</span></span>
-<span id="cb308-22"><a href="#cb308-22"></a>  <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> test_the_subject;</span>
-<span id="cb308-23"><a href="#cb308-23"></a><span class="cf">END</span>;</span>
-<span id="cb308-24"><a href="#cb308-24"></a></span>
-<span id="cb308-25"><a href="#cb308-25"></a><span class="kw">CREATE</span> PROC generate_the_subject_row(<span class="kw">LIKE</span> the_subject)</span>
-<span id="cb308-26"><a href="#cb308-26"></a><span class="cf">BEGIN</span></span>
-<span id="cb308-27"><a href="#cb308-27"></a>  <span class="kw">DECLARE</span> curs <span class="kw">CURSOR</span> <span class="kw">LIKE</span> the_subject;</span>
-<span id="cb308-28"><a href="#cb308-28"></a>  FETCH curs <span class="kw">FROM</span> ARGUMENTS;</span>
-<span id="cb308-29"><a href="#cb308-29"></a>  <span class="kw">OUT</span> curs;</span>
-<span id="cb308-30"><a href="#cb308-30"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb308"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb308-1"><a href="#cb308-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- note that the code does not actually call the test subject</span></span>
+<span id="cb308-2"><a href="#cb308-2" aria-hidden="true" tabindex="-1"></a><span class="co">-- this declaration is used so that CQL will know the shape of the result</span></span>
+<span id="cb308-3"><a href="#cb308-3" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> PROC the_subject () (<span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>, <span class="kw">data</span> TEXT);</span>
+<span id="cb308-4"><a href="#cb308-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb308-5"><a href="#cb308-5" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC open_the_subject()</span>
+<span id="cb308-6"><a href="#cb308-6" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb308-7"><a href="#cb308-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TABLE</span> test_the_subject(<span class="kw">LIKE</span> the_subject);</span>
+<span id="cb308-8"><a href="#cb308-8" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb308-9"><a href="#cb308-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb308-10"><a href="#cb308-10" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC close_the_subject()</span>
+<span id="cb308-11"><a href="#cb308-11" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb308-12"><a href="#cb308-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> test_the_subject;</span>
+<span id="cb308-13"><a href="#cb308-13" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb308-14"><a href="#cb308-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb308-15"><a href="#cb308-15" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC insert_the_subject(<span class="kw">LIKE</span> the_subject)</span>
+<span id="cb308-16"><a href="#cb308-16" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb308-17"><a href="#cb308-17" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">INTO</span> test_the_subject <span class="kw">FROM</span> ARGUMENTS;</span>
+<span id="cb308-18"><a href="#cb308-18" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb308-19"><a href="#cb308-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb308-20"><a href="#cb308-20" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC select_the_subject()</span>
+<span id="cb308-21"><a href="#cb308-21" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb308-22"><a href="#cb308-22" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> test_the_subject;</span>
+<span id="cb308-23"><a href="#cb308-23" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb308-24"><a href="#cb308-24" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb308-25"><a href="#cb308-25" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC generate_the_subject_row(<span class="kw">LIKE</span> the_subject)</span>
+<span id="cb308-26"><a href="#cb308-26" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb308-27"><a href="#cb308-27" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> curs <span class="kw">CURSOR</span> <span class="kw">LIKE</span> the_subject;</span>
+<span id="cb308-28"><a href="#cb308-28" aria-hidden="true" tabindex="-1"></a>  FETCH curs <span class="kw">FROM</span> ARGUMENTS;</span>
+<span id="cb308-29"><a href="#cb308-29" aria-hidden="true" tabindex="-1"></a>  <span class="kw">OUT</span> curs;</span>
+<span id="cb308-30"><a href="#cb308-30" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>That covers what we had before, so, what’s new? Actually quite a bit. We’ll begin with the easiest:</p>
-<div class="sourceCode" id="cb309"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb309-1"><a href="#cb309-1"></a><span class="kw">CREATE</span> PROC test_the_subject_create_tables()</span>
-<span id="cb309-2"><a href="#cb309-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb309-3"><a href="#cb309-3"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> foo(</span>
-<span id="cb309-4"><a href="#cb309-4"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
-<span id="cb309-5"><a href="#cb309-5"></a>    name TEXT</span>
-<span id="cb309-6"><a href="#cb309-6"></a>  );</span>
-<span id="cb309-7"><a href="#cb309-7"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> bar(</span>
-<span id="cb309-8"><a href="#cb309-8"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span> <span class="kw">REFERENCES</span> foo (<span class="kw">id</span>),</span>
-<span id="cb309-9"><a href="#cb309-9"></a>    <span class="kw">data</span> TEXT</span>
-<span id="cb309-10"><a href="#cb309-10"></a>  );</span>
-<span id="cb309-11"><a href="#cb309-11"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb309"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb309-1"><a href="#cb309-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_create_tables()</span>
+<span id="cb309-2"><a href="#cb309-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb309-3"><a href="#cb309-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> foo(</span>
+<span id="cb309-4"><a href="#cb309-4" aria-hidden="true" tabindex="-1"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span>,</span>
+<span id="cb309-5"><a href="#cb309-5" aria-hidden="true" tabindex="-1"></a>    name TEXT</span>
+<span id="cb309-6"><a href="#cb309-6" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb309-7"><a href="#cb309-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> bar(</span>
+<span id="cb309-8"><a href="#cb309-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">id</span> <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span> <span class="kw">PRIMARY</span> <span class="kw">KEY</span> <span class="kw">REFERENCES</span> foo (<span class="kw">id</span>),</span>
+<span id="cb309-9"><a href="#cb309-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">data</span> TEXT</span>
+<span id="cb309-10"><a href="#cb309-10" aria-hidden="true" tabindex="-1"></a>  );</span>
+<span id="cb309-11"><a href="#cb309-11" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Probably the most important of all the helpers, <code>test_the_subject_create_tables</code> will create all the tables you need to run the procedure. Note that in this case, even though the subject code only references <code>bar</code>, CQL determined that <code>foo</code> is also needed because of the foreign key.</p>
 <p>The symmetric drop procedure is also generated:</p>
-<div class="sourceCode" id="cb310"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb310-1"><a href="#cb310-1"></a><span class="kw">CREATE</span> PROC test_the_subject_drop_tables()</span>
-<span id="cb310-2"><a href="#cb310-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb310-3"><a href="#cb310-3"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> bar;</span>
-<span id="cb310-4"><a href="#cb310-4"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> foo;</span>
-<span id="cb310-5"><a href="#cb310-5"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb310"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb310-1"><a href="#cb310-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_drop_tables()</span>
+<span id="cb310-2"><a href="#cb310-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb310-3"><a href="#cb310-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> bar;</span>
+<span id="cb310-4"><a href="#cb310-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TABLE</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> foo;</span>
+<span id="cb310-5"><a href="#cb310-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Additionally, in this case there were triggers and indices. This caused the creation of helpers for those aspects.</p>
-<div class="sourceCode" id="cb311"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb311-1"><a href="#cb311-1"></a><span class="kw">CREATE</span> PROC test_the_subject_create_indexes()</span>
-<span id="cb311-2"><a href="#cb311-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb311-3"><a href="#cb311-3"></a>  <span class="kw">CREATE</span> <span class="kw">INDEX</span> bar_index <span class="kw">ON</span> bar (<span class="kw">data</span>);</span>
-<span id="cb311-4"><a href="#cb311-4"></a>  <span class="kw">CREATE</span> <span class="kw">INDEX</span> foo_index <span class="kw">ON</span> foo (name);</span>
-<span id="cb311-5"><a href="#cb311-5"></a><span class="cf">END</span>;</span>
-<span id="cb311-6"><a href="#cb311-6"></a></span>
-<span id="cb311-7"><a href="#cb311-7"></a><span class="kw">CREATE</span> PROC test_the_subject_create_triggers()</span>
-<span id="cb311-8"><a href="#cb311-8"></a><span class="cf">BEGIN</span></span>
-<span id="cb311-9"><a href="#cb311-9"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TRIGGER</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> trigger1</span>
-<span id="cb311-10"><a href="#cb311-10"></a>    <span class="kw">BEFORE</span> <span class="kw">DELETE</span> <span class="kw">ON</span> foo</span>
-<span id="cb311-11"><a href="#cb311-11"></a>  <span class="cf">BEGIN</span></span>
-<span id="cb311-12"><a href="#cb311-12"></a>  <span class="kw">DELETE</span> <span class="kw">FROM</span> foo <span class="kw">WHERE</span> name <span class="op">=</span> <span class="st">&#39;this is so bogus&#39;</span>;</span>
-<span id="cb311-13"><a href="#cb311-13"></a>  <span class="cf">END</span>;</span>
-<span id="cb311-14"><a href="#cb311-14"></a><span class="cf">END</span>;</span>
-<span id="cb311-15"><a href="#cb311-15"></a></span>
-<span id="cb311-16"><a href="#cb311-16"></a><span class="kw">CREATE</span> PROC test_the_subject_drop_indexes()</span>
-<span id="cb311-17"><a href="#cb311-17"></a><span class="cf">BEGIN</span></span>
-<span id="cb311-18"><a href="#cb311-18"></a>  <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> bar_index;</span>
-<span id="cb311-19"><a href="#cb311-19"></a>  <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> foo_index;</span>
-<span id="cb311-20"><a href="#cb311-20"></a><span class="cf">END</span>;</span>
-<span id="cb311-21"><a href="#cb311-21"></a></span>
-<span id="cb311-22"><a href="#cb311-22"></a><span class="kw">CREATE</span> PROC test_the_subject_drop_triggers()</span>
-<span id="cb311-23"><a href="#cb311-23"></a><span class="cf">BEGIN</span></span>
-<span id="cb311-24"><a href="#cb311-24"></a>  <span class="kw">DROP</span> <span class="kw">TRIGGER</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> trigger1;</span>
-<span id="cb311-25"><a href="#cb311-25"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb311"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb311-1"><a href="#cb311-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_create_indexes()</span>
+<span id="cb311-2"><a href="#cb311-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb311-3"><a href="#cb311-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">INDEX</span> bar_index <span class="kw">ON</span> bar (<span class="kw">data</span>);</span>
+<span id="cb311-4"><a href="#cb311-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> <span class="kw">INDEX</span> foo_index <span class="kw">ON</span> foo (name);</span>
+<span id="cb311-5"><a href="#cb311-5" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb311-6"><a href="#cb311-6" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb311-7"><a href="#cb311-7" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_create_triggers()</span>
+<span id="cb311-8"><a href="#cb311-8" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb311-9"><a href="#cb311-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">CREATE</span> TEMP <span class="kw">TRIGGER</span> <span class="cf">IF</span> <span class="kw">NOT</span> <span class="kw">EXISTS</span> trigger1</span>
+<span id="cb311-10"><a href="#cb311-10" aria-hidden="true" tabindex="-1"></a>    <span class="kw">BEFORE</span> <span class="kw">DELETE</span> <span class="kw">ON</span> foo</span>
+<span id="cb311-11"><a href="#cb311-11" aria-hidden="true" tabindex="-1"></a>  <span class="cf">BEGIN</span></span>
+<span id="cb311-12"><a href="#cb311-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DELETE</span> <span class="kw">FROM</span> foo <span class="kw">WHERE</span> name <span class="op">=</span> <span class="st">&#39;this is so bogus&#39;</span>;</span>
+<span id="cb311-13"><a href="#cb311-13" aria-hidden="true" tabindex="-1"></a>  <span class="cf">END</span>;</span>
+<span id="cb311-14"><a href="#cb311-14" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb311-15"><a href="#cb311-15" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb311-16"><a href="#cb311-16" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_drop_indexes()</span>
+<span id="cb311-17"><a href="#cb311-17" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb311-18"><a href="#cb311-18" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> bar_index;</span>
+<span id="cb311-19"><a href="#cb311-19" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">INDEX</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> foo_index;</span>
+<span id="cb311-20"><a href="#cb311-20" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb311-21"><a href="#cb311-21" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb311-22"><a href="#cb311-22" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_drop_triggers()</span>
+<span id="cb311-23"><a href="#cb311-23" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb311-24"><a href="#cb311-24" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DROP</span> <span class="kw">TRIGGER</span> <span class="cf">IF</span> <span class="kw">EXISTS</span> trigger1;</span>
+<span id="cb311-25"><a href="#cb311-25" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>If there are no triggers or indices the corresponding create/drop methods will not be generated.</p>
 <p>With these helpers available, when writing test code you can then choose if you want to create just the tables, or the tables and indices, or tables and indices and triggers by invoking the appropriate combination of helper methods. Since all the implicated triggers and indices are automatically included, even if they change over time, maintenance is greatly simplified.</p>
 <p>Note that in this case the code simply reads from one of the tables but in general the procedure under test might make modifications as well. Test code frequently has to read back the contents of the tables to verify that they were modified correctly. So these additional helper methods are also included:</p>
-<div class="sourceCode" id="cb312"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb312-1"><a href="#cb312-1"></a><span class="kw">CREATE</span> PROC test_the_subject_read_foo()</span>
-<span id="cb312-2"><a href="#cb312-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb312-3"><a href="#cb312-3"></a> <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> foo;</span>
-<span id="cb312-4"><a href="#cb312-4"></a><span class="cf">END</span>;</span>
-<span id="cb312-5"><a href="#cb312-5"></a></span>
-<span id="cb312-6"><a href="#cb312-6"></a><span class="kw">CREATE</span> PROC test_the_subject_read_bar()</span>
-<span id="cb312-7"><a href="#cb312-7"></a><span class="cf">BEGIN</span></span>
-<span id="cb312-8"><a href="#cb312-8"></a> <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> bar;</span>
-<span id="cb312-9"><a href="#cb312-9"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb312"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb312-1"><a href="#cb312-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_read_foo()</span>
+<span id="cb312-2"><a href="#cb312-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb312-3"><a href="#cb312-3" aria-hidden="true" tabindex="-1"></a> <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> foo;</span>
+<span id="cb312-4"><a href="#cb312-4" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span>
+<span id="cb312-5"><a href="#cb312-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb312-6"><a href="#cb312-6" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_read_bar()</span>
+<span id="cb312-7"><a href="#cb312-7" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb312-8"><a href="#cb312-8" aria-hidden="true" tabindex="-1"></a> <span class="kw">SELECT</span> <span class="op">*</span> <span class="kw">FROM</span> bar;</span>
+<span id="cb312-9"><a href="#cb312-9" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Those procedures will allow you to easily create result sets with data from the relevant tables which can then be verified for correctness. Of course if more tables were implicated those would have been included as well.</p>
 <p>As you can see the naming always follows the convention <code>test_[YOUR_PROCEDURE]_[helper_type]</code></p>
 <p>Finally, the most complicated helper is the one that used that large annotation. Recall that we provided the fragment <code>(dummy_test, (bar, (data), ('plugh'))))</code> to the compiler. This fragment helped to produce this last helper function:</p>
-<div class="sourceCode" id="cb313"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb313-1"><a href="#cb313-1"></a><span class="kw">CREATE</span> PROC test_the_subject_populate_tables()</span>
-<span id="cb313-2"><a href="#cb313-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb313-3"><a href="#cb313-3"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> foo(<span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="dv">1</span>) @dummy_seed(<span class="dv">123</span>);</span>
-<span id="cb313-4"><a href="#cb313-4"></a>  </span>
-<span id="cb313-5"><a href="#cb313-5"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> foo(<span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="dv">2</span>) @dummy_seed(<span class="dv">124</span>) </span>
-<span id="cb313-6"><a href="#cb313-6"></a>      @dummy_nullables @dummy_defaults;</span>
-<span id="cb313-7"><a href="#cb313-7"></a>  </span>
-<span id="cb313-8"><a href="#cb313-8"></a><span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> bar(<span class="kw">data</span>, <span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="st">&#39;plugh&#39;</span>, <span class="dv">1</span>) @dummy_seed(<span class="dv">125</span>);</span>
-<span id="cb313-9"><a href="#cb313-9"></a>  </span>
-<span id="cb313-10"><a href="#cb313-10"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> bar(<span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="dv">2</span>) @dummy_seed(<span class="dv">126</span>)</span>
-<span id="cb313-11"><a href="#cb313-11"></a>     @dummy_nullables @dummy_defaults;</span>
-<span id="cb313-12"><a href="#cb313-12"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb313"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb313-1"><a href="#cb313-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC test_the_subject_populate_tables()</span>
+<span id="cb313-2"><a href="#cb313-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb313-3"><a href="#cb313-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> foo(<span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="dv">1</span>) @dummy_seed(<span class="dv">123</span>);</span>
+<span id="cb313-4"><a href="#cb313-4" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb313-5"><a href="#cb313-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> foo(<span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="dv">2</span>) @dummy_seed(<span class="dv">124</span>) </span>
+<span id="cb313-6"><a href="#cb313-6" aria-hidden="true" tabindex="-1"></a>      @dummy_nullables @dummy_defaults;</span>
+<span id="cb313-7"><a href="#cb313-7" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb313-8"><a href="#cb313-8" aria-hidden="true" tabindex="-1"></a><span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> bar(<span class="kw">data</span>, <span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="st">&#39;plugh&#39;</span>, <span class="dv">1</span>) @dummy_seed(<span class="dv">125</span>);</span>
+<span id="cb313-9"><a href="#cb313-9" aria-hidden="true" tabindex="-1"></a>  </span>
+<span id="cb313-10"><a href="#cb313-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INSERT</span> <span class="kw">OR</span> IGNORE <span class="kw">INTO</span> bar(<span class="kw">id</span>) <span class="kw">VALUES</span>(<span class="dv">2</span>) @dummy_seed(<span class="dv">126</span>)</span>
+<span id="cb313-11"><a href="#cb313-11" aria-hidden="true" tabindex="-1"></a>     @dummy_nullables @dummy_defaults;</span>
+<span id="cb313-12"><a href="#cb313-12" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>In general the <code>populate_tables</code> helper will fill all implicated tables with at least two rows of data. It uses the dummy data features discussed earlier to generate the items using a seed. Recall that if <code>@dummy_seed</code> is present in an <code>insert</code> statement then any missing columns are generated using that value, either as a string, or as an integer (or true/false for a boolean). Note that the second of the two rows that is generated also specifies <code>@dummy_nullables</code> and <code>@dummy_defaults</code>. This means that even nullable columns, and columns with a default value will get the non-null seed instead. So you get a mix of null/default/explicit values loaded into your tables.</p>
 <p>Of course blindly inserting data doesn’t quite work. As you can see, the insert code used the foreign key references in the schema to figure out the necessary insert order and the primary key values for <code>foo</code> were automatically specified so that they could then be used again in <code>bar</code>.</p>
 <p>Lastly, the autotest attribute included explicit test values for the table <code>bar</code>, and in particular the <code>data</code> column has the value <code>'plugh'</code>. So the first row of data for table <code>bar</code> did not use dummy data for the <code>data</code> column but rather used <code>'plugh'</code>.</p>
@@ -4836,7 +4968,7 @@ BEGIN
 END;</code></pre>
 <p>And of course if the annotation is not flexible enough, you can write your own data population as usual.</p>
 <p>The CQL above results in the usual C signatures. For instance:</p>
-<div class="sourceCode" id="cb316"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb316-1"><a href="#cb316-1"></a>CQL_WARN_UNUSED cql_code test_the_subject_populate_tables(sqlite3 *_Nonnull _db_);</span></code></pre></div>
+<div class="sourceCode" id="cb316"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb316-1"><a href="#cb316-1" aria-hidden="true" tabindex="-1"></a>CQL_WARN_UNUSED cql_code test_the_subject_populate_tables<span class="op">(</span>sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">);</span></span></code></pre></div>
 <p>So it’s fairly easy to call from C/C++ test code or from CQL test code.</p>
 <h2 id="chapter-13-json-output">Chapter 13: JSON Output</h2>
 <!---
@@ -5774,17 +5906,17 @@ end;</code></pre>
 <h3 id="extension-query-fragments">Extension Query Fragments</h3>
 <h4 id="adding-columns">Adding Columns</h4>
 <p>The most common thing that an extension might want to do is add columns to the result. There can be any number of such extensions in the final assembly. Here’s a simple example that adds one column.</p>
-<div class="sourceCode" id="cb341"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb341-1"><a href="#cb341-1"></a><span class="ot">@attribute(cql:extension_fragment=base_frag)</span></span>
-<span id="cb341-2"><a href="#cb341-2"></a><span class="kw">create</span> proc adds_columns(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb341-3"><a href="#cb341-3"></a><span class="cf">begin</span></span>
-<span id="cb341-4"><a href="#cb341-4"></a>  <span class="kw">with</span></span>
-<span id="cb341-5"><a href="#cb341-5"></a>    base_frag(<span class="op">*</span>) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span>, <span class="ot">&quot;name&quot;</span> name, <span class="fl">1.0</span> rate),</span>
-<span id="cb341-6"><a href="#cb341-6"></a>    col_adder_frag(<span class="op">*</span>) <span class="kw">as</span> (</span>
-<span id="cb341-7"><a href="#cb341-7"></a>    <span class="kw">select</span> base_frag.<span class="op">*</span>, added_columns.<span class="kw">data</span></span>
-<span id="cb341-8"><a href="#cb341-8"></a>      <span class="kw">from</span> base_frag</span>
-<span id="cb341-9"><a href="#cb341-9"></a>      <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> added_columns <span class="kw">on</span> base_frag.<span class="kw">id</span> <span class="op">=</span> added_columns.<span class="kw">id</span>)</span>
-<span id="cb341-10"><a href="#cb341-10"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> col_adder_frag;</span>
-<span id="cb341-11"><a href="#cb341-11"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb341"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb341-1"><a href="#cb341-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:extension_fragment=base_frag)</span></span>
+<span id="cb341-2"><a href="#cb341-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc adds_columns(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb341-3"><a href="#cb341-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb341-4"><a href="#cb341-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span></span>
+<span id="cb341-5"><a href="#cb341-5" aria-hidden="true" tabindex="-1"></a>    base_frag(<span class="op">*</span>) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span>, <span class="ot">&quot;name&quot;</span> name, <span class="fl">1.0</span> rate),</span>
+<span id="cb341-6"><a href="#cb341-6" aria-hidden="true" tabindex="-1"></a>    col_adder_frag(<span class="op">*</span>) <span class="kw">as</span> (</span>
+<span id="cb341-7"><a href="#cb341-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> base_frag.<span class="op">*</span>, added_columns.<span class="kw">data</span></span>
+<span id="cb341-8"><a href="#cb341-8" aria-hidden="true" tabindex="-1"></a>      <span class="kw">from</span> base_frag</span>
+<span id="cb341-9"><a href="#cb341-9" aria-hidden="true" tabindex="-1"></a>      <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> added_columns <span class="kw">on</span> base_frag.<span class="kw">id</span> <span class="op">=</span> added_columns.<span class="kw">id</span>)</span>
+<span id="cb341-10"><a href="#cb341-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> col_adder_frag;</span>
+<span id="cb341-11"><a href="#cb341-11" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Again there are some important features to this extension and they are largely completely constrained, i.e. you must follow the pattern.</p>
 <ul>
 <li>the attribute indicates <code>extension_fragment</code> and the name (here <code>base_frag</code>) must have been previously declared in a <code>base_fragment</code></li>
@@ -5822,65 +5954,65 @@ end;</code></pre>
 </ul>
 <p>This fragment can be (and should be) compiled in its own compiland while using <code>#include</code> to get the base fragment only. This will result in code gen for the accessor functions for a piece of the overall query – the part this extension knows about. Importantly code that uses this extension’s data does not need or want to know about any other extensions that may be present, thereby keeping dependencies under control.</p>
 <p>The C signatures generated would look like this:</p>
-<div class="sourceCode" id="cb342"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb342-1"><a href="#cb342-1"></a><span class="kw">extern</span> cql_int32 adds_columns_get_id(</span>
-<span id="cb342-2"><a href="#cb342-2"></a>    base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb342-3"><a href="#cb342-3"></a>    cql_int32 row);</span>
-<span id="cb342-4"><a href="#cb342-4"></a></span>
-<span id="cb342-5"><a href="#cb342-5"></a><span class="kw">extern</span> cql_string_ref _Nonnull adds_columns_get_name(</span>
-<span id="cb342-6"><a href="#cb342-6"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb342-7"><a href="#cb342-7"></a>  cql_int32 row);</span>
-<span id="cb342-8"><a href="#cb342-8"></a></span>
-<span id="cb342-9"><a href="#cb342-9"></a><span class="kw">extern</span> cql_double adds_columns_get_rate(</span>
-<span id="cb342-10"><a href="#cb342-10"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb342-11"><a href="#cb342-11"></a>  cql_int32 row);</span>
-<span id="cb342-12"><a href="#cb342-12"></a></span>
-<span id="cb342-13"><a href="#cb342-13"></a><span class="kw">extern</span> cql_string_ref _Nullable adds_columns_get_data(</span>
-<span id="cb342-14"><a href="#cb342-14"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb342-15"><a href="#cb342-15"></a>  cql_int32 row);</span>
-<span id="cb342-16"><a href="#cb342-16"></a></span>
-<span id="cb342-17"><a href="#cb342-17"></a><span class="kw">extern</span> cql_int32 adds_columns_result_count(</span>
-<span id="cb342-18"><a href="#cb342-18"></a>  base_frag_result_set_ref _Nonnull result_set);</span></code></pre></div>
+<div class="sourceCode" id="cb342"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb342-1"><a href="#cb342-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 adds_columns_get_id<span class="op">(</span></span>
+<span id="cb342-2"><a href="#cb342-2" aria-hidden="true" tabindex="-1"></a>    base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb342-3"><a href="#cb342-3" aria-hidden="true" tabindex="-1"></a>    cql_int32 row<span class="op">);</span></span>
+<span id="cb342-4"><a href="#cb342-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb342-5"><a href="#cb342-5" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nonnull adds_columns_get_name<span class="op">(</span></span>
+<span id="cb342-6"><a href="#cb342-6" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb342-7"><a href="#cb342-7" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb342-8"><a href="#cb342-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb342-9"><a href="#cb342-9" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_double adds_columns_get_rate<span class="op">(</span></span>
+<span id="cb342-10"><a href="#cb342-10" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb342-11"><a href="#cb342-11" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb342-12"><a href="#cb342-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb342-13"><a href="#cb342-13" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nullable adds_columns_get_data<span class="op">(</span></span>
+<span id="cb342-14"><a href="#cb342-14" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb342-15"><a href="#cb342-15" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb342-16"><a href="#cb342-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb342-17"><a href="#cb342-17" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 adds_columns_result_count<span class="op">(</span></span>
+<span id="cb342-18"><a href="#cb342-18" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">);</span></span></code></pre></div>
 <p>Even if there were dozens of other extensions, the functions for reading those columns would not be declared in the header for this extension. Any given extension “sees” only the core columns plus any columns it added.</p>
 <h4 id="adding-rows">Adding Rows</h4>
 <p>Query extensions also frequently want to add additional rows to the main result set, based on the data that is already present.</p>
 <p>The second form of extension allows for this, it is similarly locked in form. Here is an example:</p>
-<div class="sourceCode" id="cb343"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb343-1"><a href="#cb343-1"></a><span class="ot">@attribute(cql:extension_fragment=base_frag)</span></span>
-<span id="cb343-2"><a href="#cb343-2"></a><span class="kw">create</span> proc adds_rows(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb343-3"><a href="#cb343-3"></a><span class="cf">begin</span></span>
-<span id="cb343-4"><a href="#cb343-4"></a>  <span class="kw">with</span></span>
-<span id="cb343-5"><a href="#cb343-5"></a>    base_frag(<span class="op">*</span>) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span>, <span class="ot">&quot;name&quot;</span> name, <span class="fl">1.0</span> rate),</span>
-<span id="cb343-6"><a href="#cb343-6"></a>    row_adder_frag(<span class="op">*</span>) <span class="kw">as</span> (</span>
-<span id="cb343-7"><a href="#cb343-7"></a>    <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> base_frag</span>
-<span id="cb343-8"><a href="#cb343-8"></a>    <span class="kw">union</span> <span class="kw">all</span></span>
-<span id="cb343-9"><a href="#cb343-9"></a>    <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> added_rows)</span>
-<span id="cb343-10"><a href="#cb343-10"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> row_adder_frag;</span>
-<span id="cb343-11"><a href="#cb343-11"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb343"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb343-1"><a href="#cb343-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:extension_fragment=base_frag)</span></span>
+<span id="cb343-2"><a href="#cb343-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc adds_rows(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb343-3"><a href="#cb343-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb343-4"><a href="#cb343-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span></span>
+<span id="cb343-5"><a href="#cb343-5" aria-hidden="true" tabindex="-1"></a>    base_frag(<span class="op">*</span>) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span>, <span class="ot">&quot;name&quot;</span> name, <span class="fl">1.0</span> rate),</span>
+<span id="cb343-6"><a href="#cb343-6" aria-hidden="true" tabindex="-1"></a>    row_adder_frag(<span class="op">*</span>) <span class="kw">as</span> (</span>
+<span id="cb343-7"><a href="#cb343-7" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> base_frag</span>
+<span id="cb343-8"><a href="#cb343-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">union</span> <span class="kw">all</span></span>
+<span id="cb343-9"><a href="#cb343-9" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> added_rows)</span>
+<span id="cb343-10"><a href="#cb343-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> row_adder_frag;</span>
+<span id="cb343-11"><a href="#cb343-11" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Let’s review the features of this second template form: * there is a surrogate for the core query * there is a manatory second CTE * the second CTE is a compound query with any number of branches, all <code>union all</code> * the first branch must be <code>select * from base_frag</code> (the base fragment) to ensure that the original rows remain * this is also why all the branches must be <code>union all</code> * this form cannot add new columns * the extension CTE may not include <code>order by</code> or <code>limit</code> because that might reorder or remove rows of the base * any extensions of this form must come before those of the <code>left outer join</code> form for a given base fragment * which ironically means <code>row_adder_frag</code> has to come before <code>col_adder_frag</code> * the usual restrictions on compound selects (same type and number of columns) ensure a consistent result * the final select after the CTE section must exactly in the form <code>select * from row_adder_frag</code> which is the name of the one and only additional CTE with no other clauses or options * in practice only the CTE will be used to create the final assembly so even if you did change the final select to something else it would be moot</p>
 <p>The signatures generated for this will look something like so:</p>
-<div class="sourceCode" id="cb344"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb344-1"><a href="#cb344-1"></a><span class="kw">extern</span> cql_int32 adds_rows_get_id(</span>
-<span id="cb344-2"><a href="#cb344-2"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb344-3"><a href="#cb344-3"></a>  cql_int32 row);</span>
-<span id="cb344-4"><a href="#cb344-4"></a></span>
-<span id="cb344-5"><a href="#cb344-5"></a><span class="kw">extern</span> cql_string_ref _Nonnull adds_rows_get_name(</span>
-<span id="cb344-6"><a href="#cb344-6"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb344-7"><a href="#cb344-7"></a>  cql_int32 row);</span>
-<span id="cb344-8"><a href="#cb344-8"></a></span>
-<span id="cb344-9"><a href="#cb344-9"></a><span class="kw">extern</span> cql_double adds_rows_get_rate(</span>
-<span id="cb344-10"><a href="#cb344-10"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb344-11"><a href="#cb344-11"></a>  cql_int32 row);</span>
-<span id="cb344-12"><a href="#cb344-12"></a></span>
-<span id="cb344-13"><a href="#cb344-13"></a><span class="kw">extern</span> cql_int32 adds_rows_result_count(</span>
-<span id="cb344-14"><a href="#cb344-14"></a>  base_frag_result_set_ref _Nonnull result_set);</span></code></pre></div>
+<div class="sourceCode" id="cb344"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb344-1"><a href="#cb344-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 adds_rows_get_id<span class="op">(</span></span>
+<span id="cb344-2"><a href="#cb344-2" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb344-3"><a href="#cb344-3" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb344-4"><a href="#cb344-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb344-5"><a href="#cb344-5" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nonnull adds_rows_get_name<span class="op">(</span></span>
+<span id="cb344-6"><a href="#cb344-6" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb344-7"><a href="#cb344-7" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb344-8"><a href="#cb344-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb344-9"><a href="#cb344-9" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_double adds_rows_get_rate<span class="op">(</span></span>
+<span id="cb344-10"><a href="#cb344-10" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb344-11"><a href="#cb344-11" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb344-12"><a href="#cb344-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb344-13"><a href="#cb344-13" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 adds_rows_result_count<span class="op">(</span></span>
+<span id="cb344-14"><a href="#cb344-14" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">);</span></span></code></pre></div>
 <p>Which gives you access to the core columns. Again this fragment can and should be compiled standalone with only the declaration for the base fragment in the same translation unit to get the cleanest possible output. This is so that consumers of this extension do not “see” other extensions which may or may not be related and may or may not always be present.</p>
 <h4 id="assembling-the-fragments">Assembling the Fragments</h4>
 <p>With all the fragments independently declared they need to be unified to create one final query. This is where the major rewriting happens. The <code>assembly_fragment</code> looks something like this:</p>
-<div class="sourceCode" id="cb345"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb345-1"><a href="#cb345-1"></a><span class="ot">@attribute(cql:assembly_fragment=base_frag)</span></span>
-<span id="cb345-2"><a href="#cb345-2"></a><span class="kw">create</span> proc base_frag(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb345-3"><a href="#cb345-3"></a><span class="cf">begin</span></span>
-<span id="cb345-4"><a href="#cb345-4"></a>  <span class="kw">with</span></span>
-<span id="cb345-5"><a href="#cb345-5"></a>    base_frag(<span class="op">*</span>) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span>, <span class="ot">&quot;name&quot;</span> name, <span class="fl">1.0</span> rate)</span>
-<span id="cb345-6"><a href="#cb345-6"></a>    <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> base_frag;</span>
-<span id="cb345-7"><a href="#cb345-7"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb345"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb345-1"><a href="#cb345-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:assembly_fragment=base_frag)</span></span>
+<span id="cb345-2"><a href="#cb345-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc base_frag(id_ <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb345-3"><a href="#cb345-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb345-4"><a href="#cb345-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span></span>
+<span id="cb345-5"><a href="#cb345-5" aria-hidden="true" tabindex="-1"></a>    base_frag(<span class="op">*</span>) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span> <span class="kw">id</span>, <span class="ot">&quot;name&quot;</span> name, <span class="fl">1.0</span> rate)</span>
+<span id="cb345-6"><a href="#cb345-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> base_frag;</span>
+<span id="cb345-7"><a href="#cb345-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>It will always be as simple as this, all the complexity is in the fragments.</p>
 <ul>
 <li>the <code>assembly_fragment</code> name must match the core fragment name</li>
@@ -5901,23 +6033,23 @@ end;</code></pre>
 <p>When compiling the assembly fragment, you should include the base, and all the other fragments, and the assembly template. The presence of the assembly_fragment will cause codegen for the extension fragments to be suppressed. The assembly translation unit only contains the assembly query as formed from the fragments.</p>
 <p>Now let’s look at how the query is rewritten, the process is pretty methodical.</p>
 <p>After rewriting the assembly looks like this:</p>
-<div class="sourceCode" id="cb346"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb346-1"><a href="#cb346-1"></a><span class="kw">CREATE</span> PROC base_frag (id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
-<span id="cb346-2"><a href="#cb346-2"></a><span class="cf">BEGIN</span></span>
-<span id="cb346-3"><a href="#cb346-3"></a>  <span class="kw">WITH</span></span>
-<span id="cb346-4"><a href="#cb346-4"></a>  base_frag (<span class="kw">id</span>, name, rate) <span class="kw">AS</span> (<span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb346-5"><a href="#cb346-5"></a>    <span class="kw">FROM</span> my_table</span>
-<span id="cb346-6"><a href="#cb346-6"></a>    <span class="kw">WHERE</span> my_table.<span class="kw">id</span> <span class="op">=</span> id_),</span>
-<span id="cb346-7"><a href="#cb346-7"></a>  row_adder_frag (<span class="kw">id</span>, name, rate) <span class="kw">AS</span> (<span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb346-8"><a href="#cb346-8"></a>    <span class="kw">FROM</span> base_frag</span>
-<span id="cb346-9"><a href="#cb346-9"></a>  <span class="kw">UNION</span> <span class="kw">ALL</span></span>
-<span id="cb346-10"><a href="#cb346-10"></a>  <span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb346-11"><a href="#cb346-11"></a>    <span class="kw">FROM</span> added_rows),</span>
-<span id="cb346-12"><a href="#cb346-12"></a>  col_adder_frag (<span class="kw">id</span>, name, rate, <span class="kw">data</span>) <span class="kw">AS</span> (<span class="kw">SELECT</span> row_adder_frag.<span class="op">*</span>, added_columns.<span class="kw">data</span></span>
-<span id="cb346-13"><a href="#cb346-13"></a>    <span class="kw">FROM</span> row_adder_frag</span>
-<span id="cb346-14"><a href="#cb346-14"></a>    <span class="kw">LEFT</span> <span class="kw">OUTER</span> <span class="kw">JOIN</span> added_columns <span class="kw">ON</span> row_adder_frag.<span class="kw">id</span> <span class="op">=</span> added_columns.<span class="kw">id</span>)</span>
-<span id="cb346-15"><a href="#cb346-15"></a>  <span class="kw">SELECT</span> <span class="op">*</span></span>
-<span id="cb346-16"><a href="#cb346-16"></a>    <span class="kw">FROM</span> col_adder_frag;</span>
-<span id="cb346-17"><a href="#cb346-17"></a><span class="cf">END</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb346"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb346-1"><a href="#cb346-1" aria-hidden="true" tabindex="-1"></a><span class="kw">CREATE</span> PROC base_frag (id_ <span class="dt">INTEGER</span> <span class="kw">NOT</span> <span class="kw">NULL</span>)</span>
+<span id="cb346-2"><a href="#cb346-2" aria-hidden="true" tabindex="-1"></a><span class="cf">BEGIN</span></span>
+<span id="cb346-3"><a href="#cb346-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">WITH</span></span>
+<span id="cb346-4"><a href="#cb346-4" aria-hidden="true" tabindex="-1"></a>  base_frag (<span class="kw">id</span>, name, rate) <span class="kw">AS</span> (<span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb346-5"><a href="#cb346-5" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> my_table</span>
+<span id="cb346-6"><a href="#cb346-6" aria-hidden="true" tabindex="-1"></a>    <span class="kw">WHERE</span> my_table.<span class="kw">id</span> <span class="op">=</span> id_),</span>
+<span id="cb346-7"><a href="#cb346-7" aria-hidden="true" tabindex="-1"></a>  row_adder_frag (<span class="kw">id</span>, name, rate) <span class="kw">AS</span> (<span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb346-8"><a href="#cb346-8" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> base_frag</span>
+<span id="cb346-9"><a href="#cb346-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNION</span> <span class="kw">ALL</span></span>
+<span id="cb346-10"><a href="#cb346-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb346-11"><a href="#cb346-11" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> added_rows),</span>
+<span id="cb346-12"><a href="#cb346-12" aria-hidden="true" tabindex="-1"></a>  col_adder_frag (<span class="kw">id</span>, name, rate, <span class="kw">data</span>) <span class="kw">AS</span> (<span class="kw">SELECT</span> row_adder_frag.<span class="op">*</span>, added_columns.<span class="kw">data</span></span>
+<span id="cb346-13"><a href="#cb346-13" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> row_adder_frag</span>
+<span id="cb346-14"><a href="#cb346-14" aria-hidden="true" tabindex="-1"></a>    <span class="kw">LEFT</span> <span class="kw">OUTER</span> <span class="kw">JOIN</span> added_columns <span class="kw">ON</span> row_adder_frag.<span class="kw">id</span> <span class="op">=</span> added_columns.<span class="kw">id</span>)</span>
+<span id="cb346-15"><a href="#cb346-15" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SELECT</span> <span class="op">*</span></span>
+<span id="cb346-16"><a href="#cb346-16" aria-hidden="true" tabindex="-1"></a>    <span class="kw">FROM</span> col_adder_frag;</span>
+<span id="cb346-17"><a href="#cb346-17" aria-hidden="true" tabindex="-1"></a><span class="cf">END</span>;</span></code></pre></div>
 <p>Let’s dissect this part by part, each CTE serves a purpose.</p>
 <ul>
 <li>the core CTE was replaced by the CTE in the base_fragment, it appears directly</li>
@@ -5939,31 +6071,31 @@ end;</code></pre>
 <p>With the rewrite of the assembly_fragment complete, the codegen for that procedure is the normal codegen for a procedure with a single select.</p>
 <p>As always, Java and Objective C codegen on these pieces will produce suitable wrappers for the C.</p>
 <p>The output code for the assembly fragment generates these reading functions:</p>
-<div class="sourceCode" id="cb347"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb347-1"><a href="#cb347-1"></a><span class="kw">extern</span> cql_int32 base_frag_get_id(</span>
-<span id="cb347-2"><a href="#cb347-2"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb347-3"><a href="#cb347-3"></a>  cql_int32 row);</span>
-<span id="cb347-4"><a href="#cb347-4"></a></span>
-<span id="cb347-5"><a href="#cb347-5"></a><span class="kw">extern</span> cql_string_ref _Nonnull base_frag_get_name(</span>
-<span id="cb347-6"><a href="#cb347-6"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb347-7"><a href="#cb347-7"></a>  cql_int32 row);</span>
-<span id="cb347-8"><a href="#cb347-8"></a></span>
-<span id="cb347-9"><a href="#cb347-9"></a><span class="kw">extern</span> cql_double base_frag_get_rate(</span>
-<span id="cb347-10"><a href="#cb347-10"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb347-11"><a href="#cb347-11"></a>  cql_int32 row);</span>
-<span id="cb347-12"><a href="#cb347-12"></a></span>
-<span id="cb347-13"><a href="#cb347-13"></a><span class="co">// used by adds_columns_get_data() to read its data</span></span>
-<span id="cb347-14"><a href="#cb347-14"></a><span class="kw">extern</span> cql_string_ref _Nullable __PRIVATE__base_frag_get_data(</span>
-<span id="cb347-15"><a href="#cb347-15"></a>  base_frag_result_set_ref _Nonnull result_set,</span>
-<span id="cb347-16"><a href="#cb347-16"></a>  cql_int32 row);</span>
-<span id="cb347-17"><a href="#cb347-17"></a></span>
-<span id="cb347-18"><a href="#cb347-18"></a><span class="kw">extern</span> cql_int32 base_frag_result_count(</span>
-<span id="cb347-19"><a href="#cb347-19"></a>  base_frag_result_set_ref _Nonnull result_set);</span></code></pre></div>
+<div class="sourceCode" id="cb347"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb347-1"><a href="#cb347-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 base_frag_get_id<span class="op">(</span></span>
+<span id="cb347-2"><a href="#cb347-2" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb347-3"><a href="#cb347-3" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb347-4"><a href="#cb347-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb347-5"><a href="#cb347-5" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nonnull base_frag_get_name<span class="op">(</span></span>
+<span id="cb347-6"><a href="#cb347-6" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb347-7"><a href="#cb347-7" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb347-8"><a href="#cb347-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb347-9"><a href="#cb347-9" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_double base_frag_get_rate<span class="op">(</span></span>
+<span id="cb347-10"><a href="#cb347-10" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb347-11"><a href="#cb347-11" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb347-12"><a href="#cb347-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb347-13"><a href="#cb347-13" aria-hidden="true" tabindex="-1"></a><span class="co">// used by adds_columns_get_data() to read its data</span></span>
+<span id="cb347-14"><a href="#cb347-14" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_string_ref _Nullable __PRIVATE__base_frag_get_data<span class="op">(</span></span>
+<span id="cb347-15"><a href="#cb347-15" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">,</span></span>
+<span id="cb347-16"><a href="#cb347-16" aria-hidden="true" tabindex="-1"></a>  cql_int32 row<span class="op">);</span></span>
+<span id="cb347-17"><a href="#cb347-17" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb347-18"><a href="#cb347-18" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> cql_int32 base_frag_result_count<span class="op">(</span></span>
+<span id="cb347-19"><a href="#cb347-19" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nonnull result_set<span class="op">);</span></span></code></pre></div>
 <p>These are exactly what you would get for a normal query except that the pieces that came from extensions are marked <code>PRIVATE</code>. Those methods should not be used directly but instead the methods generated for each extension proc should be used.</p>
 <p>Additionally, to create the result set, as usual.</p>
-<div class="sourceCode" id="cb348"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb348-1"><a href="#cb348-1"></a><span class="kw">extern</span> CQL_WARN_UNUSED cql_code base_frag_fetch_results(</span>
-<span id="cb348-2"><a href="#cb348-2"></a>  sqlite3 *_Nonnull _db_,</span>
-<span id="cb348-3"><a href="#cb348-3"></a>  base_frag_result_set_ref _Nullable *_Nonnull result_set,</span>
-<span id="cb348-4"><a href="#cb348-4"></a>  cql_int32 id_);</span></code></pre></div>
+<div class="sourceCode" id="cb348"><pre class="sourceCode c"><code class="sourceCode c"><span id="cb348-1"><a href="#cb348-1" aria-hidden="true" tabindex="-1"></a><span class="kw">extern</span> CQL_WARN_UNUSED cql_code base_frag_fetch_results<span class="op">(</span></span>
+<span id="cb348-2"><a href="#cb348-2" aria-hidden="true" tabindex="-1"></a>  sqlite3 <span class="op">*</span>_Nonnull _db_<span class="op">,</span></span>
+<span id="cb348-3"><a href="#cb348-3" aria-hidden="true" tabindex="-1"></a>  base_frag_result_set_ref _Nullable <span class="op">*</span>_Nonnull result_set<span class="op">,</span></span>
+<span id="cb348-4"><a href="#cb348-4" aria-hidden="true" tabindex="-1"></a>  cql_int32 id_<span class="op">);</span></span></code></pre></div>
 <p>With the combined set of methods you can create a variety of assembled queries from extensions in a fairly straightforward way.</p>
 <h2 id="appendix-1-command-line-options">Appendix 1: Command Line Options</h2>
 <!---
@@ -7561,9 +7693,9 @@ enforce_pop_stmt:
 <hr />
 <h3 id="cql0016-duplicate-table-name-in-join-table">CQL0016: duplicate table name in join ‘table’</h3>
 <p>When this error is produced it means the result of the join would have the same table twice with no disambiguation between the two places. The conflicting name is provided. To fix this, make an alias both tables. e.g.</p>
-<div class="sourceCode" id="cb359"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb359-1"><a href="#cb359-1"></a><span class="kw">SELECT</span> T1.<span class="kw">id</span> <span class="kw">AS</span> parent_id, T2.<span class="kw">id</span> <span class="kw">AS</span> child_id</span>
-<span id="cb359-2"><a href="#cb359-2"></a>  <span class="kw">FROM</span> foo <span class="kw">AS</span> T1</span>
-<span id="cb359-3"><a href="#cb359-3"></a>  <span class="kw">INNER</span> <span class="kw">JOIN</span> foo <span class="kw">AS</span> T2 <span class="kw">ON</span> T1.<span class="kw">id</span> <span class="op">=</span> T2.parent_id;</span></code></pre></div>
+<div class="sourceCode" id="cb359"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb359-1"><a href="#cb359-1" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> T1.<span class="kw">id</span> <span class="kw">AS</span> parent_id, T2.<span class="kw">id</span> <span class="kw">AS</span> child_id</span>
+<span id="cb359-2"><a href="#cb359-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">FROM</span> foo <span class="kw">AS</span> T1</span>
+<span id="cb359-3"><a href="#cb359-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INNER</span> <span class="kw">JOIN</span> foo <span class="kw">AS</span> T2 <span class="kw">ON</span> T1.<span class="kw">id</span> <span class="op">=</span> T2.parent_id;</span></code></pre></div>
 <hr />
 <h3 id="cql0017-index-was-present-but-now-it-does-not-exist-use-delete-instead-index">CQL0017: index was present but now it does not exist (use <code>@delete</code> instead) ‘index’</h3>
 <p>The named index is in the previous schema bit it is not in the current schema. All entities need some kind of tombstone in the schema so that they can be correctly deleted if they are still present.</p>
@@ -7701,19 +7833,19 @@ enforce_pop_stmt:
 <p>If a stored procedure might return one of several result sets, each of the select statements must have the same column names for its result. Likewise, if several select results are being combined with <code>UNION</code> or <code>UNION ALL</code> they must all have the same column names.</p>
 <p>This is important so that there can be one unambiguous column name for every column for group of select statements.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb360"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb360-1"><a href="#cb360-1"></a><span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B</span>
-<span id="cb360-2"><a href="#cb360-2"></a><span class="kw">union</span></span>
-<span id="cb360-3"><a href="#cb360-3"></a><span class="kw">select</span> <span class="dv">3</span> A, <span class="dv">4</span> C;</span></code></pre></div>
+<div class="sourceCode" id="cb360"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb360-1"><a href="#cb360-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B</span>
+<span id="cb360-2"><a href="#cb360-2" aria-hidden="true" tabindex="-1"></a><span class="kw">union</span></span>
+<span id="cb360-3"><a href="#cb360-3" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="dv">3</span> A, <span class="dv">4</span> C;</span></code></pre></div>
 <p>Would provoke this error. In this case ‘C’ would be regarded as the offending column.</p>
 <hr />
 <h3 id="cql0059-a-variable-name-might-be-ambiguous-with-a-column-name-this-is-an-anti-pattern-name">CQL0059: a variable name might be ambiguous with a column name, this is an anti-pattern ‘name’</h3>
 <p>The referenced name is the name of a local or a global in the same scope as the name of a column. This can lead to surprising results as it is not clear which name takes priority (previously the variable did rather than the column, now it’s an error).</p>
 <p>example:</p>
-<div class="sourceCode" id="cb361"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb361-1"><a href="#cb361-1"></a><span class="kw">create</span> proc foo(<span class="kw">id</span> <span class="dt">integer</span>)</span>
-<span id="cb361-2"><a href="#cb361-2"></a><span class="cf">begin</span></span>
-<span id="cb361-3"><a href="#cb361-3"></a>  <span class="co">-- this is now an error, in all cases the argument would have been selected</span></span>
-<span id="cb361-4"><a href="#cb361-4"></a>  <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> bar T1 <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">!=</span> <span class="kw">id</span>;</span>
-<span id="cb361-5"><a href="#cb361-5"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb361"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb361-1"><a href="#cb361-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(<span class="kw">id</span> <span class="dt">integer</span>)</span>
+<span id="cb361-2"><a href="#cb361-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb361-3"><a href="#cb361-3" aria-hidden="true" tabindex="-1"></a>  <span class="co">-- this is now an error, in all cases the argument would have been selected</span></span>
+<span id="cb361-4"><a href="#cb361-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> bar T1 <span class="kw">where</span> T1.<span class="kw">id</span> <span class="op">!=</span> <span class="kw">id</span>;</span>
+<span id="cb361-5"><a href="#cb361-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>To correct this, rename the local/global. Or else pick a more distinctive column name, but usually the local is the problem.</p>
 <hr />
 <h3 id="cql0060-referenced-table-can-be-independently-be-recreated-so-it-cannot-be-used-in-a-foreign-key-referenced_table">CQL0060: referenced table can be independently be recreated so it cannot be used in a foreign key, ‘referenced_table’</h3>
@@ -7730,11 +7862,11 @@ enforce_pop_stmt:
 <h3 id="cql0061-if-multiple-selects-all-columns-must-be-an-exact-type-match-expected-expected_type-found-actual_type-column">CQL0061: if multiple selects, all columns must be an exact type match (expected expected_type; found actual_type) ‘column’</h3>
 <p>In a stored proc with multiple possible selects providing the result, all of the columns of all the selects must be an exact type match.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb362"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb362-1"><a href="#cb362-1"></a><span class="cf">if</span> x <span class="cf">then</span></span>
-<span id="cb362-2"><a href="#cb362-2"></a>  <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B</span>
-<span id="cb362-3"><a href="#cb362-3"></a><span class="cf">else</span></span>
-<span id="cb362-4"><a href="#cb362-4"></a>  <span class="kw">select</span> <span class="dv">3</span> A, <span class="fl">4.0</span> B;</span>
-<span id="cb362-5"><a href="#cb362-5"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb362"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb362-1"><a href="#cb362-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> x <span class="cf">then</span></span>
+<span id="cb362-2"><a href="#cb362-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B</span>
+<span id="cb362-3"><a href="#cb362-3" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span></span>
+<span id="cb362-4"><a href="#cb362-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="dv">3</span> A, <span class="fl">4.0</span> B;</span>
+<span id="cb362-5"><a href="#cb362-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>Would provoke this error. In this case ‘B’ would be regarded as the offending column and the error is reported on the second B.</p>
 <hr />
 <h3 id="cql0062-if-multiple-selects-all-columns-must-be-an-exact-type-match-including-nullability-expected-expected_type-found-actual_type-column">CQL0062: if multiple selects, all columns must be an exact type match (including nullability) (expected expected_type; found actual_type) ‘column’</h3>
@@ -7746,24 +7878,24 @@ enforce_pop_stmt:
 <h3 id="cql0064-object-variables-may-not-appear-in-the-context-of-a-sql-statement">CQL0064: object variables may not appear in the context of a SQL statement</h3>
 <p>SQLite doesn’t understand object references, so that means you cannot try to use a variable or parameter of type object inside of a SQL statement.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb363"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb363-1"><a href="#cb363-1"></a><span class="kw">create</span> proc foo(X <span class="dt">object</span>)</span>
-<span id="cb363-2"><a href="#cb363-2"></a><span class="cf">begin</span></span>
-<span id="cb363-3"><a href="#cb363-3"></a>  <span class="kw">select</span> X <span class="kw">is</span> <span class="kw">null</span>;</span>
-<span id="cb363-4"><a href="#cb363-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb363"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb363-1"><a href="#cb363-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(X <span class="dt">object</span>)</span>
+<span id="cb363-2"><a href="#cb363-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb363-3"><a href="#cb363-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> X <span class="kw">is</span> <span class="kw">null</span>;</span>
+<span id="cb363-4"><a href="#cb363-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>In this example X is an object parameter, but even to use X for an <code>is null</code> check in a select statement would require binding an object which is not possible.</p>
 <p>On the other hand this compiles fine.</p>
-<div class="sourceCode" id="cb364"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb364-1"><a href="#cb364-1"></a><span class="kw">create</span> proc foo(X <span class="dt">object</span>, <span class="kw">out</span> is_null bool <span class="kw">not</span> <span class="kw">null</span>)</span>
-<span id="cb364-2"><a href="#cb364-2"></a><span class="cf">begin</span></span>
-<span id="cb364-3"><a href="#cb364-3"></a>  <span class="kw">set</span> is_null <span class="op">:=</span> X <span class="kw">is</span> <span class="kw">null</span>;</span>
-<span id="cb364-4"><a href="#cb364-4"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb364"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb364-1"><a href="#cb364-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(X <span class="dt">object</span>, <span class="kw">out</span> is_null bool <span class="kw">not</span> <span class="kw">null</span>)</span>
+<span id="cb364-2"><a href="#cb364-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb364-3"><a href="#cb364-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> is_null <span class="op">:=</span> X <span class="kw">is</span> <span class="kw">null</span>;</span>
+<span id="cb364-4"><a href="#cb364-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>This is another example of XQL being a two-headed beast.</p>
 <hr />
 <h3 id="cql0065-identifier-is-ambiguous-name">CQL0065: identifier is ambiguous ‘name’</h3>
 <p>There is more than one variable/column with indicated name in equally near scopes. The most common reason for this is that there are two column in a join with the same name and that name has not been qualified elsewhere.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb365"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb365-1"><a href="#cb365-1"></a><span class="kw">SELECT</span> A</span>
-<span id="cb365-2"><a href="#cb365-2"></a>  <span class="kw">FROM</span> (<span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> A, <span class="dv">2</span> <span class="kw">AS</span> B) <span class="kw">AS</span> T1</span>
-<span id="cb365-3"><a href="#cb365-3"></a>  <span class="kw">INNER</span> <span class="kw">JOIN</span> (<span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> A, <span class="dv">2</span> <span class="kw">AS</span> B) <span class="kw">AS</span> T2;</span></code></pre></div>
+<div class="sourceCode" id="cb365"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb365-1"><a href="#cb365-1" aria-hidden="true" tabindex="-1"></a><span class="kw">SELECT</span> A</span>
+<span id="cb365-2"><a href="#cb365-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">FROM</span> (<span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> A, <span class="dv">2</span> <span class="kw">AS</span> B) <span class="kw">AS</span> T1</span>
+<span id="cb365-3"><a href="#cb365-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">INNER</span> <span class="kw">JOIN</span> (<span class="kw">SELECT</span> <span class="dv">1</span> <span class="kw">AS</span> A, <span class="dv">2</span> <span class="kw">AS</span> B) <span class="kw">AS</span> T2;</span></code></pre></div>
 <p>There are two possible columns named <code>A</code>. Fix this by using <code>T1.A</code> or <code>T2.A</code>.</p>
 <hr />
 <h3 id="cql0066-if-a-table-is-marked-recreate-its-indices-must-be-in-its-schema-region-index_name">CQL0066: if a table is marked <code>@recreate</code>, its indices must be in its schema region ‘index_name’</h3>
@@ -7774,28 +7906,28 @@ enforce_pop_stmt:
 <h3 id="cql0067-cursor-was-not-used-with-fetch-cursor-cursor_name">CQL0067: cursor was not used with ‘fetch [cursor]’ ‘cursor_name’</h3>
 <p>The code is trying to access fields in the named cursor but the automatic field generation form was not used so there are no such fields.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb366"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb366-1"><a href="#cb366-1"></a><span class="kw">declare</span> a <span class="dt">integer</span>;</span>
-<span id="cb366-2"><a href="#cb366-2"></a><span class="kw">declare</span> b <span class="dt">integer</span>;</span>
-<span id="cb366-3"><a href="#cb366-3"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B;</span>
-<span id="cb366-4"><a href="#cb366-4"></a>fetch C <span class="kw">into</span> a, b; <span class="co">-- C.A and C.B not created (!)</span></span>
-<span id="cb366-5"><a href="#cb366-5"></a><span class="cf">if</span> (C.A) <span class="cf">then</span> <span class="co">-- error</span></span>
-<span id="cb366-6"><a href="#cb366-6"></a>  <span class="op">..</span>.</span>
-<span id="cb366-7"><a href="#cb366-7"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb366"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb366-1"><a href="#cb366-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> a <span class="dt">integer</span>;</span>
+<span id="cb366-2"><a href="#cb366-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> b <span class="dt">integer</span>;</span>
+<span id="cb366-3"><a href="#cb366-3" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B;</span>
+<span id="cb366-4"><a href="#cb366-4" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">into</span> a, b; <span class="co">-- C.A and C.B not created (!)</span></span>
+<span id="cb366-5"><a href="#cb366-5" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> (C.A) <span class="cf">then</span> <span class="co">-- error</span></span>
+<span id="cb366-6"><a href="#cb366-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb366-7"><a href="#cb366-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>Correct usage looks like this:</p>
-<div class="sourceCode" id="cb367"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb367-1"><a href="#cb367-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B;</span>
-<span id="cb367-2"><a href="#cb367-2"></a>fetch C;  <span class="co">-- automatically creates C.A and C.B</span></span>
-<span id="cb367-3"><a href="#cb367-3"></a><span class="cf">if</span> (C.A) <span class="cf">then</span></span>
-<span id="cb367-4"><a href="#cb367-4"></a>  <span class="op">..</span>.</span>
-<span id="cb367-5"><a href="#cb367-5"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb367"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb367-1"><a href="#cb367-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B;</span>
+<span id="cb367-2"><a href="#cb367-2" aria-hidden="true" tabindex="-1"></a>fetch C;  <span class="co">-- automatically creates C.A and C.B</span></span>
+<span id="cb367-3"><a href="#cb367-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> (C.A) <span class="cf">then</span></span>
+<span id="cb367-4"><a href="#cb367-4" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb367-5"><a href="#cb367-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0068-field-not-found-in-cursor-field">CQL0068: field not found in cursor ‘field’</h3>
 <p>The indicated field is not a valid field in a cursor expression.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb368"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb368-1"><a href="#cb368-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B;</span>
-<span id="cb368-2"><a href="#cb368-2"></a>fetch C;  <span class="co">-- automatically creates C.A and C.B</span></span>
-<span id="cb368-3"><a href="#cb368-3"></a><span class="cf">if</span> (C.X) <span class="cf">then</span> <span class="co">-- C has A and B, but no X</span></span>
-<span id="cb368-4"><a href="#cb368-4"></a>  <span class="op">..</span>.</span>
-<span id="cb368-5"><a href="#cb368-5"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb368"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb368-1"><a href="#cb368-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="dv">1</span> A, <span class="dv">2</span> B;</span>
+<span id="cb368-2"><a href="#cb368-2" aria-hidden="true" tabindex="-1"></a>fetch C;  <span class="co">-- automatically creates C.A and C.B</span></span>
+<span id="cb368-3"><a href="#cb368-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> (C.X) <span class="cf">then</span> <span class="co">-- C has A and B, but no X</span></span>
+<span id="cb368-4"><a href="#cb368-4" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb368-5"><a href="#cb368-5" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0069-name-not-found-name">CQL0069: name not found ‘name’</h3>
 <p>The indicated name could not be resolved in the scope in which it appears. Probably there is a typo. But maybe the name you need isn’t available in the scope you are trying to use it in.</p>
@@ -7839,7 +7971,7 @@ set x := y;</code></pre>
 <hr />
 <h3 id="cql0081-aggregates-only-make-sense-if-there-is-a-from-clause-name">CQL0081: aggregates only make sense if there is a FROM clause ‘name’</h3>
 <p>The indicated aggregate function was used in a select statement with no tables. For instance</p>
-<div class="sourceCode" id="cb370"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb370-1"><a href="#cb370-1"></a><span class="kw">select</span> <span class="fu">MAX</span>(<span class="dv">7</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb370"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb370-1"><a href="#cb370-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="fu">MAX</span>(<span class="dv">7</span>);</span></code></pre></div>
 <p>Doesn’t make any sense.</p>
 <hr />
 <h3 id="cql0082-argument-must-be-numeric-average">CQL0082: argument must be numeric ‘AVERAGE’</h3>
@@ -7902,13 +8034,13 @@ set x := y;</code></pre>
 <h3 id="cql0101-too-few-column-names-specified-in-common-table-expression-name">CQL0101: too few column names specified in common table expression ‘name’</h3>
 <p>In a <code>WITH</code> clause the indicated common table expression doesn’t include enough column names to capture the result of the <code>select</code> statement it is associated with.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb371"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb371-1"><a href="#cb371-1"></a><span class="kw">WITH</span> foo(a) <span class="kw">as</span> (<span class="kw">SELECT</span> <span class="dv">1</span> A, <span class="dv">2</span> B) <span class="op">..</span>.`</span></code></pre></div>
+<div class="sourceCode" id="cb371"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb371-1"><a href="#cb371-1" aria-hidden="true" tabindex="-1"></a><span class="kw">WITH</span> foo(a) <span class="kw">as</span> (<span class="kw">SELECT</span> <span class="dv">1</span> A, <span class="dv">2</span> B) <span class="op">..</span>.`</span></code></pre></div>
 <p>The select statement produces two columns the <code>foo</code> declaration specifies one.</p>
 <hr />
 <h3 id="cql0102-too-many-column-names-specified-in-common-table-expression-name">CQL0102: too many column names specified in common table expression ‘name’</h3>
 <p>In a <code>WITH</code> clause the indicated common table expression has more column names than the <code>select</code> expression it is associated with.</p>
 <p>e.g.</p>
-<div class="sourceCode" id="cb372"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb372-1"><a href="#cb372-1"></a><span class="kw">WITH</span> foo(a, b) <span class="kw">as</span> (<span class="kw">SELECT</span> <span class="dv">1</span>) <span class="op">..</span>. `</span></code></pre></div>
+<div class="sourceCode" id="cb372"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb372-1"><a href="#cb372-1" aria-hidden="true" tabindex="-1"></a><span class="kw">WITH</span> foo(a, b) <span class="kw">as</span> (<span class="kw">SELECT</span> <span class="dv">1</span>) <span class="op">..</span>. `</span></code></pre></div>
 <p>The select statement produces one column the <code>foo</code> declaration specifies two.</p>
 <hr />
 <h3 id="cql0103-duplicate-tableview-name-name">CQL0103: duplicate table/view name ‘name’</h3>
@@ -8144,27 +8276,27 @@ set x := y;</code></pre>
 <hr />
 <h3 id="cql0165-fetch-values-is-only-for-value-cursors-not-for-sqlite-cursors-cursor_name">CQL0165: fetch values is only for value cursors, not for sqlite cursors ‘cursor_name’</h3>
 <p>Cursors come in two flavors. There are “statement cursors” which are built from something like this:</p>
-<div class="sourceCode" id="cb373"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb373-1"><a href="#cb373-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo;</span>
-<span id="cb373-2"><a href="#cb373-2"></a>fetch C;</span>
-<span id="cb373-3"><a href="#cb373-3"></a><span class="co">-- or --</span></span>
-<span id="cb373-4"><a href="#cb373-4"></a>fetch C <span class="kw">into</span> a, b, c;</span></code></pre></div>
+<div class="sourceCode" id="cb373"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb373-1"><a href="#cb373-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo;</span>
+<span id="cb373-2"><a href="#cb373-2" aria-hidden="true" tabindex="-1"></a>fetch C;</span>
+<span id="cb373-3"><a href="#cb373-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- or --</span></span>
+<span id="cb373-4"><a href="#cb373-4" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">into</span> a, b, c;</span></code></pre></div>
 <p>That is, they come from a SQLite statement and you can fetch values from that statement. The second type comes from procedural values like this.</p>
-<div class="sourceCode" id="cb374"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb374-1"><a href="#cb374-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_table;</span>
-<span id="cb374-2"><a href="#cb374-2"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb374"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb374-1"><a href="#cb374-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_table;</span>
+<span id="cb374-2"><a href="#cb374-2" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>);</span></code></pre></div>
 <p>In the second example <code>C</code>’s data type will be the same as the columns in <code>my_table</code> and we will fetch its values from <code>1,2,3</code> – this version has no database backing at all, it’s just data.</p>
 <p>This error says that you declared the cursor in the first form (with a SQL statement) but then you tried to fetch it using the second form, the one for data. These forms don’t mix. If you need a value cursor for a row you can copy data from one cursor into another.</p>
 <hr />
 <h3 id="cql0166-count-of-columns-differs-from-count-of-values">CQL0166: count of columns differs from count of values</h3>
 <p>In a value cursor, declared something like this:</p>
-<div class="sourceCode" id="cb375"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb375-1"><a href="#cb375-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_table;</span>
-<span id="cb375-2"><a href="#cb375-2"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb375"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb375-1"><a href="#cb375-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_table;</span>
+<span id="cb375-2"><a href="#cb375-2" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>);</span></code></pre></div>
 <p>The type of the cursor ( in this case from <code>my_table</code>) requires a certain number of columns, but that doesn’t match the number that were provided in the values.</p>
 <p>To fix this you’ll need to add/remove values so that the type match.</p>
 <hr />
 <h3 id="cql0167-required-column-missing-in-fetch-statement-column_name">CQL0167: required column missing in FETCH statement ‘column_name’</h3>
 <p>In a value cursor, declared something like this:</p>
-<div class="sourceCode" id="cb376"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb376-1"><a href="#cb376-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_table;</span>
-<span id="cb376-2"><a href="#cb376-2"></a>fetch C(a,b,c) <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb376"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb376-1"><a href="#cb376-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> my_table;</span>
+<span id="cb376-2"><a href="#cb376-2" aria-hidden="true" tabindex="-1"></a>fetch C(a,b,c) <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>);</span></code></pre></div>
 <p>This error is saying that there is some other field in the table ‘d’ and it was not specified in the values. Nor was there a usable dummy data for that column that could be used. You need to provide a value for the missing column.</p>
 <hr />
 <h3 id="cql0168-theres-no-good-way-to-generate-dummy-blobs-not-supported-for-now">CQL0168: there’s no good way to generate dummy blobs; not supported for now</h3>
@@ -8224,7 +8356,7 @@ set x := y;</code></pre>
 <h3 id="cql0187-schema_upgrade_version-not-declared-or-doesnt-match-upgrade-version-n-for-proc-name">CQL0187: <span class="citation" data-cites="schema_upgrade_version">@schema_upgrade_version</span> not declared or doesn’t match upgrade version <code>N</code> for proc ‘name’</h3>
 <p>The named procedure was declared as a schema migration procedure in an <code>@create</code> or <code>@delete</code> annotation for schema version <code>N</code>. In order to correctly type check such a procedure it must be compiled in the context of schema version <code>N</code>. This restriction is required so that the tables and columns the procedure sees are the ones that existed in version <code>N</code> not the ones that exist in the most recent version as usual.</p>
 <p>To create this condition, the procedure must appear in a file that begins with the line:</p>
-<div class="sourceCode" id="cb377"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb377-1"><a href="#cb377-1"></a><span class="ot">@schema_upgrade_version &lt;N&gt;;</span></span></code></pre></div>
+<div class="sourceCode" id="cb377"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb377-1"><a href="#cb377-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@schema_upgrade_version &lt;N&gt;;</span></span></code></pre></div>
 <p>And this declaration must come before any <code>CREATE TABLE</code> statements. If there is no such declaration, or if it is for the wrong version, then this error will be generated.</p>
 <hr />
 <h3 id="cql0188-procedure-is-supposed-to-do-schema-migration-but-it-doesnt-have-any-dml-name">CQL0188: procedure is supposed to do schema migration but it doesn’t have any DML ‘name’</h3>
@@ -8275,8 +8407,8 @@ set x := y;</code></pre>
 <h3 id="cql0203-cursor-requires-a-procedure-that-returns-a-cursor-with-out-cursor_name">CQL0203: cursor requires a procedure that returns a cursor with OUT ‘cursor_name’</h3>
 <p>In the <code>DECLARE [cursor_name] CURSOR FETCH FROM CALL &lt;something&gt;</code> form, the code is trying to create the named cursor by calling a procedure that doesn’t actually produce a single row result set with the <code>OUT</code> statement. The procedure is valid (that would be a different error) so it’s likely that the wrong procedure is being called rather than being an outright typo. Or perhaps the procedure was changed such that it no longer produces a single row result set.</p>
 <p>This form is equivalent to:</p>
-<div class="sourceCode" id="cb378"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb378-1"><a href="#cb378-1"></a><span class="kw">DECLARE</span> [cursor_name] <span class="kw">LIKE</span> <span class="kw">procedure</span>;</span>
-<span id="cb378-2"><a href="#cb378-2"></a>FETCH [cursor_name] <span class="kw">FROM</span> <span class="kw">CALL</span> <span class="kw">procedure</span>(args);</span></code></pre></div>
+<div class="sourceCode" id="cb378"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb378-1"><a href="#cb378-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> [cursor_name] <span class="kw">LIKE</span> <span class="kw">procedure</span>;</span>
+<span id="cb378-2"><a href="#cb378-2" aria-hidden="true" tabindex="-1"></a>FETCH [cursor_name] <span class="kw">FROM</span> <span class="kw">CALL</span> <span class="kw">procedure</span>(args);</span></code></pre></div>
 <p>It’s the declaration that’s failing here, not the call.</p>
 <hr />
 <h3 id="cql0204-cursor-not-found-name">CQL0204: cursor not found ‘name’</h3>
@@ -8298,47 +8430,47 @@ set x := y;</code></pre>
 <h3 id="cql0207-proc-out-parameter-formal-cannot-be-fulfilled-by-non-variable-param_name">CQL0207: proc out parameter: formal cannot be fulfilled by non-variable ‘param_name’</h3>
 <p>In a procedure call, the indicated parameter of the procedure is an OUT or INOUT parameter but the call site doesn’t have a variable in that position in the argument list.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb379"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb379-1"><a href="#cb379-1"></a><span class="kw">declare</span> proc foo(<span class="kw">out</span> x <span class="dt">integer</span>);</span>
-<span id="cb379-2"><a href="#cb379-2"></a></span>
-<span id="cb379-3"><a href="#cb379-3"></a><span class="co">-- the constant 1 cannot be used in the out position when calling foo</span></span>
-<span id="cb379-4"><a href="#cb379-4"></a><span class="kw">call</span> foo(<span class="dv">1</span>); <span class="st">&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb379"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb379-1"><a href="#cb379-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> proc foo(<span class="kw">out</span> x <span class="dt">integer</span>);</span>
+<span id="cb379-2"><a href="#cb379-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb379-3"><a href="#cb379-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- the constant 1 cannot be used in the out position when calling foo</span></span>
+<span id="cb379-4"><a href="#cb379-4" aria-hidden="true" tabindex="-1"></a><span class="kw">call</span> foo(<span class="dv">1</span>); <span class="st">&#39;</span></span></code></pre></div>
 <hr />
 <h3 id="cql0208-available-for-re-use">CQL0208 available for re-use</h3>
 <hr />
 <h3 id="cql0209-proc-out-parameter-arg-must-be-an-exact-type-match-expected-expected_type-found-actual_type-param_name">CQL0209: proc out parameter: arg must be an exact type match (expected expected_type; found actual_type) ‘param_name’</h3>
 <p>In a procedure call, the indicated parameter is in an ‘out’ position, it is a viable local variable but it is not an exact type match for the parameter. The type of variable used to capture out parameters must be an exact match.</p>
-<div class="sourceCode" id="cb380"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb380-1"><a href="#cb380-1"></a><span class="kw">declare</span> proc foo(<span class="kw">out</span> x <span class="dt">integer</span>);</span>
-<span id="cb380-2"><a href="#cb380-2"></a></span>
-<span id="cb380-3"><a href="#cb380-3"></a><span class="kw">create</span> proc bar(<span class="kw">out</span> y <span class="dt">real</span>)</span>
-<span id="cb380-4"><a href="#cb380-4"></a><span class="cf">begin</span></span>
-<span id="cb380-5"><a href="#cb380-5"></a>  <span class="kw">call</span> foo(y); <span class="co">-- y is a real variable, not an integer.</span></span>
-<span id="cb380-6"><a href="#cb380-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb380"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb380-1"><a href="#cb380-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> proc foo(<span class="kw">out</span> x <span class="dt">integer</span>);</span>
+<span id="cb380-2"><a href="#cb380-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb380-3"><a href="#cb380-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc bar(<span class="kw">out</span> y <span class="dt">real</span>)</span>
+<span id="cb380-4"><a href="#cb380-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb380-5"><a href="#cb380-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> foo(y); <span class="co">-- y is a real variable, not an integer.</span></span>
+<span id="cb380-6"><a href="#cb380-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The above produces:</p>
-<div class="sourceCode" id="cb381"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb381-1"><a href="#cb381-1"></a>CQL0209: proc <span class="kw">out</span> parameter: arg must be an exact <span class="kw">type</span> match</span>
-<span id="cb381-2"><a href="#cb381-2"></a>(expected <span class="dt">integer</span>; found <span class="dt">real</span>) <span class="st">&#39;y&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb381"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb381-1"><a href="#cb381-1" aria-hidden="true" tabindex="-1"></a>CQL0209: proc <span class="kw">out</span> parameter: arg must be an exact <span class="kw">type</span> match</span>
+<span id="cb381-2"><a href="#cb381-2" aria-hidden="true" tabindex="-1"></a>(expected <span class="dt">integer</span>; found <span class="dt">real</span>) <span class="st">&#39;y&#39;</span></span></code></pre></div>
 <hr />
 <h3 id="cql0210-proc-out-parameter-arg-must-be-an-exact-type-match-even-nullability">CQL0210: proc out parameter: arg must be an exact type match (even nullability)</h3>
 <p>(expected expected_type; found actual_type) ‘variable_name’</p>
 <p>In a procedure call, the indicated parameter is in an ‘out’ position, it is a viable local variable of the correct type but the nullability does not match. The type of variable used to capture out parameters must be an exact match.</p>
-<div class="sourceCode" id="cb382"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb382-1"><a href="#cb382-1"></a><span class="kw">declare</span> proc foo(<span class="kw">out</span> x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
-<span id="cb382-2"><a href="#cb382-2"></a></span>
-<span id="cb382-3"><a href="#cb382-3"></a><span class="kw">create</span> proc bar(<span class="kw">out</span> y <span class="dt">integer</span>)</span>
-<span id="cb382-4"><a href="#cb382-4"></a><span class="cf">begin</span></span>
-<span id="cb382-5"><a href="#cb382-5"></a>  <span class="kw">call</span> foo(y); <span class="co">-- y is nullable but foo is expecting not null.</span></span>
-<span id="cb382-6"><a href="#cb382-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb382"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb382-1"><a href="#cb382-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> proc foo(<span class="kw">out</span> x <span class="dt">integer</span> <span class="kw">not</span> <span class="kw">null</span>);</span>
+<span id="cb382-2"><a href="#cb382-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb382-3"><a href="#cb382-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc bar(<span class="kw">out</span> y <span class="dt">integer</span>)</span>
+<span id="cb382-4"><a href="#cb382-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb382-5"><a href="#cb382-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">call</span> foo(y); <span class="co">-- y is nullable but foo is expecting not null.</span></span>
+<span id="cb382-6"><a href="#cb382-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>The above produces:</p>
-<div class="sourceCode" id="cb383"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb383-1"><a href="#cb383-1"></a>CQL0210: proc <span class="kw">out</span> parameter: arg must be an exact <span class="kw">type</span> match (even nullability)</span>
-<span id="cb383-2"><a href="#cb383-2"></a>(expected <span class="dt">integer</span> notnull; found <span class="dt">integer</span>) <span class="st">&#39;y&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb383"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb383-1"><a href="#cb383-1" aria-hidden="true" tabindex="-1"></a>CQL0210: proc <span class="kw">out</span> parameter: arg must be an exact <span class="kw">type</span> match (even nullability)</span>
+<span id="cb383-2"><a href="#cb383-2" aria-hidden="true" tabindex="-1"></a>(expected <span class="dt">integer</span> notnull; found <span class="dt">integer</span>) <span class="st">&#39;y&#39;</span></span></code></pre></div>
 <hr />
 <h3 id="cql0211-last-formal-arg-of-procedure-is-not-an-out-arg-cannot-use-proc-as-a-function-name">CQL0211: last formal arg of procedure is not an out arg, cannot use proc as a function ‘name’</h3>
 <p>In a function call, the target of the function call was a procedure, procedures can be used like functions but their last parameter must be marked <code>out</code>. That will be the return value. In this case the last argument was not marked as <code>out</code> and so the call is invalid.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb384"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb384-1"><a href="#cb384-1"></a><span class="kw">declare</span> proc foo(x <span class="dt">integer</span>);</span>
-<span id="cb384-2"><a href="#cb384-2"></a></span>
-<span id="cb384-3"><a href="#cb384-3"></a><span class="kw">create</span> proc bar(<span class="kw">out</span> y <span class="dt">integer</span>)</span>
-<span id="cb384-4"><a href="#cb384-4"></a><span class="cf">begin</span></span>
-<span id="cb384-5"><a href="#cb384-5"></a>  <span class="kw">set</span> y <span class="op">:=</span> foo(); <span class="co">-- foo does not have an out argument at the end</span></span>
-<span id="cb384-6"><a href="#cb384-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb384"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb384-1"><a href="#cb384-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> proc foo(x <span class="dt">integer</span>);</span>
+<span id="cb384-2"><a href="#cb384-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb384-3"><a href="#cb384-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc bar(<span class="kw">out</span> y <span class="dt">integer</span>)</span>
+<span id="cb384-4"><a href="#cb384-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb384-5"><a href="#cb384-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> y <span class="op">:=</span> foo(); <span class="co">-- foo does not have an out argument at the end</span></span>
+<span id="cb384-6"><a href="#cb384-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0212-too-few-arguments-provided-to-procedure-name">CQL0212: too few arguments provided to procedure ‘name’</h3>
 <p>In a procedure call to the named procedure, not enough arguments were provided to make the call. One or more arguments may have been omitted or perhaps the called procedure has changed such that it now requires more arguments.</p>
@@ -8349,28 +8481,28 @@ set x := y;</code></pre>
 <h3 id="cql0214-procedures-with-results-can-only-be-called-using-a-cursor-in-global-context-name">CQL0214: procedures with results can only be called using a cursor in global context ‘name’</h3>
 <p>The named procedure results a result set, either with the <code>SELECT</code> statement or the <code>OUT</code> statement. However it is being called from outside of any procedure. Because of this, its result cannot then be returned anywhere. As a result, at the global level the result must be capture with a cursor.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb385"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb385-1"><a href="#cb385-1"></a><span class="kw">create</span> proc foo()</span>
-<span id="cb385-2"><a href="#cb385-2"></a><span class="cf">begin</span></span>
-<span id="cb385-3"><a href="#cb385-3"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
-<span id="cb385-4"><a href="#cb385-4"></a><span class="cf">end</span>;</span>
-<span id="cb385-5"><a href="#cb385-5"></a></span>
-<span id="cb385-6"><a href="#cb385-6"></a><span class="kw">call</span> foo();  <span class="co">-- this is not valid</span></span>
-<span id="cb385-7"><a href="#cb385-7"></a><span class="kw">declare</span> <span class="kw">cursor</span> C <span class="cf">for</span> <span class="kw">call</span> foo();  <span class="co">-- C captures the result of foo, this is ok.</span></span></code></pre></div>
+<div class="sourceCode" id="cb385"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb385-1"><a href="#cb385-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo()</span>
+<span id="cb385-2"><a href="#cb385-2" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb385-3"><a href="#cb385-3" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
+<span id="cb385-4"><a href="#cb385-4" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span>
+<span id="cb385-5"><a href="#cb385-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb385-6"><a href="#cb385-6" aria-hidden="true" tabindex="-1"></a><span class="kw">call</span> foo();  <span class="co">-- this is not valid</span></span>
+<span id="cb385-7"><a href="#cb385-7" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">cursor</span> C <span class="cf">for</span> <span class="kw">call</span> foo();  <span class="co">-- C captures the result of foo, this is ok.</span></span></code></pre></div>
 <hr />
 <h3 id="cql0215-value-cursors-are-not-used-with-fetch-c-or-fetch-c-into-cursor_name">CQL0215: value cursors are not used with FETCH C, or FETCH C INTO ‘cursor_name’</h3>
 <p>In a <code>FETCH</code> statement of the form <code>FETCH [cursor]</code> or <code>FETCH [cursor] INTO</code> the named cursor is a value cursor. These forms of the <code>FETCH</code> statement apply only to statement cursors.</p>
 <p>Example:good</p>
-<div class="sourceCode" id="cb386"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb386-1"><a href="#cb386-1"></a><span class="co">-- value cursor shaped like a table</span></span>
-<span id="cb386-2"><a href="#cb386-2"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
-<span id="cb386-3"><a href="#cb386-3"></a><span class="co">--ok, C is fetched from the select results</span></span>
-<span id="cb386-4"><a href="#cb386-4"></a>fetch C;</span></code></pre></div>
+<div class="sourceCode" id="cb386"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb386-1"><a href="#cb386-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- value cursor shaped like a table</span></span>
+<span id="cb386-2"><a href="#cb386-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
+<span id="cb386-3"><a href="#cb386-3" aria-hidden="true" tabindex="-1"></a><span class="co">--ok, C is fetched from the select results</span></span>
+<span id="cb386-4"><a href="#cb386-4" aria-hidden="true" tabindex="-1"></a>fetch C;</span></code></pre></div>
 <p>Example: bad</p>
-<div class="sourceCode" id="cb387"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb387-1"><a href="#cb387-1"></a><span class="co">-- value cursor shaped like a table</span></span>
-<span id="cb387-2"><a href="#cb387-2"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> bar;</span>
-<span id="cb387-3"><a href="#cb387-3"></a><span class="co">-- invalid, there is no source for fetching a value cursor</span></span>
-<span id="cb387-4"><a href="#cb387-4"></a>fetch C;</span>
-<span id="cb387-5"><a href="#cb387-5"></a><span class="co">-- ok assuming bar is made up of 3 integers</span></span>
-<span id="cb387-6"><a href="#cb387-6"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb387"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb387-1"><a href="#cb387-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- value cursor shaped like a table</span></span>
+<span id="cb387-2"><a href="#cb387-2" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="kw">like</span> bar;</span>
+<span id="cb387-3"><a href="#cb387-3" aria-hidden="true" tabindex="-1"></a><span class="co">-- invalid, there is no source for fetching a value cursor</span></span>
+<span id="cb387-4"><a href="#cb387-4" aria-hidden="true" tabindex="-1"></a>fetch C;</span>
+<span id="cb387-5"><a href="#cb387-5" aria-hidden="true" tabindex="-1"></a><span class="co">-- ok assuming bar is made up of 3 integers</span></span>
+<span id="cb387-6"><a href="#cb387-6" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">from</span> <span class="kw">values</span>(<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>);</span></code></pre></div>
 <ul>
 <li>statement cursors come from SQL statements and can be fetched</li>
 <li>value cursors are of a prescribed shape and can only be loaded from value sources</li>
@@ -8401,19 +8533,19 @@ set x := y;</code></pre>
 <h3 id="cql0223-the-cursor-was-not-fetched-with-the-auto-fetch-syntax-fetch-cursor-cursor_name">CQL0223: the cursor was not fetched with the auto-fetch syntax ‘fetch [cursor]’ ‘cursor_name’</h3>
 <p>The statement form <code>OUT [cursor_name]</code> makes a procedure that returns a single row result set that corresponds to the current value of the cursor. If the cursor never held values directly then there is nothing to return.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb388"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb388-1"><a href="#cb388-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
-<span id="cb388-2"><a href="#cb388-2"></a><span class="kw">out</span> C;  <span class="co">-- error C was never fetched</span></span>
-<span id="cb388-3"><a href="#cb388-3"></a></span>
-<span id="cb388-4"><a href="#cb388-4"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
-<span id="cb388-5"><a href="#cb388-5"></a>fetch C <span class="kw">into</span> x, y, z;</span>
-<span id="cb388-6"><a href="#cb388-6"></a><span class="co">-- error C was used to load x, y, z so it&#39;s not holding any data</span></span>
-<span id="cb388-7"><a href="#cb388-7"></a><span class="kw">out</span> C;</span>
-<span id="cb388-8"><a href="#cb388-8"></a></span>
-<span id="cb388-9"><a href="#cb388-9"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
-<span id="cb388-10"><a href="#cb388-10"></a><span class="co">-- create storage in C to hold bar columns (e.g. C.x, C,y, C.z)</span></span>
-<span id="cb388-11"><a href="#cb388-11"></a>fetch C;</span>
-<span id="cb388-12"><a href="#cb388-12"></a><span class="co">-- ok, C holds data</span></span>
-<span id="cb388-13"><a href="#cb388-13"></a><span class="kw">out</span> C;</span></code></pre></div>
+<div class="sourceCode" id="cb388"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb388-1"><a href="#cb388-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
+<span id="cb388-2"><a href="#cb388-2" aria-hidden="true" tabindex="-1"></a><span class="kw">out</span> C;  <span class="co">-- error C was never fetched</span></span>
+<span id="cb388-3"><a href="#cb388-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb388-4"><a href="#cb388-4" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
+<span id="cb388-5"><a href="#cb388-5" aria-hidden="true" tabindex="-1"></a>fetch C <span class="kw">into</span> x, y, z;</span>
+<span id="cb388-6"><a href="#cb388-6" aria-hidden="true" tabindex="-1"></a><span class="co">-- error C was used to load x, y, z so it&#39;s not holding any data</span></span>
+<span id="cb388-7"><a href="#cb388-7" aria-hidden="true" tabindex="-1"></a><span class="kw">out</span> C;</span>
+<span id="cb388-8"><a href="#cb388-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb388-9"><a href="#cb388-9" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> bar;</span>
+<span id="cb388-10"><a href="#cb388-10" aria-hidden="true" tabindex="-1"></a><span class="co">-- create storage in C to hold bar columns (e.g. C.x, C,y, C.z)</span></span>
+<span id="cb388-11"><a href="#cb388-11" aria-hidden="true" tabindex="-1"></a>fetch C;</span>
+<span id="cb388-12"><a href="#cb388-12" aria-hidden="true" tabindex="-1"></a><span class="co">-- ok, C holds data</span></span>
+<span id="cb388-13"><a href="#cb388-13" aria-hidden="true" tabindex="-1"></a><span class="kw">out</span> C;</span></code></pre></div>
 <hr />
 <h3 id="cql0224-available-for-re-use">CQL0224 available for re-use</h3>
 <hr />
@@ -8421,23 +8553,23 @@ set x := y;</code></pre>
 <p>The <code>@previous_schema</code> directive says that any schema that follows should be compared against what was declared before this point. This gives CQL the opportunity to detect changes in schema that are not supportable.</p>
 <p>The previous schema directive must be outside of any stored procedure.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb389"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb389-1"><a href="#cb389-1"></a><span class="ot">@previous_schema;  -- ok here</span></span>
-<span id="cb389-2"><a href="#cb389-2"></a></span>
-<span id="cb389-3"><a href="#cb389-3"></a><span class="kw">create</span> proc foo()</span>
-<span id="cb389-4"><a href="#cb389-4"></a><span class="cf">begin</span></span>
-<span id="cb389-5"><a href="#cb389-5"></a>  @previous <span class="kw">schema</span>; <span class="co">-- nope</span></span>
-<span id="cb389-6"><a href="#cb389-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb389"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb389-1"><a href="#cb389-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@previous_schema;  -- ok here</span></span>
+<span id="cb389-2"><a href="#cb389-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb389-3"><a href="#cb389-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo()</span>
+<span id="cb389-4"><a href="#cb389-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb389-5"><a href="#cb389-5" aria-hidden="true" tabindex="-1"></a>  @previous <span class="kw">schema</span>; <span class="co">-- nope</span></span>
+<span id="cb389-6"><a href="#cb389-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0226-schema-upgrade-declaration-must-be-outside-of-any-proc">CQL0226: schema upgrade declaration must be outside of any proc</h3>
 <p>The <code>@schema_upgrade_script</code> directive tells CQL that the code that follows is intended to upgrade schema from one version to another. This kind of script is normally generated by the <code>--rt schema_upgrade</code> option discussed elsewhere. When processing such a script, a different set of rules are used for DDL analysis. In particular, it’s normal to declare the final versions of tables but have DDL that creates the original version and more DDL to upgrade them from wherever they are to the final version (as declared). Ordinarily these duplicate definitions would produce errors. This directive allows those duplications.</p>
 <p>This error is reporting that the directive happened inside of a stored procedure, this is not allowed.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb390"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb390-1"><a href="#cb390-1"></a><span class="ot">@schema_upgrade_script;  -- ok here</span></span>
-<span id="cb390-2"><a href="#cb390-2"></a></span>
-<span id="cb390-3"><a href="#cb390-3"></a><span class="kw">create</span> proc foo()</span>
-<span id="cb390-4"><a href="#cb390-4"></a><span class="cf">begin</span></span>
-<span id="cb390-5"><a href="#cb390-5"></a>  @schema_upgrade_script; <span class="co">-- nope</span></span>
-<span id="cb390-6"><a href="#cb390-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb390"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb390-1"><a href="#cb390-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@schema_upgrade_script;  -- ok here</span></span>
+<span id="cb390-2"><a href="#cb390-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb390-3"><a href="#cb390-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo()</span>
+<span id="cb390-4"><a href="#cb390-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb390-5"><a href="#cb390-5" aria-hidden="true" tabindex="-1"></a>  @schema_upgrade_script; <span class="co">-- nope</span></span>
+<span id="cb390-6"><a href="#cb390-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0227-schema-upgrade-declaration-must-come-before-any-tables-are-declared">CQL0227: schema upgrade declaration must come before any tables are declared</h3>
 <p>The <code>@schema_upgrade_script</code> directive tells CQL that the code that follows is intended to upgrade schema from one version to another. This kind of script is normally generated by the <code>--rt schema_upgrade</code> option discussed elsewhere. When processing such a script, a different set of rules are used for DDL analysis. In particular, it’s normal to declare the final versions of tables but have DDL that creates the original version and more DDL to upgrade them from wherever they are to the final version (as declared). Ordinarily these duplicate definitions would produce errors. This directive allows those duplications.</p>
@@ -8490,11 +8622,11 @@ set x := y;</code></pre>
 <h3 id="cql0241-concat-may-only-appear-in-the-context-of-sql-statement">CQL0241: CONCAT may only appear in the context of SQL statement</h3>
 <p>The SQLite <code>||</code> operator has complex string conversion rules making it impossible to faithfully emulate. Since there is no helper function for doing concatenations, CQL choses to support this operator only in contexts where it will be evaluated by SQLite. That is, inside of some SQL statement.</p>
 <p>Examples:</p>
-<div class="sourceCode" id="cb391"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb391-1"><a href="#cb391-1"></a><span class="kw">declare</span> X text;</span>
-<span id="cb391-2"><a href="#cb391-2"></a></span>
-<span id="cb391-3"><a href="#cb391-3"></a><span class="kw">set</span> X <span class="op">:=</span> <span class="st">&#39;foo&#39;</span> <span class="op">||</span> <span class="st">&#39;bar&#39;</span>;   <span class="co">-- error</span></span>
-<span id="cb391-4"><a href="#cb391-4"></a></span>
-<span id="cb391-5"><a href="#cb391-5"></a><span class="kw">set</span> X <span class="op">:=</span> (<span class="kw">select</span> <span class="st">&#39;foo&#39;</span> <span class="op">||</span> <span class="st">&#39;bar&#39;</span>);  <span class="co">-- ok</span></span></code></pre></div>
+<div class="sourceCode" id="cb391"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb391-1"><a href="#cb391-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> X text;</span>
+<span id="cb391-2"><a href="#cb391-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb391-3"><a href="#cb391-3" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> X <span class="op">:=</span> <span class="st">&#39;foo&#39;</span> <span class="op">||</span> <span class="st">&#39;bar&#39;</span>;   <span class="co">-- error</span></span>
+<span id="cb391-4"><a href="#cb391-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb391-5"><a href="#cb391-5" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> X <span class="op">:=</span> (<span class="kw">select</span> <span class="st">&#39;foo&#39;</span> <span class="op">||</span> <span class="st">&#39;bar&#39;</span>);  <span class="co">-- ok</span></span></code></pre></div>
 <p>If concatenation is required in some non-sql context, use the <code>(select ..)</code> expression form to let SQLite do the evaluation.</p>
 <hr />
 <h3 id="cql0242-lossy-conversion-from-type-type">CQL0242: lossy conversion from type ‘type’</h3>
@@ -8523,12 +8655,12 @@ set x := y;</code></pre>
 <hr />
 <h3 id="cql0250-table-valued-function-not-declared-function_name">CQL0250: table-valued function not declared ‘function_name’</h3>
 <p>In a select statement, there is a reference to the indicated table-valued-function. For instance:</p>
-<div class="sourceCode" id="cb392"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb392-1"><a href="#cb392-1"></a><span class="co">-- the above error happens if my_function has not been declared</span></span>
-<span id="cb392-2"><a href="#cb392-2"></a><span class="co">-- as a table valued function</span></span>
-<span id="cb392-3"><a href="#cb392-3"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_function(<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb392"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb392-1"><a href="#cb392-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- the above error happens if my_function has not been declared</span></span>
+<span id="cb392-2"><a href="#cb392-2" aria-hidden="true" tabindex="-1"></a><span class="co">-- as a table valued function</span></span>
+<span id="cb392-3"><a href="#cb392-3" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> my_function(<span class="dv">1</span>,<span class="dv">2</span>,<span class="dv">3</span>);</span></code></pre></div>
 <p>However , <code>my_function</code> has not been declared as a function at all. A correct declaration might look like this:</p>
-<div class="sourceCode" id="cb393"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb393-1"><a href="#cb393-1"></a><span class="kw">declare</span> <span class="kw">select</span> <span class="kw">function</span> my_function(a <span class="dt">int</span>, b <span class="dt">int</span>, c <span class="dt">int</span>)</span>
-<span id="cb393-2"><a href="#cb393-2"></a>                                   (x <span class="dt">int</span>, y text);</span></code></pre></div>
+<div class="sourceCode" id="cb393"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb393-1"><a href="#cb393-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> <span class="kw">select</span> <span class="kw">function</span> my_function(a <span class="dt">int</span>, b <span class="dt">int</span>, c <span class="dt">int</span>)</span>
+<span id="cb393-2"><a href="#cb393-2" aria-hidden="true" tabindex="-1"></a>                                   (x <span class="dt">int</span>, y text);</span></code></pre></div>
 <p>Either there is a typo in the name or the declaration is missing, or both…</p>
 <hr />
 <h3 id="cql0251-fragment-must-end-with-exactly-select-from-cte">CQL0251: fragment must end with exactly ‘SELECT * FROM CTE’</h3>
@@ -8556,39 +8688,39 @@ set x := y;</code></pre>
 <h3 id="cql0258-extension-fragment-must-add-exactly-one-cte-found-extra-named-name">CQL0258: extension fragment must add exactly one CTE; found extra named ‘name’</h3>
 <p>The extension fragment includes more than one additional CTE, it must have exactly one.</p>
 <p>In the following example, <code>ext2</code> is not valid, you have to stop at <code>ext1</code></p>
-<div class="sourceCode" id="cb394"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb394-1"><a href="#cb394-1"></a><span class="co">-- example bad extension fragment</span></span>
-<span id="cb394-2"><a href="#cb394-2"></a><span class="ot">@attribute(cql:extension_fragment=core)</span></span>
-<span id="cb394-3"><a href="#cb394-3"></a><span class="kw">create</span> proc test_bad_extension_fragment_three()</span>
-<span id="cb394-4"><a href="#cb394-4"></a><span class="cf">begin</span></span>
-<span id="cb394-5"><a href="#cb394-5"></a>  <span class="kw">with</span></span>
-<span id="cb394-6"><a href="#cb394-6"></a>    core(x,y,z) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span>,nullable(<span class="ot">&quot;a&quot;</span>),nullable(3L)),</span>
-<span id="cb394-7"><a href="#cb394-7"></a>    ext1(x,y,z,a) <span class="kw">as</span> (<span class="kw">select</span> core.<span class="op">*</span>, extra1.<span class="op">*</span> <span class="kw">from</span> core <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> extra1),</span>
-<span id="cb394-8"><a href="#cb394-8"></a>    ext2(x,y,z,b) <span class="kw">as</span> (<span class="kw">select</span> core.<span class="op">*</span>, extra2.<span class="op">*</span> <span class="kw">from</span> core <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> extra2)</span>
-<span id="cb394-9"><a href="#cb394-9"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> ext2;</span>
-<span id="cb394-10"><a href="#cb394-10"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb394"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb394-1"><a href="#cb394-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- example bad extension fragment</span></span>
+<span id="cb394-2"><a href="#cb394-2" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:extension_fragment=core)</span></span>
+<span id="cb394-3"><a href="#cb394-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc test_bad_extension_fragment_three()</span>
+<span id="cb394-4"><a href="#cb394-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb394-5"><a href="#cb394-5" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span></span>
+<span id="cb394-6"><a href="#cb394-6" aria-hidden="true" tabindex="-1"></a>    core(x,y,z) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span>,nullable(<span class="ot">&quot;a&quot;</span>),nullable(3L)),</span>
+<span id="cb394-7"><a href="#cb394-7" aria-hidden="true" tabindex="-1"></a>    ext1(x,y,z,a) <span class="kw">as</span> (<span class="kw">select</span> core.<span class="op">*</span>, extra1.<span class="op">*</span> <span class="kw">from</span> core <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> extra1),</span>
+<span id="cb394-8"><a href="#cb394-8" aria-hidden="true" tabindex="-1"></a>    ext2(x,y,z,b) <span class="kw">as</span> (<span class="kw">select</span> core.<span class="op">*</span>, extra2.<span class="op">*</span> <span class="kw">from</span> core <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> extra2)</span>
+<span id="cb394-9"><a href="#cb394-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> ext2;</span>
+<span id="cb394-10"><a href="#cb394-10" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0259-extension-fragment-cte-must-select-t.-from-base-cte">CQL0259: extension fragment CTE must select T.* from base CTE</h3>
 <p>For the select expression in extension fragment, it must include all columns from the base table. This error indicates the select expression doesn’t select from the base table. It should look like this</p>
-<div class="sourceCode" id="cb395"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb395-1"><a href="#cb395-1"></a><span class="kw">select</span> core.<span class="op">*</span>, <span class="op">..</span>. <span class="kw">from</span> core</span></code></pre></div>
+<div class="sourceCode" id="cb395"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb395-1"><a href="#cb395-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> core.<span class="op">*</span>, <span class="op">..</span>. <span class="kw">from</span> core</span></code></pre></div>
 <p>Here core is the name of its base table.</p>
 <hr />
 <h3 id="cql0260-extension-fragment-cte-must-be-a-simple-left-outer-join-from-table_name">CQL0260: extension fragment CTE must be a simple left outer join from ‘table_name’</h3>
 <p>Extension fragments may add columns to the result, to do this without lose any rows you must always left outer join to the new data that you with to include. There is a specific prescription for this. It has to look like this:</p>
-<div class="sourceCode" id="cb396"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb396-1"><a href="#cb396-1"></a><span class="ot">@attribute(cql:extension_fragment=core)</span></span>
-<span id="cb396-2"><a href="#cb396-2"></a><span class="kw">create</span> proc an_extension()</span>
-<span id="cb396-3"><a href="#cb396-3"></a><span class="cf">begin</span></span>
-<span id="cb396-4"><a href="#cb396-4"></a>  <span class="kw">with</span></span>
-<span id="cb396-5"><a href="#cb396-5"></a>    core(x,y,z) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span>,nullable(<span class="ot">&quot;a&quot;</span>),nullable(3L)),</span>
-<span id="cb396-6"><a href="#cb396-6"></a>    ext1(x,y,z,a) <span class="kw">as</span> (<span class="kw">select</span> core.<span class="op">*</span>, extra_column <span class="kw">from</span> core <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> extra_stuff),</span>
-<span id="cb396-7"><a href="#cb396-7"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> ext1;</span>
-<span id="cb396-8"><a href="#cb396-8"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb396"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb396-1"><a href="#cb396-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:extension_fragment=core)</span></span>
+<span id="cb396-2"><a href="#cb396-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc an_extension()</span>
+<span id="cb396-3"><a href="#cb396-3" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb396-4"><a href="#cb396-4" aria-hidden="true" tabindex="-1"></a>  <span class="kw">with</span></span>
+<span id="cb396-5"><a href="#cb396-5" aria-hidden="true" tabindex="-1"></a>    core(x,y,z) <span class="kw">as</span> (<span class="kw">select</span> <span class="dv">1</span>,nullable(<span class="ot">&quot;a&quot;</span>),nullable(3L)),</span>
+<span id="cb396-6"><a href="#cb396-6" aria-hidden="true" tabindex="-1"></a>    ext1(x,y,z,a) <span class="kw">as</span> (<span class="kw">select</span> core.<span class="op">*</span>, extra_column <span class="kw">from</span> core <span class="kw">left</span> <span class="kw">outer</span> <span class="kw">join</span> extra_stuff),</span>
+<span id="cb396-7"><a href="#cb396-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> ext1;</span>
+<span id="cb396-8"><a href="#cb396-8" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <p>Here extension <code>ext1</code> is adding <code>extra_column</code> which came from <code>extra_stuff</code>. There could have been any desired join condition or indeed any join expression at all but it has to begin with <code>from core left outer join</code> so that all the core columns will be present and now rows can be removed.</p>
 <hr />
 <h3 id="cql0261-the-cursor-did-not-originate-from-a-sqlite-statement-it-only-has-values-cursor_name">CQL0261: the cursor did not originate from a SQLite statement, it only has values ‘cursor_name’</h3>
 <p>The form:</p>
-<div class="sourceCode" id="cb397"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb397-1"><a href="#cb397-1"></a>  <span class="kw">SET</span> [name] <span class="kw">FROM</span> <span class="kw">CURSOR</span> [cursor_name]</span></code></pre></div>
+<div class="sourceCode" id="cb397"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb397-1"><a href="#cb397-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">SET</span> [name] <span class="kw">FROM</span> <span class="kw">CURSOR</span> [cursor_name]</span></code></pre></div>
 <p>Is used to wrap a cursor in an object so that it can be returned for forwarded. This is the so-called “boxing” operation on the cursor. The object can then be “unboxed” later to make a cursor again. However the point of this is to keep reading forward on the cursor perhaps in another procedure. You can only read forward on a cursor that has an associated SQLite statement. That is the cursor was created with something like this</p>
-<div class="sourceCode" id="cb398"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb398-1"><a href="#cb398-1"></a>  <span class="kw">DECLARE</span> [name] <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="op">..</span>. | <span class="kw">CALL</span> <span class="op">..</span>.</span></code></pre></div>
+<div class="sourceCode" id="cb398"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb398-1"><a href="#cb398-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">DECLARE</span> [name] <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">SELECT</span> <span class="op">..</span>. | <span class="kw">CALL</span> <span class="op">..</span>.</span></code></pre></div>
 <p>If the cursor isn’t of this form it’s just values, you can’t move it forward and so “boxing” it is of no value. Hence not allowed. You can return the cursor values with <code>OUT</code> instead.</p>
 <hr />
 <h3 id="cql0262-like-arguments-used-on-a-procedure-with-no-arguments-procedure_name">CQL0262: LIKE … ARGUMENTS used on a procedure with no arguments ‘procedure_name’</h3>
@@ -8597,9 +8729,9 @@ set x := y;</code></pre>
 <hr />
 <h3 id="cql0263-non-ansi-joins-are-forbidden-if-strict-join-mode-is-enabled.">CQL0263: non-ANSI joins are forbidden if strict join mode is enabled.</h3>
 <p>You can enable strict enforcement of joins to avoid the form</p>
-<div class="sourceCode" id="cb399"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb399-1"><a href="#cb399-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> A, B;</span></code></pre></div>
+<div class="sourceCode" id="cb399"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb399-1"><a href="#cb399-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> A, B;</span></code></pre></div>
 <p>which sometimes confuses people (the above is exactly the same as</p>
-<div class="sourceCode" id="cb400"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb400-1"><a href="#cb400-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> A <span class="kw">inner</span> <span class="kw">join</span> B <span class="kw">on</span> <span class="dv">1</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb400"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb400-1"><a href="#cb400-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> A <span class="kw">inner</span> <span class="kw">join</span> B <span class="kw">on</span> <span class="dv">1</span>;</span></code></pre></div>
 <p>Usually there are constraints on the join also in the WHERE clause but there don’t have to be.</p>
 <p><code>@enforce_strict join</code> turns on this mode.</p>
 <hr />
@@ -8621,63 +8753,63 @@ set x := y;</code></pre>
 <h3 id="cql0269-at-least-part-of-this-unique-key-is-redundant-with-previous-unique-keys">CQL0269: at least part of this unique key is redundant with previous unique keys</h3>
 <p>The new unique key must have at least one column that is not in a previous key AND it must not have all the columns from any previous key.</p>
 <p>e.g:</p>
-<div class="sourceCode" id="cb401"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb401-1"><a href="#cb401-1"></a><span class="kw">create</span> <span class="kw">table</span> t1 (</span>
-<span id="cb401-2"><a href="#cb401-2"></a>  a <span class="dt">int</span>,</span>
-<span id="cb401-3"><a href="#cb401-3"></a>  b <span class="dt">long</span>,</span>
-<span id="cb401-4"><a href="#cb401-4"></a>  c text,</span>
-<span id="cb401-5"><a href="#cb401-5"></a>  d <span class="dt">real</span>,</span>
-<span id="cb401-6"><a href="#cb401-6"></a>  <span class="kw">UNIQUE</span> (a, b),</span>
-<span id="cb401-7"><a href="#cb401-7"></a>  <span class="kw">UNIQUE</span> (a, b, c), <span class="co">-- INVALID  (a, b) is already unique key</span></span>
-<span id="cb401-8"><a href="#cb401-8"></a>  <span class="kw">UNIQUE</span> (b, a), <span class="co">-- INVALID (b, a) is the same as (a, b)</span></span>
-<span id="cb401-9"><a href="#cb401-9"></a>  <span class="kw">UNIQUE</span> (c, d, b, a), <span class="co">-- INVALID subset (b, a) is already unique key</span></span>
-<span id="cb401-10"><a href="#cb401-10"></a>  <span class="kw">UNIQUE</span> (a), <span class="co">-- INVALID a is part of (a, b) key</span></span>
-<span id="cb401-11"><a href="#cb401-11"></a>  <span class="kw">UNIQUE</span> (a, c), <span class="co">-- VALID</span></span>
-<span id="cb401-12"><a href="#cb401-12"></a>  <span class="kw">UNIQUE</span> (d), <span class="co">-- VALID</span></span>
-<span id="cb401-13"><a href="#cb401-13"></a>  <span class="kw">UNIQUE</span> (b, d) <span class="co">-- VALID</span></span>
-<span id="cb401-14"><a href="#cb401-14"></a>);</span></code></pre></div>
+<div class="sourceCode" id="cb401"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb401-1"><a href="#cb401-1" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1 (</span>
+<span id="cb401-2"><a href="#cb401-2" aria-hidden="true" tabindex="-1"></a>  a <span class="dt">int</span>,</span>
+<span id="cb401-3"><a href="#cb401-3" aria-hidden="true" tabindex="-1"></a>  b <span class="dt">long</span>,</span>
+<span id="cb401-4"><a href="#cb401-4" aria-hidden="true" tabindex="-1"></a>  c text,</span>
+<span id="cb401-5"><a href="#cb401-5" aria-hidden="true" tabindex="-1"></a>  d <span class="dt">real</span>,</span>
+<span id="cb401-6"><a href="#cb401-6" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (a, b),</span>
+<span id="cb401-7"><a href="#cb401-7" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (a, b, c), <span class="co">-- INVALID  (a, b) is already unique key</span></span>
+<span id="cb401-8"><a href="#cb401-8" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (b, a), <span class="co">-- INVALID (b, a) is the same as (a, b)</span></span>
+<span id="cb401-9"><a href="#cb401-9" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (c, d, b, a), <span class="co">-- INVALID subset (b, a) is already unique key</span></span>
+<span id="cb401-10"><a href="#cb401-10" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (a), <span class="co">-- INVALID a is part of (a, b) key</span></span>
+<span id="cb401-11"><a href="#cb401-11" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (a, c), <span class="co">-- VALID</span></span>
+<span id="cb401-12"><a href="#cb401-12" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (d), <span class="co">-- VALID</span></span>
+<span id="cb401-13"><a href="#cb401-13" aria-hidden="true" tabindex="-1"></a>  <span class="kw">UNIQUE</span> (b, d) <span class="co">-- VALID</span></span>
+<span id="cb401-14"><a href="#cb401-14" aria-hidden="true" tabindex="-1"></a>);</span></code></pre></div>
 <hr />
 <h3 id="cql0270-use-fetch-from-for-procedures-that-returns-a-cursor-with-out-cursor">CQL0270: use FETCH FROM for procedures that returns a cursor with OUT ‘cursor’</h3>
 <p>If you are calling a procedure that returns a value cursor (using <code>OUT</code>) then you accept that cursor using the pattern</p>
-<div class="sourceCode" id="cb402"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb402-1"><a href="#cb402-1"></a><span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> FETCH <span class="kw">FROM</span> <span class="kw">CALL</span> foo(<span class="op">..</span>.);</span></code></pre></div>
+<div class="sourceCode" id="cb402"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb402-1"><a href="#cb402-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> FETCH <span class="kw">FROM</span> <span class="kw">CALL</span> foo(<span class="op">..</span>.);</span></code></pre></div>
 <p>The pattern</p>
-<div class="sourceCode" id="cb403"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb403-1"><a href="#cb403-1"></a><span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">CALL</span> foo(<span class="op">..</span>.);</span></code></pre></div>
+<div class="sourceCode" id="cb403"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb403-1"><a href="#cb403-1" aria-hidden="true" tabindex="-1"></a><span class="kw">DECLARE</span> C <span class="kw">CURSOR</span> <span class="cf">FOR</span> <span class="kw">CALL</span> foo(<span class="op">..</span>.);</span></code></pre></div>
 <p>Is used for procedures that provide a full <code>select</code> statement.</p>
 <p>Note that in the former cause you don’t then use <code>fetch</code> on the cursor. There is at most one row anyway and it’s fetched for you so a fetch would be useless. In the second case you fetch as many rows as there are and/or you want.</p>
 <hr />
 <h3 id="cql0271-the-offset-clause-may-only-be-used-if-limit-is-also-present">CQL0271: the OFFSET clause may only be used if LIMIT is also present</h3>
-<div class="sourceCode" id="cb404"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb404-1"><a href="#cb404-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo offset <span class="dv">1</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb404"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb404-1"><a href="#cb404-1" aria-hidden="true" tabindex="-1"></a><span class="kw">select</span> <span class="op">*</span> <span class="kw">from</span> foo offset <span class="dv">1</span>;</span></code></pre></div>
 <p>Is not supported by SQLite. <code>OFFSET</code> may only be used if <code>LIMIT</code> is also present. Also, both should be small because offset is not cheap. There is no way to do offset other than to read and ignore the indicated number of rows. So something like <code>offset 1000</code> is always horrible.</p>
 <hr />
 <h3 id="cql0272-the-set-of-columns-referenced-in-the-foreign-key-statement-should-match-exactly-a-unique-key-in-parent-table">CQL0272: THE SET OF COLUMNS REFERENCED IN THE FOREIGN KEY STATEMENT SHOULD MATCH EXACTLY A UNIQUE KEY IN PARENT TABLE</h3>
 <p>If you’re creating a table t2 with foreign keys on table t1, then the set of t1’s columns reference in the foreign key statement for table t2 should be: - A primary key in <code>t1</code></p>
-<div class="sourceCode" id="cb405"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb405-1"><a href="#cb405-1"></a>e.g:</span>
-<span id="cb405-2"><a href="#cb405-2"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text <span class="kw">primary</span> <span class="kw">key</span>);</span>
-<span id="cb405-3"><a href="#cb405-3"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text <span class="kw">primary</span> <span class="kw">key</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a) <span class="kw">references</span> t1(a));</span></code></pre></div>
+<div class="sourceCode" id="cb405"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb405-1"><a href="#cb405-1" aria-hidden="true" tabindex="-1"></a>e.g:</span>
+<span id="cb405-2"><a href="#cb405-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text <span class="kw">primary</span> <span class="kw">key</span>);</span>
+<span id="cb405-3"><a href="#cb405-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text <span class="kw">primary</span> <span class="kw">key</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a) <span class="kw">references</span> t1(a));</span></code></pre></div>
 <ul>
 <li>A unique key in <code>t1</code></li>
 </ul>
-<div class="sourceCode" id="cb406"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb406-1"><a href="#cb406-1"></a>e.g:</span>
-<span id="cb406-2"><a href="#cb406-2"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text <span class="kw">unique</span>);</span>
-<span id="cb406-3"><a href="#cb406-3"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text <span class="kw">primary</span> <span class="kw">key</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a) <span class="kw">references</span> t1(a));</span></code></pre></div>
+<div class="sourceCode" id="cb406"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb406-1"><a href="#cb406-1" aria-hidden="true" tabindex="-1"></a>e.g:</span>
+<span id="cb406-2"><a href="#cb406-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text <span class="kw">unique</span>);</span>
+<span id="cb406-3"><a href="#cb406-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text <span class="kw">primary</span> <span class="kw">key</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a) <span class="kw">references</span> t1(a));</span></code></pre></div>
 <ul>
 <li>A group of unique key in <code>t1</code></li>
 </ul>
-<div class="sourceCode" id="cb407"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb407-1"><a href="#cb407-1"></a>e.g:</span>
-<span id="cb407-2"><a href="#cb407-2"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text, b <span class="dt">int</span>, <span class="kw">unique</span>(a, b));</span>
-<span id="cb407-3"><a href="#cb407-3"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text, b <span class="dt">int</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a, b) <span class="kw">references</span> t1(a, b));</span></code></pre></div>
+<div class="sourceCode" id="cb407"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb407-1"><a href="#cb407-1" aria-hidden="true" tabindex="-1"></a>e.g:</span>
+<span id="cb407-2"><a href="#cb407-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text, b <span class="dt">int</span>, <span class="kw">unique</span>(a, b));</span>
+<span id="cb407-3"><a href="#cb407-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text, b <span class="dt">int</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a, b) <span class="kw">references</span> t1(a, b));</span></code></pre></div>
 <ul>
 <li>A group of primary key in <code>t1</code></li>
 </ul>
-<div class="sourceCode" id="cb408"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb408-1"><a href="#cb408-1"></a>e.g:</span>
-<span id="cb408-2"><a href="#cb408-2"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span>(a, b));</span>
-<span id="cb408-3"><a href="#cb408-3"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text, b <span class="dt">int</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a, b) <span class="kw">references</span> t1(a, b));</span></code></pre></div>
+<div class="sourceCode" id="cb408"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb408-1"><a href="#cb408-1" aria-hidden="true" tabindex="-1"></a>e.g:</span>
+<span id="cb408-2"><a href="#cb408-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text, b <span class="dt">int</span>, <span class="kw">primary</span> <span class="kw">key</span>(a, b));</span>
+<span id="cb408-3"><a href="#cb408-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text, b <span class="dt">int</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a, b) <span class="kw">references</span> t1(a, b));</span></code></pre></div>
 <ul>
 <li>A unique index in <code>t1</code></li>
 </ul>
-<div class="sourceCode" id="cb409"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb409-1"><a href="#cb409-1"></a>e.g:</span>
-<span id="cb409-2"><a href="#cb409-2"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text, b <span class="dt">int</span>);</span>
-<span id="cb409-3"><a href="#cb409-3"></a><span class="kw">create</span> <span class="kw">unique</span> <span class="kw">index</span> unq <span class="kw">on</span> t1(a, b);</span>
-<span id="cb409-4"><a href="#cb409-4"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text, b <span class="dt">int</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a, b) <span class="kw">references</span> t1(a, b));</span></code></pre></div>
+<div class="sourceCode" id="cb409"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb409-1"><a href="#cb409-1" aria-hidden="true" tabindex="-1"></a>e.g:</span>
+<span id="cb409-2"><a href="#cb409-2" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t1(a text, b <span class="dt">int</span>);</span>
+<span id="cb409-3"><a href="#cb409-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">unique</span> <span class="kw">index</span> unq <span class="kw">on</span> t1(a, b);</span>
+<span id="cb409-4"><a href="#cb409-4" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> <span class="kw">table</span> t2(a text, b <span class="dt">int</span>, <span class="kw">foreign</span> <span class="kw">key</span>(a, b) <span class="kw">references</span> t1(a, b));</span></code></pre></div>
 <hr />
 <h3 id="cql0273-autotest-attribute-has-incorrect-format-in-dummy_test">CQL0273: autotest attribute has incorrect format (…) in ‘dummy_test’</h3>
 <p>In a <code>cql:autotest</code> annotation, the given <strong>dummy_test</strong> info (table name, column name, column value) has incorrect format.</p>
@@ -8703,23 +8835,23 @@ set x := y;</code></pre>
 <h3 id="cql0280-upsert-statement-requires-a-where-clause-if-the-insert-clause-uses-select">CQL0280: upsert statement requires a where clause if the insert clause uses select</h3>
 <p>When the <code>INSERT</code> statement to which the UPSERT is attached takes its values from a <code>SELECT</code> statement, there is a potential parsing ambiguity. The SQLite parser might not be able to tell if the <code>ON</code> keyword is introducing the UPSERT or if it is the <code>ON</code> clause of a join. To work around this, the <code>SELECT</code> statement should always include a <code>WHERE</code> clause, even if that <code>WHERE</code> clause is just <code>WHERE 1</code> (always true). Note: The CQL parser doesn’t have this ambiguity because it treats “ON CONFLICT” as a single token so this is CQL reporting that SQLite might have trouble with the query as written.</p>
 <p>e.g:</p>
-<div class="sourceCode" id="cb410"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb410-1"><a href="#cb410-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> bar <span class="kw">where</span> <span class="dv">1</span> <span class="kw">on</span> conflict(<span class="kw">id</span>) do <span class="kw">nothing</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb410"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb410-1"><a href="#cb410-1" aria-hidden="true" tabindex="-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> bar <span class="kw">where</span> <span class="dv">1</span> <span class="kw">on</span> conflict(<span class="kw">id</span>) do <span class="kw">nothing</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0281-upsert-statement-does-not-include-table-name-in-the-update-statement">CQL0281: upsert statement does not include table name in the update statement</h3>
 <p>The UPDATE statement of and UPSERT should not include the table name because the name is already known from the INSERT statement part of the UPSERT e.g:</p>
-<div class="sourceCode" id="cb411"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb411-1"><a href="#cb411-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> bar <span class="kw">where</span> <span class="dv">1</span> <span class="kw">on</span> conflict(<span class="kw">id</span>) do <span class="kw">update</span> <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb411"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb411-1"><a href="#cb411-1" aria-hidden="true" tabindex="-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo <span class="kw">select</span> <span class="kw">id</span> <span class="kw">from</span> bar <span class="kw">where</span> <span class="dv">1</span> <span class="kw">on</span> conflict(<span class="kw">id</span>) do <span class="kw">update</span> <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0282-update-statement-require-table-name">CQL0282: update statement require table name</h3>
 <p>The UPDATE statement should always include a table name except if the UPDATE statement is part of an UPSERT statement.</p>
 <p>e.g:</p>
-<div class="sourceCode" id="cb412"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb412-1"><a href="#cb412-1"></a><span class="kw">update</span> foo <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span>
-<span id="cb412-2"><a href="#cb412-2"></a><span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>) <span class="kw">values</span>(<span class="dv">1</span>) do <span class="kw">update</span> <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb412"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb412-1"><a href="#cb412-1" aria-hidden="true" tabindex="-1"></a><span class="kw">update</span> foo <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span>
+<span id="cb412-2"><a href="#cb412-2" aria-hidden="true" tabindex="-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>) <span class="kw">values</span>(<span class="dv">1</span>) do <span class="kw">update</span> <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0283-upsert-syntax-only-support-insert-into">CQL0283: upsert syntax only support INSERT INTO</h3>
 <p>The INSERT statement part of an UPSERT statement can only uses INSERT INTO …</p>
-<div class="sourceCode" id="cb413"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb413-1"><a href="#cb413-1"></a>e.g:</span>
-<span id="cb413-2"><a href="#cb413-2"></a><span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>) <span class="kw">values</span>(<span class="dv">1</span>) <span class="kw">on</span> conflict do <span class="kw">nothing</span>;</span>
-<span id="cb413-3"><a href="#cb413-3"></a><span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>) <span class="kw">values</span>(<span class="dv">1</span>) <span class="kw">on</span> conflict do <span class="kw">update</span> <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb413"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb413-1"><a href="#cb413-1" aria-hidden="true" tabindex="-1"></a>e.g:</span>
+<span id="cb413-2"><a href="#cb413-2" aria-hidden="true" tabindex="-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>) <span class="kw">values</span>(<span class="dv">1</span>) <span class="kw">on</span> conflict do <span class="kw">nothing</span>;</span>
+<span id="cb413-3"><a href="#cb413-3" aria-hidden="true" tabindex="-1"></a><span class="kw">insert</span> <span class="kw">into</span> foo(<span class="kw">id</span>) <span class="kw">values</span>(<span class="dv">1</span>) <span class="kw">on</span> conflict do <span class="kw">update</span> <span class="kw">set</span> <span class="kw">id</span><span class="op">=</span><span class="dv">10</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0284-ad-hoc-schema-migration-directive-must-provide-a-procedure-to-run">CQL0284: ad hoc schema migration directive must provide a procedure to run</h3>
 <p><code>@schema_ad_hoc_migration</code> must provide both a version number and a migrate procedure name. This is unlike the other version directives like <code>@create</code> where the version number is optional. This is because the whole point of this migrator is to invoke a procedure of your choice.</p>
@@ -8841,30 +8973,30 @@ set x := y;</code></pre>
 <h3 id="cql0318-more-than-one-fragment-annotation-on-procedure-procedure_name">CQL0318: more than one fragment annotation on procedure ‘procedure_name’</h3>
 <p>The indicated procedure has several cql:*_fragment annotations such as cql:base_fragment and cql:extension_fragment. You can have at most one of these.</p>
 <p>example:</p>
-<div class="sourceCode" id="cb414"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb414-1"><a href="#cb414-1"></a><span class="ot">@attribute(cql:assembly_fragment=foo)</span></span>
-<span id="cb414-2"><a href="#cb414-2"></a><span class="ot">@attribute(cql:base_fragment=goo)</span></span>
-<span id="cb414-3"><a href="#cb414-3"></a><span class="kw">create</span> proc mixed_frag_types3(id_ <span class="dt">integer</span>)</span>
-<span id="cb414-4"><a href="#cb414-4"></a><span class="cf">begin</span></span>
-<span id="cb414-5"><a href="#cb414-5"></a>  <span class="op">..</span>.</span>
-<span id="cb414-6"><a href="#cb414-6"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb414"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb414-1"><a href="#cb414-1" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:assembly_fragment=foo)</span></span>
+<span id="cb414-2"><a href="#cb414-2" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:base_fragment=goo)</span></span>
+<span id="cb414-3"><a href="#cb414-3" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc mixed_frag_types3(id_ <span class="dt">integer</span>)</span>
+<span id="cb414-4"><a href="#cb414-4" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb414-5"><a href="#cb414-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb414-6"><a href="#cb414-6" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0319-the-name-of-the-assembly-procedure-must-match-the-name-of-the-base-fragment-procedure_name">CQL0319: the name of the assembly procedure must match the name of the base fragment ‘procedure_name’</h3>
 <p>The name of the procedure that carries the assembly attribute (cql:assembly_fragment) has to match the name of the base fragment. This is because the code that is generated for the extension fragments refers to some shared code that is generated in the assembly fragment. If the assembly fragment were allowed to have a distinct name the linkage could never work.</p>
 <p>example:</p>
-<div class="sourceCode" id="cb415"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb415-1"><a href="#cb415-1"></a><span class="co">-- correct example</span></span>
-<span id="cb415-2"><a href="#cb415-2"></a><span class="co">-- note: &#39;foo&#39; must be a valid base fragment, declared elsewhere</span></span>
-<span id="cb415-3"><a href="#cb415-3"></a><span class="ot">@attribute(cql:assembly_fragment=foo)</span></span>
-<span id="cb415-4"><a href="#cb415-4"></a><span class="kw">create</span> proc foo(id_ <span class="dt">integer</span>)</span>
-<span id="cb415-5"><a href="#cb415-5"></a><span class="cf">begin</span></span>
-<span id="cb415-6"><a href="#cb415-6"></a>  <span class="op">..</span>.</span>
-<span id="cb415-7"><a href="#cb415-7"></a><span class="cf">end</span>;</span>
-<span id="cb415-8"><a href="#cb415-8"></a></span>
-<span id="cb415-9"><a href="#cb415-9"></a><span class="co">-- incorrect example</span></span>
-<span id="cb415-10"><a href="#cb415-10"></a><span class="ot">@attribute(cql:assembly_fragment=foo)</span></span>
-<span id="cb415-11"><a href="#cb415-11"></a><span class="kw">create</span> proc bar(id_ <span class="dt">integer</span>)</span>
-<span id="cb415-12"><a href="#cb415-12"></a><span class="cf">begin</span></span>
-<span id="cb415-13"><a href="#cb415-13"></a>  <span class="op">..</span>.</span>
-<span id="cb415-14"><a href="#cb415-14"></a><span class="cf">end</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb415"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb415-1"><a href="#cb415-1" aria-hidden="true" tabindex="-1"></a><span class="co">-- correct example</span></span>
+<span id="cb415-2"><a href="#cb415-2" aria-hidden="true" tabindex="-1"></a><span class="co">-- note: &#39;foo&#39; must be a valid base fragment, declared elsewhere</span></span>
+<span id="cb415-3"><a href="#cb415-3" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:assembly_fragment=foo)</span></span>
+<span id="cb415-4"><a href="#cb415-4" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc foo(id_ <span class="dt">integer</span>)</span>
+<span id="cb415-5"><a href="#cb415-5" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb415-6"><a href="#cb415-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb415-7"><a href="#cb415-7" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span>
+<span id="cb415-8"><a href="#cb415-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb415-9"><a href="#cb415-9" aria-hidden="true" tabindex="-1"></a><span class="co">-- incorrect example</span></span>
+<span id="cb415-10"><a href="#cb415-10" aria-hidden="true" tabindex="-1"></a><span class="ot">@attribute(cql:assembly_fragment=foo)</span></span>
+<span id="cb415-11"><a href="#cb415-11" aria-hidden="true" tabindex="-1"></a><span class="kw">create</span> proc bar(id_ <span class="dt">integer</span>)</span>
+<span id="cb415-12"><a href="#cb415-12" aria-hidden="true" tabindex="-1"></a><span class="cf">begin</span></span>
+<span id="cb415-13"><a href="#cb415-13" aria-hidden="true" tabindex="-1"></a>  <span class="op">..</span>.</span>
+<span id="cb415-14"><a href="#cb415-14" aria-hidden="true" tabindex="-1"></a><span class="cf">end</span>;</span></code></pre></div>
 <hr />
 <h3 id="cql0320-extension-fragment-cte-must-have-a-from-clause-and-no-other-top-level-clauses-frag_name">CQL0320: extension fragment CTE must have a FROM clause and no other top level clauses ‘frag_name’</h3>
 <p>In the extension fragment form that uses <code>LEFT OUTER JOIN</code> to add columns you cannot include top level restrictions/changes like <code>WHERE</code>, <code>ORDER BY</code>, <code>LIMIT</code> and so forth. Any of these would remove or reorder the rows from the core fragment and that is not allowed, you can only add columns. Hence you must have a <code>FROM</code> clause and you can have no other top level clauses. You can use any clauses you like in a nested select to get your additional columns.</p>
@@ -8960,12 +9092,12 @@ set x := y;</code></pre>
 <hr />
 <h3 id="cql0346-the-variable-must-be-of-type-objectt-cursor-where-t-is-a-valid-shape-name-variable">CQL0346: the variable must be of type <code>object&lt;T cursor&gt;</code> where T is a valid shape name ‘variable’</h3>
 <p>It’s possible to take the statement associated with a statement cursor and store it in an object variable. Using the form:</p>
-<div class="sourceCode" id="cb416"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb416-1"><a href="#cb416-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> X;</span></code></pre></div>
+<div class="sourceCode" id="cb416"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb416-1"><a href="#cb416-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> C <span class="kw">cursor</span> <span class="cf">for</span> X;</span></code></pre></div>
 <p>The object variable ‘X’ must be declared as follows:</p>
-<div class="sourceCode" id="cb417"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb417-1"><a href="#cb417-1"></a><span class="kw">declare</span> X <span class="dt">object</span><span class="op">&lt;</span>T <span class="kw">cursor</span><span class="op">&gt;</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb417"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb417-1"><a href="#cb417-1" aria-hidden="true" tabindex="-1"></a><span class="kw">declare</span> X <span class="dt">object</span><span class="op">&lt;</span>T <span class="kw">cursor</span><span class="op">&gt;</span>;</span></code></pre></div>
 <p>Where <code>T</code> refers to a named object with a shape, like a table, a view, or a stored procedure that returns a result set. This type <code>T</code> must match the shape of the cursor exactly i.e. having the column names and types.</p>
 <p>The reverse operation, storing a statement cursor in a variable is also possible with this form:</p>
-<div class="sourceCode" id="cb418"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb418-1"><a href="#cb418-1"></a><span class="kw">set</span> X <span class="kw">from</span> <span class="kw">cursor</span> C;</span></code></pre></div>
+<div class="sourceCode" id="cb418"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb418-1"><a href="#cb418-1" aria-hidden="true" tabindex="-1"></a><span class="kw">set</span> X <span class="kw">from</span> <span class="kw">cursor</span> C;</span></code></pre></div>
 <p>This has similar constraints on the variable <code>X</code>.</p>
 <p>This error indicates that the variable in question (<code>X</code> in this example) is not a typed object variable so it can’t be the source of a cursor, or accept a cursor.</p>
 <p>See Chapter 5 of the CQL Programming Language.</p>
@@ -9046,11 +9178,11 @@ set x := y;</code></pre>
 <h3 id="cql0369-the-select-if-nothing-construct-is-for-use-in-top-level-expressions-not-inside-of-other-dml">CQL0369: The (select … if nothing) construct is for use in top level expressions, not inside of other DML</h3>
 <p>This form allows for error control of (select…) expressions. But SQLite does not understand the form at all, so it can only appear at the top level of expressions where CQL can strip it out. Here are some examples:</p>
 <p>good:</p>
-<div class="sourceCode" id="cb419"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb419-1"><a href="#cb419-1"></a>  <span class="kw">set</span> x <span class="op">:=</span> (<span class="kw">select</span> foo <span class="kw">from</span> bar <span class="kw">where</span> baz <span class="cf">if</span> <span class="kw">nothing</span> <span class="dv">0</span>);</span>
-<span id="cb419-2"><a href="#cb419-2"></a>  <span class="cf">if</span> (<span class="kw">select</span> foo <span class="kw">from</span> bar <span class="kw">where</span> baz <span class="cf">if</span> <span class="kw">nothing</span> <span class="dv">1</span>) <span class="cf">then</span> <span class="op">..</span>. <span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
+<div class="sourceCode" id="cb419"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb419-1"><a href="#cb419-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">set</span> x <span class="op">:=</span> (<span class="kw">select</span> foo <span class="kw">from</span> bar <span class="kw">where</span> baz <span class="cf">if</span> <span class="kw">nothing</span> <span class="dv">0</span>);</span>
+<span id="cb419-2"><a href="#cb419-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (<span class="kw">select</span> foo <span class="kw">from</span> bar <span class="kw">where</span> baz <span class="cf">if</span> <span class="kw">nothing</span> <span class="dv">1</span>) <span class="cf">then</span> <span class="op">..</span>. <span class="cf">end</span> <span class="cf">if</span>;</span></code></pre></div>
 <p>bad:</p>
-<div class="sourceCode" id="cb420"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb420-1"><a href="#cb420-1"></a>  <span class="kw">select</span> foo <span class="kw">from</span> bar <span class="kw">where</span> (<span class="kw">select</span> something <span class="kw">from</span> somewhere <span class="cf">if</span> <span class="kw">nothing</span> <span class="kw">null</span>);</span>
-<span id="cb420-2"><a href="#cb420-2"></a>  <span class="kw">delete</span> <span class="kw">from</span> foo <span class="kw">where</span> (<span class="kw">select</span> something <span class="kw">from</span> somewhere <span class="cf">if</span> <span class="kw">nothing</span> <span class="dv">1</span>);</span></code></pre></div>
+<div class="sourceCode" id="cb420"><pre class="sourceCode sql"><code class="sourceCode sql"><span id="cb420-1"><a href="#cb420-1" aria-hidden="true" tabindex="-1"></a>  <span class="kw">select</span> foo <span class="kw">from</span> bar <span class="kw">where</span> (<span class="kw">select</span> something <span class="kw">from</span> somewhere <span class="cf">if</span> <span class="kw">nothing</span> <span class="kw">null</span>);</span>
+<span id="cb420-2"><a href="#cb420-2" aria-hidden="true" tabindex="-1"></a>  <span class="kw">delete</span> <span class="kw">from</span> foo <span class="kw">where</span> (<span class="kw">select</span> something <span class="kw">from</span> somewhere <span class="cf">if</span> <span class="kw">nothing</span> <span class="dv">1</span>);</span></code></pre></div>
 <p>Basically if you are already in a SQL context, the form isn’t usable because SQLite simply doesn’t understand if nothing at all. This error makes it so that you’ll get a build time failure from CQL rather than a run time failure from SQLite.</p>
 <hr />
 <h2 id="appendix-5-json-schema-grammar">Appendix 5: JSON Schema Grammar</h2>

--- a/CQL_Guide/generated/guide.md
+++ b/CQL_Guide/generated/guide.md
@@ -1582,7 +1582,7 @@ Each of these has their own macro for `retain` and `release` though all three ac
 
 #### Assigning to an `out` parameter or a global variable
 
-* `out,`inout`parameters, and global variables work just like local variables except that CQL does not call`release` at the end of the procedure
+* `out`, `inout` parameters, and global variables work just like local variables except that CQL does not call `release` at the end of the procedure
 
 ### Function Return Values
 
@@ -2501,13 +2501,13 @@ end;
 ```
  Automatic cursors are so much easier to use than explicit storage that explicit storage is rarely seen.  Storing to `out` parameters is a case where explicit is ok, the `out` parameters have to be declared anyway.
 
- #### For Value Cursors
+#### For Value Cursors
 
  A cursor declared in one of these forms:
 
  * `declare C cursor fetch from call foo(args)`
    * `foo` must be a procedure that returns one row with `OUT`
- * `declare C cursor like select 1 id, "x" name;
+ * `declare C cursor like select 1 id, "x" name;`
  * `declare C cursor like X;`
    * where X is the name of a table, a view, another cursor, or a procedure that returns a structured result
 
@@ -2546,7 +2546,7 @@ With this form, any possible valid cursor values could be set, but many forms of
 
 * `fetch C(a,b) from cursor D(a,b)`
   * the named columns of D are used as the values
-  * in this case it becomes: `fetch C(a,b) from values(D.a, D.b);
+  * in this case it becomes: `fetch C(a,b) from values(D.a, D.b);`
 
 That most recent form does seem like it saves much but recall the first rewrite:
 
@@ -2575,7 +2575,7 @@ Like can be used in both places, for instance suppose `E` is a cursor that has a
 
  As is mentioned above, the `fetch` form means to load an entire row into the cursor.  This is important because "half loaded" cursors would be semantically problematic.  However there are many cases where you might like to amend the values of an already loaded cursor.  You can do this with the `update` form.
 
- * `update cursor C(a,b,..) from values(1,2,..);
+ * `update cursor C(a,b,..) from values(1,2,..);`
    * the update form is a no-op if the cursor is not already loaded with values (!!)
    * the columns and values are type checked so a valid row is ensured (or no row)
    * all the re-writes above are legal so `update cursor C(like D) from D` is possible, it is in fact the use-case for which this was designed.


### PR DESCRIPTION
Summary:
These markdown fixes address the formatting depicted in the following screenshots grabbed from https://cgsql.dev/cql-guide/ch03

https://cgsql.dev/cql-guide/ch03#assigning-to-an-out-parameter-or-a-global-variable

...

https://cgsql.dev/cql-guide/ch05/#for-value-cursors

Reviewed By: winniequinn

Differential Revision: D26948967

