### PR TITLE
Allow string literals in pieces (e.g. multiline)

### DIFF
--- a/sources/ast.h
+++ b/sources/ast.h
@@ -943,5 +943,6 @@ AST(blob_create_val_stmt)
 AST(blob_update_key_stmt)
 AST(blob_update_val_stmt)
 AST(seed_stub)
+AST(str_chain)
 
 #pragma clang diagnostic pop

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -78,6 +78,7 @@ static void parse_cleanup();
 static void cql_usage();
 static ast_node *make_statement_node(ast_node *misc_attrs, ast_node *any_stmt);
 static ast_node *make_coldef_node(ast_node *col_def_tye_attrs, ast_node *misc_attrs);
+static ast_node *reduce_str_chain(ast_node *str_chain);
 
 // Set to true upon a call to `yyerror`.
 static bool_t parse_error_occurred;
@@ -233,7 +234,7 @@ static void cql_reset_globals(void);
 %type <aval> col_key_list col_key_def col_def col_name
 %type <aval> version_attrs opt_version_attrs version_attrs_opt_recreate opt_delete_version_attr opt_delete_plain_attr
 %type <aval> misc_attr_key misc_attr misc_attrs misc_attr_value misc_attr_value_list
-%type <aval> col_attrs str_literal num_literal any_literal const_expr
+%type <aval> col_attrs str_literal num_literal any_literal const_expr str_chain str_leaf
 %type <aval> pk_def fk_def unq_def check_def fk_target_options opt_module_args opt_conflict_clause
 %type <aval> col_calc col_calcs column_calculation
 
@@ -945,8 +946,17 @@ data_type_with_options:
   ;
 
 str_literal:
-  STRLIT  { $str_literal = new_ast_str($STRLIT);}
-  | CSTRLIT  { $str_literal = new_ast_cstr($CSTRLIT); }
+  str_chain { $str_literal = reduce_str_chain($str_chain); }
+  ;
+
+str_chain[result]:
+  str_leaf { $result = new_ast_str_chain($str_leaf, NULL); }
+  | str_leaf str_chain[next] { $result = new_ast_str_chain($str_leaf, $next); }
+  ;
+
+str_leaf:
+  STRLIT  { $str_leaf = new_ast_str($STRLIT);}
+  | CSTRLIT  { $str_leaf = new_ast_cstr($CSTRLIT); }
   ;
 
 num_literal:
@@ -2888,4 +2898,37 @@ static ast_node *make_coldef_node(ast_node *col_def_type_attrs, ast_node *misc_a
   }
 
   return new_ast_col_def(col_def_type_attrs, misc_attrs);
+}
+
+static ast_node *reduce_str_chain(ast_node *str_chain) {
+  Contract(is_ast_str_chain(str_chain));
+
+  // trivial case, length one chain
+  if (!str_chain->right) {
+    return str_chain->left;
+  }
+
+  CHARBUF_OPEN(tmp);
+  CHARBUF_OPEN(result);
+
+  for (ast_node *item = str_chain; item; item = item->right) {
+    Invariant(is_ast_str_chain(item));
+    Invariant(is_ast_str(item->left));
+
+    str_ast_node *str_node = (str_ast_node *)item->left;
+    cg_decode_string_literal(str_node->value, &tmp);
+  }
+
+  cg_encode_string_literal(tmp.ptr, &result);
+  ast_node *lit = new_ast_str(Strdup(result.ptr));
+
+  // this just forces the literal to be echoed as a C literal
+  // so that it is prettier in the echoed output, otherwise no difference
+  // all literals are stored in SQL format.
+  ((str_ast_node *)lit)->cstr_literal = true;
+
+  CHARBUF_CLOSE(result);
+  CHARBUF_CLOSE(tmp);
+
+  return lit;
 }

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -77523,6 +77523,23 @@ END;
 
 The statement ending at line XXXX
 
+CREATE PROC string_chain ()
+BEGIN
+  LET z := "abc\n123\r\n\x02lmnop''";
+END;
+
+  {create_proc_stmt}: ok
+  | {name string_chain}: ok
+  | {proc_params_stmts}
+    | {stmt_list}: ok
+      | {let_stmt}: z: text notnull variable
+        | {name z}: z: text notnull variable
+        | {strlit 'abc
+123
+lmnop'''''}: text notnull
+
+The statement ending at line XXXX
+
 DECLARE PROC requires_out_text_notnull (OUT t TEXT NOT NULL);
 
   {declare_proc_stmt}: ok

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -19674,6 +19674,15 @@ begin
   let x := a;
 end;
 
+-- TEST: make a multi-part string literal
+-- +  LET z := "abc\n123\r\n\x02lmnop''";
+create proc string_chain()
+begin
+  let z := "abc\n" 
+     "123\r\n\x02" 
+     "lmnop''";
+end;
+
 -- Used in the following test.
 declare proc requires_out_text_notnull(out t text not null);
 

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -1795,6 +1795,8 @@ CREATE TABLE unary_plus_default_value(
 
 DECLARE PROC foo (LIKE X(-x));
 
+LET z := "abc\n123\r\n\x02lmnop''";
+
 SET file := 'path/I/do/not/like';
 
 SET file := 'long/path/I/do/not/like';

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1631,6 +1631,8 @@ create table unary_plus_default_value(
 
 declare proc foo(like X(-x));
 
+let z := "abc\n" "123\r\n\x02" "lmnop''";
+
 --- keep this at the end because the line numbers will be whack after this so syntax errors will be annoying...
 
 # 1 "long/path/I/do/not/like"
@@ -1640,3 +1642,4 @@ declare proc foo(like X(-x));
 set file := @FILE('path/');  -- take starting at path
 set file := @FILE('');  -- keep the whole string
 set file := @FILE('xxxx');  -- pattern not found, keep it all
+


### PR DESCRIPTION
This allows string literals of the form

```
let z := "abc" 
 '"'
 "'" 
"def" "ghi";
```

