### PR TITLE
Support default values in insert statements on backed tables

### DIFF
--- a/sources/ast.h
+++ b/sources/ast.h
@@ -209,6 +209,16 @@ extern minipool *_Nullable ast_pool;
   Contract(current_file && yylineno > 0); \
   ast_reset_rewrite_info()
 
+// any new nodes will be charged to this location
+#define AST_REWRITE_INFO_SAVE() \
+  int32_t lineno_saved = yylineno; \
+  CSTR current_file_saved = current_file;
+
+// reset the location to make sure it's not used by the next new nodes
+#define AST_REWRITE_INFO_RESTORE() \
+  ast_set_rewrite_info(lineno_saved, current_file_saved);
+
+
 cql_noexport void ast_set_rewrite_info(int32_t lineno, CSTR _Nonnull filename);
 cql_noexport void ast_reset_rewrite_info(void);
 

--- a/sources/sem.h
+++ b/sources/sem.h
@@ -314,6 +314,7 @@ cql_noexport sem_node *new_sem(sem_t sem_type);
 cql_noexport bool_t sem_verify_assignment(ast_node *ast, sem_t sem_type_needed, sem_t sem_type_found, CSTR var_name);
 cql_noexport void sem_select(ast_node *node);
 cql_noexport ast_node *sem_recover_with_stmt(ast_node *ast);
+cql_noexport ast_node *sem_skip_with(ast_node *ast);
 
 #endif
 
@@ -344,7 +345,6 @@ cql_data_decl( cte_state *cte_cur );
 cql_data_decl( symtab *ref_sources_for_target_table );
 cql_data_decl( symtab *ref_targets_for_source_table );
 
-
 // True if we are presently emitting a vault stored proc.
 // A stored proc with attribution vault_sensitive is a vault stored proc
 cql_data_decl( bool_t use_encode );
@@ -368,3 +368,8 @@ cql_data_decl( bool_t in_upsert_rewrite );
 
 // hold the table ast query in the current upsert statement.
 cql_data_decl ( ast_node *current_upsert_table_ast );
+
+// When processing the schema, record default values for each table
+// so that we can find them quickly.  This is a symbol table of symbol tables.
+// We store them here rather than on the sem_node because they are sparse
+cql_data_decl( symtab *table_default_values );

--- a/sources/symtab.c
+++ b/sources/symtab.c
@@ -196,6 +196,11 @@ cql_noexport symtab *_Nonnull symtab_ensure_symtab(symtab *syms, const char *nam
   return value;
 }
 
+cql_noexport bool_t symtab_add_symtab(symtab *syms, CSTR name, symtab *data) {
+  syms->teardown = symtab_teardown;
+  return symtab_add(syms, name, (void*)data);
+}
+
 static void bytebuf_teardown(void *val) {
   bytebuf_close((bytebuf*)val);
   free(val);

--- a/sources/symtab.h
+++ b/sources/symtab.h
@@ -38,6 +38,7 @@ cql_noexport symtab_entry *_Nullable symtab_find(symtab *_Nullable syms, const c
 cql_noexport bytebuf *_Nonnull symtab_ensure_bytebuf(symtab *_Nonnull syms, const char *_Nonnull sym_new);
 cql_noexport void symtab_append_bytes(symtab *_Nonnull syms, const char *_Nonnull sym_new, const void *_Nullable bytes, size_t count);
 cql_noexport symtab *_Nonnull symtab_ensure_symtab(symtab *_Nonnull syms, const char *_Nonnull name);
+cql_noexport bool_t symtab_add_symtab(symtab *_Nonnull syms, CSTR _Nonnull name, symtab *_Nonnull data);
 cql_noexport charbuf *_Nonnull symtab_ensure_charbuf(symtab *_Nonnull syms, const char *_Nonnull sym_new);
 
 // patternlint-disable-next-line prefer-sized-ints-in-msys

--- a/sources/test/run_test.sql
+++ b/sources/test/run_test.sql
@@ -5615,6 +5615,10 @@ BEGIN_TEST(blob_funcs)
   EXPECT(2345 == (select bgetval(b,0)));
   EXPECT(3456 == (select bgetval(b,1)));
 
+
+END_TEST(blob_funcs)
+
+BEGIN_TEST(backed_tables)
   -- seed some data
   insert into backed values (1, 100, 101), (2, 200, 201);
 
@@ -5665,6 +5669,37 @@ BEGIN_TEST(blob_funcs)
   insert into backed2(id) values(1);
   EXPECT(1 == (select id from backed2));
 END_TEST(blob_funcs)
+
+@attribute(cql:backed_by=backing)
+create table backed_table_with_defaults(
+  pk1 integer default 1000,
+  pk2 integer default 2000,
+  x int default 3000,
+  y int default 4000,
+  constraint pk primary key (pk1, pk2)
+);
+
+BEGIN_TEST(backed_tables_default_values)
+
+  insert into backed_table_with_defaults(pk1, x) values (1, 100), (2, 200);
+  declare C cursor for select * from backed_table_with_defaults;
+  -- verify default values inserted
+  fetch C;
+  EXPECT(C);
+  EXPECT(C.pk1 = 1);
+  EXPECT(C.pk2 = 2000);
+  EXPECT(C.x = 100);
+  EXPECT(C.y = 4000);
+  fetch C;
+  EXPECT(C);
+  EXPECT(C.pk1 = 2);
+  EXPECT(C.pk2 = 2000);
+  EXPECT(C.x = 200);
+  EXPECT(C.y = 4000);
+  fetch C;
+  EXPECT(NOT C);
+
+END_TEST(backed_tables_default_values)
 
 #endif
 

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1571,7 +1571,6 @@ test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not su
 test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 'id' specifies auto increment in 'autoinc_col_backed'
 test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 'id' has a check expression in 'check_col_backed'
 test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 't' specifies collation order in 'collate_col_backed'
-test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 'id' has a default value in 'default_value_col_backed'
 test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 't' has delete attribute in 'deleted_col_backed'
 test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 't' has create attribute in 'created_col_backed'
 test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: @recreate attribute doesn't match the backing table 'recreate_backed'

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -86871,38 +86871,46 @@ The statement ending at line XXXX
 
 @ATTRIBUTE(cql:backed_by=simple_backing_table)
 CREATE TABLE default_value_col_backed(
-  id INTEGER DEFAULT 5,
+  id INTEGER PRIMARY KEY,
+  x INTEGER NOT NULL DEFAULT 7,
   t TEXT
 );
 
-test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0487: table is not suitable for use as backed storage: column 'id' has a default value in 'default_value_col_backed'
-
-  {stmt_and_attr}: err
+  {stmt_and_attr}: ok
   | {misc_attrs}: ok
   | | {misc_attr}
   |   | {dot}
   |   | | {name cql}
   |   | | {name backed_by}
   |   | {name simple_backing_table}: ok
-  | {create_table_stmt}: err
+  | {create_table_stmt}: default_value_col_backed: { id: integer notnull primary_key, x: integer notnull has_default, t: text } backed
     | {create_table_name_flags}
     | | {table_flags_attrs}
     | | | {int 0}
     | | {name default_value_col_backed}
     | {col_key_list}
-      | {col_def}: id: integer has_default
+      | {col_def}: id: integer notnull primary_key
       | | {col_def_type_attrs}: ok
       |   | {col_def_name_type}
       |   | | {name id}
       |   | | {type_int}: integer
-      |   | {col_attrs_default}: ok
-      |     | {int 5}: integer notnull
+      |   | {col_attrs_pk}: ok
+      |     | {autoinc_and_conflict_clause}
       | {col_key_list}
-        | {col_def}: t: text
-          | {col_def_type_attrs}: ok
-            | {col_def_name_type}
-              | {name t}
-              | {type_text}: text
+        | {col_def}: x: integer notnull has_default
+        | | {col_def_type_attrs}: ok
+        |   | {col_def_name_type}
+        |   | | {name x}
+        |   | | {type_int}: integer
+        |   | {col_attrs_not_null}: ok
+        |     | {col_attrs_default}
+        |       | {int 7}: integer notnull
+        | {col_key_list}
+          | {col_def}: t: text
+            | {col_def_type_attrs}: ok
+              | {col_def_name_type}
+                | {name t}
+                | {type_text}: text
 
 The statement ending at line XXXX
 
@@ -88384,6 +88392,172 @@ test/sem_test.sql:XXXX:1: error: in create_table_stmt : CQL0488: the indicated t
           |     |               | {name simple_backing_table}
           |     |               | {name k}
           |     | {select_from_etc}: ok
+          |       | {select_where}
+          |         | {select_groupby}
+          |           | {select_having}
+          | {select_orderby}
+            | {select_limit}
+              | {select_offset}
+
+The statement ending at line XXXX
+
+@ATTRIBUTE(cql:backed_by=simple_backing_table)
+CREATE TABLE bt_default(
+  pk1 INTEGER DEFAULT 2222,
+  pk2 INTEGER DEFAULT 99,
+  x INTEGER DEFAULT 1111,
+  y INTEGER DEFAULT 42,
+  CONSTRAINT pk PRIMARY KEY (pk1, pk2)
+);
+
+  {stmt_and_attr}: ok
+  | {misc_attrs}: ok
+  | | {misc_attr}
+  |   | {dot}
+  |   | | {name cql}
+  |   | | {name backed_by}
+  |   | {name simple_backing_table}: ok
+  | {create_table_stmt}: bt_default: { pk1: integer notnull has_default partial_pk, pk2: integer notnull has_default partial_pk, x: integer has_default, y: integer has_default } backed
+    | {create_table_name_flags}
+    | | {table_flags_attrs}
+    | | | {int 0}
+    | | {name bt_default}
+    | {col_key_list}
+      | {col_def}: pk1: integer notnull has_default partial_pk
+      | | {col_def_type_attrs}: ok
+      |   | {col_def_name_type}
+      |   | | {name pk1}
+      |   | | {type_int}: integer
+      |   | {col_attrs_default}: ok
+      |     | {int 2222}: integer notnull
+      | {col_key_list}
+        | {col_def}: pk2: integer notnull has_default partial_pk
+        | | {col_def_type_attrs}: ok
+        |   | {col_def_name_type}
+        |   | | {name pk2}
+        |   | | {type_int}: integer
+        |   | {col_attrs_default}: ok
+        |     | {int 99}: integer notnull
+        | {col_key_list}
+          | {col_def}: x: integer has_default
+          | | {col_def_type_attrs}: ok
+          |   | {col_def_name_type}
+          |   | | {name x}
+          |   | | {type_int}: integer
+          |   | {col_attrs_default}: ok
+          |     | {int 1111}: integer notnull
+          | {col_key_list}
+            | {col_def}: y: integer has_default
+            | | {col_def_type_attrs}: ok
+            |   | {col_def_name_type}
+            |   | | {name y}
+            |   | | {type_int}: integer
+            |   | {col_attrs_default}: ok
+            |     | {int 42}: integer notnull
+            | {col_key_list}
+              | {pk_def}
+                | {name pk}
+                | {indexed_columns_conflict_clause}
+                  | {indexed_columns}
+                    | {indexed_column}
+                    | | {name pk1}: pk1: integer
+                    | {indexed_columns}
+                      | {indexed_column}
+                        | {name pk2}: pk2: integer
+
+The statement ending at line XXXX
+
+WITH
+_vals (pk1, x) AS (VALUES(1, 2))
+INSERT INTO simple_backing_table(k, v) SELECT cql_blob_create(bt_default, V.pk1, bt_default.pk1, 99, bt_default.pk2), cql_blob_create(bt_default, V.x, bt_default.x, 42, bt_default.y)
+  FROM _vals AS V;
+
+  {with_insert_stmt}: ok
+  | {with}
+  | | {cte_tables}: ok
+  |   | {cte_table}: _vals: { pk1: integer notnull, x: integer notnull }
+  |     | {cte_decl}: _vals: { pk1: integer notnull, x: integer notnull }
+  |     | | {name _vals}
+  |     | | {name_list}
+  |     |   | {name pk1}: pk1: integer notnull partial_pk
+  |     |   | {name_list}
+  |     |     | {name x}: x: integer
+  |     | {select_stmt}: values: { column1: integer notnull, column2: integer notnull }
+  |       | {select_core_list}: values: { column1: integer notnull, column2: integer notnull }
+  |       | | {select_core}: values: { column1: integer notnull, column2: integer notnull }
+  |       |   | {select_values}
+  |       |   | {values}: values: { column1: integer notnull, column2: integer notnull }
+  |       |     | {insert_list}: ok
+  |       |       | {int 1}: integer notnull
+  |       |       | {insert_list}
+  |       |         | {int 2}: integer notnull
+  |       | {select_orderby}
+  |         | {select_limit}
+  |           | {select_offset}
+  | {insert_stmt}: ok
+    | {insert_normal}
+    | {name_columns_values}
+      | {name simple_backing_table}: simple_backing_table: { k: blob notnull primary_key, v: blob notnull } backing
+      | {columns_values}: ok
+        | {column_spec}
+        | | {name_list}
+        |   | {name k}: k: blob notnull
+        |   | {name_list}
+        |     | {name v}: v: blob notnull
+        | {select_stmt}: select: { _anon: blob notnull, _anon: blob notnull }
+          | {select_core_list}: select: { _anon: blob notnull, _anon: blob notnull }
+          | | {select_core}: select: { _anon: blob notnull, _anon: blob notnull }
+          |   | {select_expr_list_con}: select: { _anon: blob notnull, _anon: blob notnull }
+          |     | {select_expr_list}: select: { _anon: blob notnull, _anon: blob notnull }
+          |     | | {select_expr}: blob notnull
+          |     | | | {call}: blob notnull
+          |     | |   | {name cql_blob_create}: blob notnull
+          |     | |   | {call_arg_list}
+          |     | |     | {call_filter_clause}
+          |     | |     | {arg_list}: ok
+          |     | |       | {name bt_default}
+          |     | |       | {arg_list}
+          |     | |         | {dot}: pk1: integer notnull
+          |     | |         | | {name V}
+          |     | |         | | {name pk1}
+          |     | |         | {arg_list}
+          |     | |           | {dot}: integer notnull has_default partial_pk
+          |     | |           | | {name bt_default}
+          |     | |           | | {name pk1}
+          |     | |           | {arg_list}
+          |     | |             | {int 99}: integer notnull
+          |     | |             | {arg_list}
+          |     | |               | {dot}: integer notnull has_default partial_pk
+          |     | |                 | {name bt_default}
+          |     | |                 | {name pk2}
+          |     | | {select_expr_list}
+          |     |   | {select_expr}: blob notnull
+          |     |     | {call}: blob notnull
+          |     |       | {name cql_blob_create}: blob notnull
+          |     |       | {call_arg_list}
+          |     |         | {call_filter_clause}
+          |     |         | {arg_list}: ok
+          |     |           | {name bt_default}
+          |     |           | {arg_list}
+          |     |             | {dot}: x: integer notnull
+          |     |             | | {name V}
+          |     |             | | {name x}
+          |     |             | {arg_list}
+          |     |               | {dot}: integer has_default
+          |     |               | | {name bt_default}
+          |     |               | | {name x}
+          |     |               | {arg_list}
+          |     |                 | {int 42}: integer notnull
+          |     |                 | {arg_list}
+          |     |                   | {dot}: integer has_default
+          |     |                     | {name bt_default}
+          |     |                     | {name y}
+          |     | {select_from_etc}: TABLE { V: _vals }
+          |       | {table_or_subquery_list}: TABLE { V: _vals }
+          |       | | {table_or_subquery}: TABLE { V: _vals }
+          |       |   | {name _vals}: TABLE { V: _vals }
+          |       |   | {opt_as_alias}
+          |       |     | {name V}
           |       | {select_where}
           |         | {select_groupby}
           |           | {select_having}


### PR DESCRIPTION
Any columns with available default values that have not been manually added to the insert statement are added.  This simulates what SQLite would do with missing columns.