### PR TITLE
Add references to appendix 10 in the right places.

### DIFF
--- a/CQL_Guide/ch02.md
+++ b/CQL_Guide/ch02.md
@@ -434,4 +434,6 @@ Which probably doesn't come up very often but it does illustrate several things:
  * `WITH RECURSIVE` actually provides a full lambda calculus so arbitrary computation is possible
  * You can use `WITH RECURSIVE` to create table expressions that are sequences of numbers easily, with no reference to any real data
 
-Note: A working version of this code can be found in the `sources/demo` directory of CG/SQL project.
+Note:
+ * A working version of this code can be found in the `sources/demo` directory of CG/SQL project.
+ * Additional demo code is avilable in [Appendix 10](https://cgsql.dev/cql-guide/x12).

--- a/CQL_Guide/ch07.md
+++ b/CQL_Guide/ch07.md
@@ -321,3 +321,5 @@ cql --in hello.sql --cg hello.h hello.c
 cc -o hello -I ${cgsql}/sources main.c hello.c ${cgsql}/sources/cqlrt.c -lsqlite3
 ./hello
 ```
+
+Additional demo code is avilable in [Appendix 10](https://cgsql.dev/cql-guide/x12).

--- a/CQL_Guide/generated/make_guide.sh
+++ b/CQL_Guide/generated/make_guide.sh
@@ -11,7 +11,17 @@ do
   ( cat "$f"; echo ""; echo "" ) >>guide.tmp
 done
 
-for f in ../x*.md
+# one digit appendices first
+for f in ../x?.md
+do
+  (cat "$f"; \
+   echo ""; \
+   echo ""; \
+   echo "" ) >>guide.tmp
+done
+
+# two digit appendices second
+for f in ../x??.md
 do
   (cat "$f"; \
    echo ""; \


### PR DESCRIPTION
Emit the guide in numeric order not sorted order (i.e. x10 goes after x9 not after x1)