### PR TITLE
Additional changes to remove the last of the gcov warnings

### DIFF
--- a/sources/common/Makefile_common
+++ b/sources/common/Makefile_common
@@ -197,17 +197,30 @@ run_test_compressed: $O/cqltest.o $O/run_test_compressed.o $O/run_test_client.o 
 run_test_compat: $O/cqltest.o $O/run_test.o $O/run_test_client.o $O/result_set_extension.o $O/cqlrt_compat.o
 	$(CC) -o $O/run_test_compat $(CFLAGS) $(COMPAT_TEST_ARGS) $(SQLITE_LINK)
 
+# ensure that the same .o file is used exactly, rather than rebuilding from .c, this avoids gcov errors
+
 $O/upgrade_test.o: upgrade/upgrade_test.c
-	$(CC) -o $@ -c $(CFLAGS) upgrade/upgrade_test.c
+	$(CC) -o $@ -c $(CFLAGS) $<
+
+$O/downgrade_test.o: upgrade/downgrade_test.c
+	$(CC) -o $@ -c $(CFLAGS) $<
 
 $O/upgrade_validate.o: $O/upgrade_validate.c
 
-upgrade_test: $O/upgrade_test.o $O/upgrade_validate.o
-	$(CC) $(CFLAGS) -o $O/upgrade0 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade0.c $O/upgrade_test.o $(SQLITE_LINK)
-	$(CC) $(CFLAGS) -o $O/upgrade1 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade1.c $O/upgrade_test.o $(SQLITE_LINK)
-	$(CC) $(CFLAGS) -o $O/upgrade2 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade2.c $O/upgrade_test.o $(SQLITE_LINK)
-	$(CC) $(CFLAGS) -o $O/upgrade3 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade3.c $O/upgrade_test.o $(SQLITE_LINK)
-	$(CC) $(CFLAGS) -o $O/downgrade_test $O/cqlrt.o $O/generated_upgrade1.c upgrade/downgrade_test.c $(SQLITE_LINK)
+$O/generated_upgrade0.o: $O/generated_upgrade0.c
+
+$O/generated_upgrade1.o: $O/generated_upgrade1.c
+
+$O/generated_upgrade2.o: $O/generated_upgrade2.c
+
+$O/generated_upgrade3.o: $O/generated_upgrade3.c
+
+upgrade_test: $O/upgrade_test.o $O/upgrade_validate.o $O/generated_upgrade0.o $O/generated_upgrade1.o $O/generated_upgrade2.o $O/generated_upgrade3.o $O/downgrade_test.o
+	$(CC) $(CFLAGS) -o $O/upgrade0 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade0.o $O/upgrade_test.o $(SQLITE_LINK)
+	$(CC) $(CFLAGS) -o $O/upgrade1 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade1.o $O/upgrade_test.o $(SQLITE_LINK)
+	$(CC) $(CFLAGS) -o $O/upgrade2 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade2.o $O/upgrade_test.o $(SQLITE_LINK)
+	$(CC) $(CFLAGS) -o $O/upgrade3 $O/cqlrt.o $O/upgrade_validate.o $O/generated_upgrade3.o $O/upgrade_test.o $(SQLITE_LINK)
+	$(CC) $(CFLAGS) -o $O/downgrade_test $O/cqlrt.o $O/generated_upgrade1.o $O/downgrade_test.o $(SQLITE_LINK)
 
 query_plan_test: $O/query_plan_test.o $O/cqlrt.o $O/query_plan.o $O/udf.o
 	$(CC) $(CFLAGS) -o $O/query_plan_test $O/query_plan_test.o $O/cqlrt.o $O/query_plan.o $O/udf.o $(SQLITE_LINK)

--- a/sources/common/ok_common.sh
+++ b/sources/common/ok_common.sh
@@ -60,7 +60,7 @@ copy_ref cg_test_json_schema.out
 copy_ref cg_test_objc.out
 copy_ref cg_test_objc.err
 copy_ref cg_test_query_plan.out
-# query plan diff temporarily disbled until SQLite 3.32 changes are sorted out
+# query plan diff temporarily disabled until SQLite 3.32 changes are sorted out
 # copy_ref cg_test_query_plan_js.out
 copy_ref cg_test_schema_partial_upgrade.out
 copy_ref cg_test_schema_partial_upgrade.err

--- a/sources/common/test_common.sh
+++ b/sources/common/test_common.sh
@@ -1396,7 +1396,7 @@ query_plan_test() {
     failed
   fi
 
-  echo "query plan diff temporarily disbled until SQLite 3.32 changes are sorted out"
+  echo "query plan diff temporarily disabled until SQLite 3.32 changes are sorted out"
   # echo validating query plan view
   # echo "  computing diffs (empty if none)"
   # on_diff_exit cg_test_query_plan_js.out


### PR DESCRIPTION
This removes the last instances of the same file compiled two ways and hence the last warning from gcov.