### PR TITLE
In upgrade test: Wrap the upgrade process in a transaction as is normally done.

### DIFF
--- a/sources/upgrade/upgrade_test.c
+++ b/sources/upgrade/upgrade_test.c
@@ -46,9 +46,14 @@ static int32_t _vtab_create(sqlite3 *_Nonnull db,
 }
 
 int32_t upgrade(sqlite3* db, bool should_use_virtual) {
-  int32_t rv;
-  sqlite3_module module;
+  cql_code rv;
+
+  if (begin_transaction(db)) {
+    fprintf(stderr, "failed to begin transaction\n");
+  }
+
   if (should_use_virtual) {
+    sqlite3_module module;
     module.iVersion = 1;
     module.xConnect = _vtab_connect;
     module.xCreate = _vtab_create;
@@ -59,16 +64,31 @@ int32_t upgrade(sqlite3* db, bool should_use_virtual) {
       NULL
     );
     if (rv != SQLITE_OK) {
+      fprintf(stderr, "failed sqlite3_create_module for test_module\n");
       return rv;
     }
+
     test_result_set_ref result_set;
     rv = test_fetch_results(db, &result_set);
+    if (rv != SQLITE_OK) {
+      fprintf(stderr, "failed fetching upgrade results (including virtuals)\n");
+      return rv;
+    }
     cql_result_set_release(result_set);
   } else {
     test_no_virtual_tables_result_set_ref result_set;
     rv = test_no_virtual_tables_fetch_results(db, &result_set);
+    if (rv != SQLITE_OK) {
+      fprintf(stderr, "failed fetching upgrade results (no virtuals)\n");
+      return rv;
+    }
     cql_result_set_release(result_set);
   }
+
+  if (commit_transaction(db)) {
+    fprintf(stderr, "failed to commit transaction\n");
+  }
+
   return rv;
 }
 
@@ -76,7 +96,7 @@ int32_t post_validate(sqlite3* db, cql_int64 old_version) {
   cql_int64 new_version = -1;
   cql_string_ref facet = cql_string_ref_new("cql_schema_version");
   if (test_cql_get_facet_version(db, facet, &new_version)) {
-    printf("Unable to read cql_schema_version facet\n");
+    fprintf(stderr, "Unable to read cql_schema_version facet\n");
     cql_string_release(facet);
     return SQLITE_ERROR;
   }
@@ -90,7 +110,7 @@ int32_t post_validate(sqlite3* db, cql_int64 old_version) {
   int32_t result = old_version <= new_version ? SQLITE_OK : SQLITE_ERROR;
 
   if (result != SQLITE_OK) {
-    printf("unexpected version old:%d, new:%d\n", (int32_t)old_version, (int32_t)new_version);
+    fprintf(stderr, "unexpected version old:%d, new:%d\n", (int32_t)old_version, (int32_t)new_version);
   }
 
   return result;
@@ -98,14 +118,14 @@ int32_t post_validate(sqlite3* db, cql_int64 old_version) {
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {
-    printf("Expected usage: ./upgrade_test /path/to/db/\n");
+    fprintf(stderr, "Expected usage: ./upgrade_test /path/to/db/\n");
     return SQLITE_ERROR;
   }
 
   sqlite3* db;
   if (sqlite3_open_v2(argv[1], &db,
       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL)) {
-    printf("Unable to open DB.\n");
+    fprintf(stderr, "Unable to open DB '%s'\n", argv[1]);
     return SQLITE_ERROR;
   }
 
@@ -115,48 +135,48 @@ int main(int argc, char *argv[]) {
 
   cql_int64 version = -1;
   if (pre_validate(db, &version)) {
-    printf("Unable to validate DB contents pre-upgrade.\n");
+    fprintf(stderr, "Unable to validate DB contents pre-upgrade.\n");
     return SQLITE_ERROR;
   }
 
   cql_int64 current_version = -1;
   cql_int64 proposed_version = -1;
   if (test_get_current_and_proposed_versions(db, &current_version, &proposed_version)) {
-    printf("Error getting current and proposed versions\n");
+    fprintf(stderr, "Error getting current and proposed versions\n");
     return SQLITE_ERROR;
   }
 
   if (current_version != version) {
-    printf("Error getting DB versions: current_version %lld does not match expected version: %lld", current_version, version);
+    fprintf(stderr, "Error getting DB versions: current_version %lld does not match expected version: %lld", current_version, version);
     return SQLITE_ERROR;
   }
 
   if (upgrade(db, should_use_virtual_tables)) {
-    printf("Unable to upgrade DB.\n");
+    fprintf(stderr, "Unable to upgrade DB.\n");
     return SQLITE_ERROR;
   }
 
   cql_int64 current_version_after = -1;
   cql_int64 proposed_version_after = -1;
   if (test_get_current_and_proposed_versions(db, &current_version_after, &proposed_version_after)) {
-    printf("Error getting current and proposed versions after upgrade\n");
+    fprintf(stderr, "Error getting current and proposed versions after upgrade\n");
     return SQLITE_ERROR;
   }
 
   if( proposed_version != current_version_after || proposed_version_after != current_version_after) {
-    printf("Error - proposed_version %lld (before upgrade) and current_version_after %lld"
+    fprintf(stderr, "Error - proposed_version %lld (before upgrade) and current_version_after %lld"
            " and proposed_version_after %lld do not match.",
           proposed_version, current_version_after, proposed_version_after);
     return SQLITE_ERROR;
   }
 
   if (post_validate(db, version)) {
-    printf("Unable to validate DB contents post-upgrade.\n");
+    fprintf(stderr, "Unable to validate DB contents post-upgrade.\n");
     return SQLITE_ERROR;
   }
 
   if (sqlite3_close_v2(db)) {
-    printf("Unable to close DB.\n");
+    fprintf(stderr, "Unable to close DB.\n");
     return SQLITE_ERROR;
   }
 

--- a/sources/upgrade/upgrade_validate.sql
+++ b/sources/upgrade/upgrade_validate.sql
@@ -153,3 +153,13 @@ begin
     throw;
   end;
 end;
+
+create proc begin_transaction()
+begin
+  BEGIN TRANSACTION;
+end;
+
+create proc commit_transaction()
+begin
+  COMMIT TRANSACTION;
+end;


### PR DESCRIPTION
This has the nice side effect of improving the speed of the upgrade test considerably.
Write diagnostics for fails consistently to stderr.
Added an option to include verbose error tracing in case of upgrader failure.

Note that the upgrader is not affected by this, it's still up to the caller to decide if/when to use a transaction.