### PR TITLE
One of the call forms was totally not supported;  call out_union_proc();

### DIFF
--- a/sources/sem.h
+++ b/sources/sem.h
@@ -152,7 +152,8 @@ cql_data_decl( bytebuf *recreate_annotations );
 #define SEM_TYPE_HIDDEN_COL       _64(0x200000000) // set if and only if hidden column on a virtual table
 #define SEM_TYPE_TVF              _64(0x400000000) // set if and only table node is a table valued function
 #define SEM_TYPE_IMPLICIT         _64(0x800000000) // set if and only the variable was declare implicitly (via declare out)
-#define SEM_TYPE_FLAGS            _64(0xFFFFFFF00) // all the flag bits we have so far
+#define SEM_TYPE_CALLS_OUT_UNION _64(0x1000000000) // set if proc calls an out union proc for a result
+#define SEM_TYPE_FLAGS           _64(0x1FFFFFFF00) // all the flag bits we have so far
 
 #define SEM_EXPR_CONTEXT_NONE           0x001
 #define SEM_EXPR_CONTEXT_SELECT_LIST    0x002
@@ -211,6 +212,7 @@ cql_noexport bool_t is_insert_stmt(ast_node *ast);
 cql_noexport bool_t is_update_stmt(ast_node *ast);
 cql_noexport bool_t has_result_set(ast_node *ast);
 cql_noexport bool_t has_out_stmt_result(ast_node *ast);
+cql_noexport bool_t has_out_union_call(ast_node *ast);
 cql_noexport bool_t has_out_union_stmt_result(ast_node *ast);
 cql_noexport bool_t is_autotest_dummy_table(CSTR name);
 cql_noexport bool_t is_autotest_dummy_insert(CSTR name);


### PR DESCRIPTION
if you have an existing out union procedure you should be able to call it for your result, which makes you
look like an out union procedure.  This is the same as all the other flavors.

There can be no mix/match here but if you want to multiplex out union procs
you should be able to do this.

Still pending:

* the out arg for out union is not properly initialized

* when the out union proc is called in this form we should release the current out union result set if any.