### PR TITLE
Add coverage for the object result type, fill in some missing cqlrt support

### DIFF
--- a/sources/cg_java.c
+++ b/sources/cg_java.c
@@ -373,7 +373,6 @@ static void cg_java_create_proc_stmt(ast_node *ast) {
       if (core_type_of(sem_type) == SEM_TYPE_OBJECT) {
         cql_error("out cursors with object columns are not yet supported for java\n");
         cql_cleanup_and_exit(1);
-        return;
       }
     }
 

--- a/sources/common/test_common.sh
+++ b/sources/common/test_common.sh
@@ -389,6 +389,13 @@ code_gen_java_test() {
     failed
   fi
 
+  echo 'running object result not supported by java test'
+  if ${CQL} --in "${TEST_DIR}/java_no_object.sql" --cg out/x.java --rt java --java_package_name x 2>"${OUT_DIR}/java_object_result.err"
+  then
+    echo 'object type appears in result set, this should have caused an error'
+    failed
+  fi
+
   echo validating codegen
   echo "  computing diffs (empty if none)"
 

--- a/sources/cqlrt_common.c
+++ b/sources/cqlrt_common.c
@@ -752,6 +752,11 @@ void cql_copyoutrow(sqlite3 *_Nullable db, cql_result_set_ref _Nonnull result_se
         }
         break;
       }
+      case CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL: {
+        cql_object_ref *obj_ref = va_arg(args, cql_object_ref *);
+        cql_set_object_ref(obj_ref, cql_result_set_get_object_col(result_set, row, column));
+        break;
+      }
       case CQL_DATA_TYPE_INT32: {
         cql_nullable_int32 *_Nonnull int32p = va_arg(args, cql_nullable_int32 *_Nonnull);
         if (cql_result_set_get_is_null_col(result_set, row, column)) {
@@ -824,6 +829,11 @@ void cql_copyoutrow(sqlite3 *_Nullable db, cql_result_set_ref _Nonnull result_se
           cql_set_blob_ref(blob_ref, new_blob_ref);
           cql_blob_release(new_blob_ref);
         }
+        break;
+      }
+      case CQL_DATA_TYPE_OBJECT: {
+        cql_object_ref *obj_ref = va_arg(args, cql_object_ref *);
+        cql_set_object_ref(obj_ref, cql_result_set_get_object_col(result_set, row, column));
         break;
       }
     }

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -3852,6 +3852,15 @@ begin
    let y := ifnull_throw(x);
 end;
 
+-- +  CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
+-- + cql_offsetof(out_object_row, o)
+create proc out_object(o object not null)
+begin
+  declare C cursor like out_object arguments;
+  fetch C from arguments;
+  out C;
+end;
+
 --------------------------------------------------------------------
 -------------------- add new tests before this point ---------------
 --------------------------------------------------------------------

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -281,6 +281,14 @@ typedef struct global_cursor2_row {
 #define global_cursor2_refs_offset cql_offsetof(global_cursor2_row, x) // count = 1
 extern void out2_proc(cql_nullable_int32 x, cql_int32 *_Nonnull y, cql_int32 *_Nonnull z);
 
+
+typedef struct out_object_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_object_ref _Nonnull o;
+} out_object_row;
+extern void out_object(cql_object_ref _Nonnull o, out_object_row *_Nonnull _result_);
 cql_string_literal(_literal_1_This_is_a_test_, "This is a \" \\ test '' \n \" ");
 cql_string_literal(_literal_2_b_, "b");
 cql_string_literal(_literal_3_c_, "c");
@@ -8980,6 +8988,84 @@ CQL_WARN_UNUSED cql_code uses_ifnull_throw(sqlite3 *_Nonnull _db_, cql_nullable_
 
 cql_cleanup:
   return _rc_;
+}
+#undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC out_object (o OBJECT NOT NULL)
+BEGIN
+  DECLARE C CURSOR LIKE out_object ARGUMENTS;
+  FETCH C(o) FROM VALUES(o);
+  OUT C;
+END;
+*/
+
+#define _PROC_ "out_object"
+
+#define out_object_refs_offset cql_offsetof(out_object_row, o) // count = 1
+static int32_t out_object_perf_index;
+
+cql_string_literal(out_object_stored_procedure_name, "out_object");
+
+cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
+  out_object_row *data = (out_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data->o;
+}
+
+uint8_t out_object_data_types[out_object_data_types_count] = {
+  CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
+};
+
+static cql_uint16 out_object_col_offsets[] = { 1,
+  cql_offsetof(out_object_row, o)
+};
+
+cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_count((cql_result_set_ref)result_set);
+}
+
+void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o) {
+  cql_profile_start(CRC_out_object, &out_object_perf_index);
+  *result_set = NULL;
+  out_object_row *row = (out_object_row *)calloc(1, sizeof(out_object_row));
+  out_object(o, row);
+  cql_fetch_info info = {
+    .rc = SQLITE_OK,
+    .data_types = out_object_data_types,
+    .col_offsets = out_object_col_offsets,
+    .refs_count = 1,
+    .refs_offset = out_object_refs_offset,
+    .rowsize = sizeof(out_object_row),
+    .crc = CRC_out_object,
+    .perf_index = &out_object_perf_index,
+  };
+  cql_one_row_result(&info, (char *)row, row->_has_row_, (cql_result_set_ref *)result_set);
+}
+
+// export: DECLARE PROC out_object (o OBJECT NOT NULL) OUT (o OBJECT NOT NULL);
+
+typedef struct out_object_C_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_object_ref _Nonnull o;
+} out_object_C_row;
+
+#define out_object_C_refs_offset cql_offsetof(out_object_C_row, o) // count = 1
+void out_object(cql_object_ref _Nonnull o, out_object_row *_Nonnull _result_) {
+  memset(_result_, 0, sizeof(*_result_));
+  out_object_C_row C = { ._refs_count_ = 1, ._refs_offset_ = out_object_C_refs_offset };
+
+  C._has_row_ = 1;
+  cql_set_object_ref(&C.o, o);
+  _result_->_has_row_ = C._has_row_;
+  _result_->_refs_count_ = 1;
+  _result_->_refs_offset_ = out_object_refs_offset;
+  cql_set_object_ref(&_result_->o, C.o);
+
+  cql_teardown_row(C);
 }
 #undef _PROC_
 cql_int32 this_is_the_end = 0;

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -2565,6 +2565,34 @@ extern CQL_WARN_UNUSED cql_code uses_throw(sqlite3 *_Nonnull _db_);
 extern CQL_WARN_UNUSED cql_code uses_ifnull_throw(sqlite3 *_Nonnull _db_, cql_nullable_int32 x);
 
 // The statement ending at line XXXX
+#define CRC_out_object 1794985861949478211L
+
+extern cql_string_ref _Nonnull out_object_stored_procedure_name;
+
+#define out_object_data_types_count 1
+
+#ifndef result_set_type_decl_out_object_result_set
+#define result_set_type_decl_out_object_result_set 1
+cql_result_set_type_decl(out_object_result_set, out_object_result_set_ref);
+#endif
+extern cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set);
+extern cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set);
+extern void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o);
+#define out_object_copy(result_set, result_set_to) \
+cql_result_set_get_meta((cql_result_set_ref)(result_set))->copy( \
+  (cql_result_set_ref)(result_set), \
+  (cql_result_set_ref *)(result_set_to), \
+  0, \
+  1)
+#define out_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
+#define out_object_equal(rs1, rs2) \
+cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
+  (cql_result_set_ref)(rs1), \
+  0, \
+  (cql_result_set_ref)(rs2), \
+  0)
+
+// The statement ending at line XXXX
 extern cql_int32 this_is_the_end;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_type_getters.sql
+++ b/sources/test/cg_test_c_type_getters.sql
@@ -113,3 +113,13 @@ begin
     ext2(*) as (select frag_test.*, f3 from frag_test left outer join foo on f1 = id)
   select * from ext2;
 end;
+
+-- TEST: emit an object result set with type getters
+-- + static inline cql_object_ref _Nonnull emit_object_result_set_get_o(emit_object_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+-- +   return cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 0);
+create proc emit_object_result_set(o object not null)
+begin
+   declare C cursor like emit_object_result_set arguments;
+   fetch C from arguments;
+   out union C;
+end;

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -281,6 +281,14 @@ typedef struct global_cursor2_row {
 #define global_cursor2_refs_offset cql_offsetof(global_cursor2_row, x) // count = 1
 extern void out2_proc(cql_nullable_int32 x, cql_int32 *_Nonnull y, cql_int32 *_Nonnull z);
 
+
+typedef struct out_object_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_object_ref _Nonnull o;
+} out_object_row;
+extern void out_object(cql_object_ref _Nonnull o, out_object_row *_Nonnull _result_);
 cql_string_literal(_literal_1_This_is_a_test_, "This is a \" \\ test '' \n \" ");
 cql_string_literal(_literal_2_b_, "b");
 cql_string_literal(_literal_3_c_, "c");
@@ -8980,6 +8988,84 @@ CQL_WARN_UNUSED cql_code uses_ifnull_throw(sqlite3 *_Nonnull _db_, cql_nullable_
 
 cql_cleanup:
   return _rc_;
+}
+#undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC out_object (o OBJECT NOT NULL)
+BEGIN
+  DECLARE C CURSOR LIKE out_object ARGUMENTS;
+  FETCH C(o) FROM VALUES(o);
+  OUT C;
+END;
+*/
+
+#define _PROC_ "out_object"
+
+#define out_object_refs_offset cql_offsetof(out_object_row, o) // count = 1
+static int32_t out_object_perf_index;
+
+cql_string_literal(out_object_stored_procedure_name, "out_object");
+
+cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set) {
+  out_object_row *data = (out_object_row *)cql_result_set_get_data((cql_result_set_ref)result_set);
+  return data->o;
+}
+
+uint8_t out_object_data_types[out_object_data_types_count] = {
+  CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
+};
+
+static cql_uint16 out_object_col_offsets[] = { 1,
+  cql_offsetof(out_object_row, o)
+};
+
+cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_count((cql_result_set_ref)result_set);
+}
+
+void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o) {
+  cql_profile_start(CRC_out_object, &out_object_perf_index);
+  *result_set = NULL;
+  out_object_row *row = (out_object_row *)calloc(1, sizeof(out_object_row));
+  out_object(o, row);
+  cql_fetch_info info = {
+    .rc = SQLITE_OK,
+    .data_types = out_object_data_types,
+    .col_offsets = out_object_col_offsets,
+    .refs_count = 1,
+    .refs_offset = out_object_refs_offset,
+    .rowsize = sizeof(out_object_row),
+    .crc = CRC_out_object,
+    .perf_index = &out_object_perf_index,
+  };
+  cql_one_row_result(&info, (char *)row, row->_has_row_, (cql_result_set_ref *)result_set);
+}
+
+// export: DECLARE PROC out_object (o OBJECT NOT NULL) OUT (o OBJECT NOT NULL);
+
+typedef struct out_object_C_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_object_ref _Nonnull o;
+} out_object_C_row;
+
+#define out_object_C_refs_offset cql_offsetof(out_object_C_row, o) // count = 1
+void out_object(cql_object_ref _Nonnull o, out_object_row *_Nonnull _result_) {
+  memset(_result_, 0, sizeof(*_result_));
+  out_object_C_row C = { ._refs_count_ = 1, ._refs_offset_ = out_object_C_refs_offset };
+
+  C._has_row_ = 1;
+  cql_set_object_ref(&C.o, o);
+  _result_->_has_row_ = C._has_row_;
+  _result_->_refs_count_ = 1;
+  _result_->_refs_offset_ = out_object_refs_offset;
+  cql_set_object_ref(&_result_->o, C.o);
+
+  cql_teardown_row(C);
 }
 #undef _PROC_
 cql_int32 this_is_the_end = 0;

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -2565,6 +2565,34 @@ extern CQL_WARN_UNUSED cql_code uses_throw(sqlite3 *_Nonnull _db_);
 extern CQL_WARN_UNUSED cql_code uses_ifnull_throw(sqlite3 *_Nonnull _db_, cql_nullable_int32 x);
 
 // The statement ending at line XXXX
+#define CRC_out_object 1794985861949478211L
+
+extern cql_string_ref _Nonnull out_object_stored_procedure_name;
+
+#define out_object_data_types_count 1
+
+#ifndef result_set_type_decl_out_object_result_set
+#define result_set_type_decl_out_object_result_set 1
+cql_result_set_type_decl(out_object_result_set, out_object_result_set_ref);
+#endif
+extern cql_object_ref _Nonnull out_object_get_o(out_object_result_set_ref _Nonnull result_set);
+extern cql_int32 out_object_result_count(out_object_result_set_ref _Nonnull result_set);
+extern void out_object_fetch_results( out_object_result_set_ref _Nullable *_Nonnull result_set, cql_object_ref _Nonnull o);
+#define out_object_copy(result_set, result_set_to) \
+cql_result_set_get_meta((cql_result_set_ref)(result_set))->copy( \
+  (cql_result_set_ref)(result_set), \
+  (cql_result_set_ref *)(result_set_to), \
+  0, \
+  1)
+#define out_object_hash(result_set) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), 0)
+#define out_object_equal(rs1, rs2) \
+cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
+  (cql_result_set_ref)(rs1), \
+  0, \
+  (cql_result_set_ref)(rs2), \
+  0)
+
+// The statement ending at line XXXX
 extern cql_int32 this_is_the_end;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_type_getters.c.ref
+++ b/sources/test/cg_test_c_with_type_getters.c.ref
@@ -8,6 +8,13 @@
 #pragma clang diagnostic ignored "-Wliteral-conversion"
 extern CQL_WARN_UNUSED cql_code selector(sqlite3 *_Nonnull _db_, sqlite3_stmt *_Nullable *_Nonnull _result_stmt);
 
+typedef struct emit_object_result_set_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_object_ref _Nonnull o;
+} emit_object_result_set_row;
+
 // The statement ending at line XXXX
 
 /*
@@ -161,3 +168,71 @@ END;
 cql_int32 ext2_result_count(frag_test_result_set_ref _Nonnull result_set) {
   return cql_result_set_get_count((cql_result_set_ref)result_set);
 }
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC emit_object_result_set (o OBJECT NOT NULL)
+BEGIN
+  DECLARE C CURSOR LIKE emit_object_result_set ARGUMENTS;
+  FETCH C(o) FROM VALUES(o);
+  OUT UNION C;
+END;
+*/
+
+#define _PROC_ "emit_object_result_set_fetch_results"
+
+#define emit_object_result_set_refs_offset cql_offsetof(emit_object_result_set_row, o) // count = 1
+static int32_t emit_object_result_set_perf_index;
+
+cql_string_literal(emit_object_result_set_stored_procedure_name, "emit_object_result_set");
+
+uint8_t emit_object_result_set_data_types[emit_object_result_set_data_types_count] = {
+  CQL_DATA_TYPE_OBJECT | CQL_DATA_TYPE_NOT_NULL, // o
+};
+
+#define emit_object_result_set_refs_offset cql_offsetof(emit_object_result_set_row, o) // count = 1
+
+static cql_uint16 emit_object_result_set_col_offsets[] = { 1,
+  cql_offsetof(emit_object_result_set_row, o)
+};
+
+cql_int32 emit_object_result_set_result_count(emit_object_result_set_result_set_ref _Nonnull result_set) {
+  return cql_result_set_get_count((cql_result_set_ref)result_set);
+}
+cql_fetch_info emit_object_result_set_info = {
+  .rc = SQLITE_OK,
+  .data_types = emit_object_result_set_data_types,
+  .col_offsets = emit_object_result_set_col_offsets,
+  .refs_count = 1,
+  .refs_offset = emit_object_result_set_refs_offset,
+  .rowsize = sizeof(emit_object_result_set_row),
+  .crc = CRC_emit_object_result_set,
+  .perf_index = &emit_object_result_set_perf_index,
+};
+// export: DECLARE PROC emit_object_result_set (o OBJECT NOT NULL) OUT UNION (o OBJECT NOT NULL);
+
+typedef struct emit_object_result_set_C_row {
+  cql_bool _has_row_;
+  cql_uint16 _refs_count_;
+  cql_uint16 _refs_offset_;
+  cql_object_ref _Nonnull o;
+} emit_object_result_set_C_row;
+
+#define emit_object_result_set_C_refs_offset cql_offsetof(emit_object_result_set_C_row, o) // count = 1
+void emit_object_result_set_fetch_results(emit_object_result_set_result_set_ref _Nullable *_Nonnull _result_set_, cql_object_ref _Nonnull o) {
+  cql_bytebuf _rows_;
+  cql_bytebuf_open(&_rows_);
+  *_result_set_ = NULL;
+  emit_object_result_set_C_row C = { ._refs_count_ = 1, ._refs_offset_ = emit_object_result_set_C_refs_offset };
+
+  cql_profile_start(CRC_emit_object_result_set, &emit_object_result_set_perf_index);
+  C._has_row_ = 1;
+  cql_set_object_ref(&C.o, o);
+  cql_retain_row(C);
+  if (C._has_row_) cql_bytebuf_append(&_rows_, (const void *)&C, sizeof(C));
+
+  cql_results_from_data(SQLITE_OK, &_rows_, &emit_object_result_set_info, (cql_result_set_ref *)_result_set_);
+  cql_teardown_row(C);
+}
+#undef _PROC_

--- a/sources/test/cg_test_c_with_type_getters.h.ref
+++ b/sources/test/cg_test_c_with_type_getters.h.ref
@@ -166,3 +166,37 @@ cql_result_set_get_meta((cql_result_set_ref)(result_set))->copy( \
   (cql_result_set_ref *)(result_set_to), \
   from, \
   count)
+
+// The statement ending at line XXXX
+#define CRC_emit_object_result_set -8134731798097882462L
+
+extern cql_string_ref _Nonnull emit_object_result_set_stored_procedure_name;
+
+#define emit_object_result_set_data_types_count 1
+
+extern uint8_t emit_object_result_set_data_types[emit_object_result_set_data_types_count];
+
+#ifndef result_set_type_decl_emit_object_result_set_result_set
+#define result_set_type_decl_emit_object_result_set_result_set 1
+cql_result_set_type_decl(emit_object_result_set_result_set, emit_object_result_set_result_set_ref);
+#endif
+
+static inline cql_object_ref _Nonnull emit_object_result_set_get_o(emit_object_result_set_result_set_ref _Nonnull result_set, cql_int32 row) {
+  return cql_result_set_get_object_col((cql_result_set_ref)result_set, row, 0);
+}
+
+extern cql_int32 emit_object_result_set_result_count(emit_object_result_set_result_set_ref _Nonnull result_set);
+#define emit_object_result_set_copy(result_set, result_set_to, from, count) \
+cql_result_set_get_meta((cql_result_set_ref)(result_set))->copy( \
+  (cql_result_set_ref)(result_set), \
+  (cql_result_set_ref *)(result_set_to), \
+  from, \
+  count)
+#define emit_object_result_set_row_hash(result_set, row) cql_result_set_get_meta((cql_result_set_ref)(result_set))->rowHash((cql_result_set_ref)(result_set), row)
+#define emit_object_result_set_row_equal(rs1, row1, rs2, row2) \
+cql_result_set_get_meta((cql_result_set_ref)(rs1))->rowsEqual( \
+  (cql_result_set_ref)(rs1), \
+  row1, \
+  (cql_result_set_ref)(rs2), \
+  row2)
+extern void emit_object_result_set_fetch_results(emit_object_result_set_result_set_ref _Nullable *_Nonnull _result_set_, cql_object_ref _Nonnull o);

--- a/sources/test/cg_test_exports.out.ref
+++ b/sources/test/cg_test_exports.out.ref
@@ -161,4 +161,5 @@ DECLARE PROC out_decl_test_3 (x INTEGER);
 DECLARE PROC binary_ops_with_null ();
 DECLARE PROC uses_throw () USING TRANSACTION;
 DECLARE PROC uses_ifnull_throw (x INTEGER) USING TRANSACTION;
+DECLARE PROC out_object (o OBJECT NOT NULL) OUT (o OBJECT NOT NULL);
 DECLARE PROC end_proc ();

--- a/sources/test/cg_test_objc.out.ref
+++ b/sources/test/cg_test_objc.out.ref
@@ -2338,6 +2338,46 @@ static inline BOOL CGBVaultAliasColumnNameProcRowEqual(CGBVaultAliasColumnNamePr
   return CGCVaultAliasColumnNameProcRowEqual(CGCVaultAliasColumnNameProcFromCGBVaultAliasColumnNameProc(resultSet1), row1, CGCVaultAliasColumnNameProcFromCGBVaultAliasColumnNameProc(resultSet2), row2);
 }
 
+@class CGBOutObject;
+
+static inline CGBOutObject *CGBOutObjectFromCGCOutObject(CGCOutObjectResultSetRef resultSet)
+{
+  return (__bridge CGBOutObject *)resultSet;
+}
+
+static inline CGCOutObjectResultSetRef CGCOutObjectFromCGBOutObject(CGBOutObject *resultSet)
+{
+  return (__bridge CGCOutObjectResultSetRef)resultSet;
+}
+
+static inline NSObject * CGBOutObjectGetO(CGBOutObject *resultSet)
+{
+  CGCOutObjectResultSetRef cResultSet = CGCOutObjectFromCGBOutObject(resultSet);
+  return (__bridge NSObject *)CGCOutObjectGetO(cResultSet);
+}
+
+static inline int32_t CGBOutObjectResultCount(CGBOutObject *resultSet)
+{
+  return CGCOutObjectResultCount(CGCOutObjectFromCGBOutObject(resultSet));
+}
+
+static inline CGBOutObject *CGBOutObjectCopy(CGBOutObject *resultSet)
+{
+  CGCOutObjectResultSetRef copy;
+  CGCOutObjectCopy(CGCOutObjectFromCGBOutObject(resultSet), &copy);
+  return (__bridge_transfer CGBOutObject *)copy;
+}
+
+static inline NSUInteger CGBOutObjectHash(CGBOutObject *resultSet)
+{
+  return CGCOutObjectHash(CGCOutObjectFromCGBOutObject(resultSet));
+}
+
+static inline BOOL CGBOutObjectEqual(CGBOutObject *resultSet1, CGBOutObject *resultSet2)
+{
+  return CGCOutObjectEqual(CGCOutObjectFromCGBOutObject(resultSet1), CGCOutObjectFromCGBOutObject(resultSet2));
+}
+
 @class CGBFragTest;
 
 static inline CGCFragTestResultSetRef CGCExtFromCGBExt(CGBFragTest *resultSet)

--- a/sources/test/java_no_object.sql
+++ b/sources/test/java_no_object.sql
@@ -1,0 +1,7 @@
+
+create proc out_object_result_err(o object not null)
+begin
+  declare C cursor like out_object_result_err arguments;
+  fetch C from arguments;
+  out C;
+end;

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -2550,6 +2550,38 @@ BEGIN_TEST(encoded_null_values)
   EXPECT(C.bl0 IS null);
 END_TEST(encoded_null_values)
 
+
+declare proc obj_shape() out union (o object);
+declare proc not_null_obj_shape() out union (o object not null);
+
+create proc emit_object_result_set()
+begin
+  let _set := set_create();
+  declare C cursor like obj_shape;
+  fetch C using _set o;
+  out union C;
+end;
+
+create proc emit_object_result_set_not_null()
+begin
+  let _set := set_create();
+  declare C cursor like not_null_obj_shape;
+  fetch C using _set o;
+  out union C;
+end;
+
+BEGIN_TEST(object_result_set_value)
+  declare D cursor for call emit_object_result_set();
+  fetch D;
+  EXPECT(D);
+  EXPECT(D.o is not null);
+
+  declare E cursor for call emit_object_result_set_not_null();
+  fetch E;
+  EXPECT(E);
+  EXPECT(E.o is not null);
+END_TEST(object_result_set_value)
+
 @attribute(cql:vault_sensitive=(y))
 create procedure load_some_encoded_field()
 begin


### PR DESCRIPTION
the necessary support in copyoutrow was missing. Added some run tests to exercise out union with objects.  Adding some other missing coverage for error cases and such.  Removed dead return.