### PR TITLE
Revisiting the handling of MIN_LONG (yet again)

### DIFF
--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -5164,6 +5164,27 @@ begin
   fetch C from blob make_blob();
 end;
 
+-- TEST: ensure that the max constants are getting handled correctly
+-- including the special cases to avoid compiler warnings.  Note that
+-- this code has to compile correctly in C to pass the test also.  Run
+-- time checks for this are in run_test.sql because this is subtle
+--
+-- +  big1 = _64(0x7fffffffffffffff);
+-- +  big2 = _64(0x8000000000000000);
+-- +  big3 = (_64(9223372036854775807)-1);
+-- +  big4 = (_64(9223372036854775807)-1);
+-- +  big5 = _64(9223372036854775807);
+-- +  big6 = _64(9223372036854775807);
+create proc bigstuff()
+begin
+  let big1 := 0x7fffffffffffffffL;
+  let big2 := 0x8000000000000000L;
+  let big3 := -9223372036854775808L;
+  let big4 := -9223372036854775808;
+  let big5 := 9223372036854775807L;
+  let big6 := 9223372036854775807;
+end;
+
 --------------------------------------------------------------------
 -------------------- add new tests before this point ---------------
 --------------------------------------------------------------------

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -16155,6 +16155,40 @@ cql_cleanup:
   return _rc_;
 }
 #undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC bigstuff ()
+BEGIN
+  LET big1 := 0x7fffffffffffffffL;
+  LET big2 := 0x8000000000000000L;
+  LET big3 := -9223372036854775808L;
+  LET big4 := -9223372036854775808L;
+  LET big5 := 9223372036854775807L;
+  LET big6 := 9223372036854775807L;
+END;
+*/
+
+#define _PROC_ "bigstuff"
+// export: DECLARE PROC bigstuff ();
+void bigstuff(void) {
+  cql_int64 big1 = 0;
+  cql_int64 big2 = 0;
+  cql_int64 big3 = 0;
+  cql_int64 big4 = 0;
+  cql_int64 big5 = 0;
+  cql_int64 big6 = 0;
+
+  big1 = _64(0x7fffffffffffffff);
+  big2 = _64(0x8000000000000000);
+  big3 = (_64(9223372036854775807)-1);
+  big4 = (_64(9223372036854775807)-1);
+  big5 = _64(9223372036854775807);
+  big6 = _64(9223372036854775807);
+
+}
+#undef _PROC_
 cql_int32 this_is_the_end = 0;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c.h.ref
+++ b/sources/test/cg_test_c.h.ref
@@ -3497,6 +3497,9 @@ extern cql_blob_ref _Nullable make_blob(void);
 extern CQL_WARN_UNUSED cql_code deserialize_func(sqlite3 *_Nonnull _db_);
 
 // The statement ending at line XXXX
+extern void bigstuff(void);
+
+// The statement ending at line XXXX
 extern cql_int32 this_is_the_end;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -16155,6 +16155,40 @@ cql_cleanup:
   return _rc_;
 }
 #undef _PROC_
+
+// The statement ending at line XXXX
+
+/*
+CREATE PROC bigstuff ()
+BEGIN
+  LET big1 := 0x7fffffffffffffffL;
+  LET big2 := 0x8000000000000000L;
+  LET big3 := -9223372036854775808L;
+  LET big4 := -9223372036854775808L;
+  LET big5 := 9223372036854775807L;
+  LET big6 := 9223372036854775807L;
+END;
+*/
+
+#define _PROC_ "bigstuff"
+// export: DECLARE PROC bigstuff ();
+void bigstuff(void) {
+  cql_int64 big1 = 0;
+  cql_int64 big2 = 0;
+  cql_int64 big3 = 0;
+  cql_int64 big4 = 0;
+  cql_int64 big5 = 0;
+  cql_int64 big6 = 0;
+
+  big1 = _64(0x7fffffffffffffff);
+  big2 = _64(0x8000000000000000);
+  big3 = (_64(9223372036854775807)-1);
+  big4 = (_64(9223372036854775807)-1);
+  big5 = _64(9223372036854775807);
+  big6 = _64(9223372036854775807);
+
+}
+#undef _PROC_
 cql_int32 this_is_the_end = 0;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_c_with_namespace.h.ref
+++ b/sources/test/cg_test_c_with_namespace.h.ref
@@ -3497,6 +3497,9 @@ extern cql_blob_ref _Nullable make_blob(void);
 extern CQL_WARN_UNUSED cql_code deserialize_func(sqlite3 *_Nonnull _db_);
 
 // The statement ending at line XXXX
+extern void bigstuff(void);
+
+// The statement ending at line XXXX
 extern cql_int32 this_is_the_end;
 
 // The statement ending at line XXXX

--- a/sources/test/cg_test_exports.out.ref
+++ b/sources/test/cg_test_exports.out.ref
@@ -224,4 +224,5 @@ DECLARE PROC use_nested_select_shared_frag_form () (x INTEGER NOT NULL);
 DECLARE PROC slash_star_and_star_slash ();
 DECLARE PROC blob_serialization_test () USING TRANSACTION;
 DECLARE PROC deserialize_func () USING TRANSACTION;
+DECLARE PROC bigstuff ();
 DECLARE PROC end_proc ();

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -4590,8 +4590,17 @@ BEGIN_TEST(serialization_tricky_values)
   call round_trip_long(-32769);
   call round_trip_long(0x7fffffffL); 
   call round_trip_long(-214783648L);
-  call round_trip_long(0x7fffffffffffffffL); // max int64
-  call round_trip_long(0x8000000000000000L); // min int64
+  call round_trip_long(0x7fffffffffffffffL);  -- max int64
+  call round_trip_long(0x8000000000000000L);  -- min int64
+
+  -- these are actually testing constant handling rather than
+  -- the blob but this is a convenient way to ensure that it was
+  -- all on the up and up.  Especially since we already confirmed
+  -- above that it works in hex.
+  call round_trip_long(-9223372036854775808L); -- min int64 in decimal
+  call round_trip_long(-9223372036854775808);  -- min int64 in decimal
+  call round_trip_long(9223372036854775807L);  -- max int64 in decimal
+  call round_trip_long(9223372036854775807);   -- max int64 in decimal
 END_TEST(serialization_tricky_values)
 
 declare proc rand_reset();


### PR DESCRIPTION
In light of what compilers demand in 2022 there is a special case for this value to avoid warnings now.