### PR TITLE
assorted changes to allow lua backed tables to work

### DIFF
--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -1303,7 +1303,17 @@ static void gen_cql_blob_create(ast_node *ast) {
      ast_node *col = second_arg(args);
      gen_printf(", ");
      gen_root_expr(val);
-     if (!use_offsets) {
+     if (use_offsets) {
+       // when creating a key blob all columns are present in order, so no need to
+       // emit the offsets, they are assumed.  However, value blobs can have
+       // some or all of the values and might skip some
+       if (!is_pk) {
+         EXTRACT_STRING(cname, col->right);
+         int32_t offset = get_table_col_offset(table_ast, cname, CQL_SEARCH_COL_VALUES);
+         gen_printf(", %d", offset);
+       }
+     }
+     else {
        gen_printf(", ");
        gen_field_hash(col);
      }

--- a/sources/lua_demo/run_test.sh
+++ b/sources/lua_demo/run_test.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 lua_demo/prepare_run_test.sh
 lua out/run_test.lua
+xxxx
 
 echo "schema upgrade test"
 


### PR DESCRIPTION
it doesn't really work though because the luasqlite3 library gives you no way to return an int64 from a UDF losslessly so we can't do type hashes.  I hacked a version that did 32 bit type hashes and it passes.