### PR TITLE
Fixes for a better code generation for prepared statements inside loops

### DIFF
--- a/sources/cg_common.h
+++ b/sources/cg_common.h
@@ -71,10 +71,18 @@ charbuf *tag##_main_saved = cg_main_output; \
 int32_t tag##_indent = indent; \
 cg_main_output = &tag##_buf; \
 
+#define CG_PUSH_MAIN_INDENT2(tag) \
+CG_PUSH_MAIN_INDENT(tag, 2)
+
 #define CG_POP_MAIN_INDENT(tag) \
 cg_main_output = tag##_main_saved; \
 bindent(cg_main_output, &tag##_buf, tag##_indent); \
 CHARBUF_CLOSE(tag##_buf);
+
+#define MK_TMP_STMT_STR(idx) \
+  char tmp_stmt_name_idx[64]; \
+  snprintf(tmp_stmt_name_idx, sizeof(tmp_stmt_name_idx), "_temp%d_stmt", idx)
+
 
 // Make a temporary buffer for the evaluation results using the canonical
 // naming convention.  This might exit having burned some stack slots

--- a/sources/cql.h
+++ b/sources/cql.h
@@ -581,6 +581,9 @@ typedef struct rtdata {
   // Template for the java method copy.
   const char *cql_result_set_copy;
 
+  // The target type for NULL object value.
+  const char *cql_target_null;
+
   void (*cql_post_common_init)(void);
 } rtdata;
 

--- a/sources/cqlrt.lua
+++ b/sources/cqlrt.lua
@@ -461,6 +461,10 @@ function cql_step(stmt)
   return stmt:step()
 end
 
+function cql_reset_stmt(stmt)
+  return stmt:reset()
+end
+
 function cql_exec(db, sql)
   return db:exec(sql)
 end

--- a/sources/rt_common.c
+++ b/sources/rt_common.c
@@ -103,6 +103,7 @@ static rtdata rt_c = {
   .cql_result_set_set_string = "cql_result_set_set_string_col",
   .cql_result_set_set_object = "cql_result_set_set_object_col",
   .cql_result_set_set_blob = "cql_result_set_set_blob_col",
+  .cql_target_null = "NULL",
 };
 
 static rtdata rt_lua = {
@@ -243,6 +244,7 @@ static rtdata rt_java = {
     "  }\n"
     "  return new %s(resultSet);\n"
     "}\n\n",
+  .cql_target_null = "null",
 };
 
 static rtdata rt_schema_upgrade = {

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -496,20 +496,20 @@ fetch exchange_cursor into arg1, arg2;
 close exchange_cursor;
 
 -- TEST: simple nested select
--- + _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- + _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +  "SELECT ? + 1"
--- + cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+-- + cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, i2);
 -- + if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
--- + _rc_ = sqlite3_step(_temp_stmt);
+-- + _rc_ = sqlite3_step(_temp0_stmt);
 -- + if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
--- + i2 = sqlite3_column_int(_temp_stmt, 0);
--- + cql_finalize_stmt(&_temp_stmt);
+-- + i2 = sqlite3_column_int(_temp0_stmt, 0);
+-- + cql_finalize_stmt(&_temp0_stmt);
 set i2 := (select i2+1);
 
 -- TEST: nested select with nullable
 -- validate just the different bit
--- + cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+-- + cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
 -- +               CQL_DATA_TYPE_INT32, &i0_nullable);
 set i0_nullable := (select i0_nullable+1);
 
@@ -519,7 +519,7 @@ set i0_nullable := (select i0_nullable+1);
 delete from bar where name like '\\ " \n';
 
 -- TEST: binding an out parameter
--- + cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+-- + cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, *foo);
 create procedure outparm_test(out foo integer not null)
 begin
@@ -1321,7 +1321,7 @@ end;
 -- + @DUMMY_SEED(123) @DUMMY_DEFAULTS @DUMMY_NULLABLES;
 -- + _seed_ = 123;
 -- + "INSERT INTO bar(id, name, rate, type, size) VALUES(?, printf('name_%d', ?), ?, ?, ?)"
--- + cql_multibind(&_rc_, _db_, &_temp_stmt, 5,
+-- + cql_multibind(&_rc_, _db_, &_temp0_stmt, 5,
 -- +4              CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_);
 create proc dummy_user()
@@ -1470,11 +1470,11 @@ create table blob_table (
 );
 
 -- TEST: fetch a nullable blob
--- + cql_column_nullable_blob_ref(_temp_stmt, 0, &blob_var);
+-- + cql_column_nullable_blob_ref(_temp0_stmt, 0, &blob_var);
 set blob_var := (select b_nullable from blob_table where blob_id = 1);
 
 -- TEST: fetch a not null blob
--- + cql_column_blob_ref(_temp_stmt, 0, &_tmp_blob_0);
+-- + cql_column_blob_ref(_temp0_stmt, 0, &_tmp_blob_0);
 set blob_var := (select b_notnull from blob_table where blob_id = 1);
 
 -- some not null blob object we can use
@@ -1486,7 +1486,7 @@ set blob_var_notnull := blob_notnull_func();
 -- TEST: bind a nullable blob and a not null blob
 -- + INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
 -- + "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)"
--- + cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+-- + cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
 -- +               CQL_DATA_TYPE_BLOB, blob_var,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
 insert into blob_table(blob_id, b_nullable, b_notnull) values(0, blob_var, blob_var_notnull);
@@ -1869,7 +1869,7 @@ end;
 declare select func SqlUserFunc(id integer) real not null;
 
 -- TEST: invoke a declared user function
--- + _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- + _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +  "SELECT SqlUserFunc(123)"
 set r2 := (select SqlUserFunc(123));
 
@@ -1885,7 +1885,7 @@ set r2 := (select SqlUserFunc(123));
 -- + cql_int32 id_, cql_string_ref _Nullable name_, cql_nullable_int64 rate_, cql_nullable_int32 type_,
 -- + cql_nullable_double size_, cql_int32 *_Nonnull out_arg)
 -- + "INSERT INTO blob_table(blob_id, b_notnull, b_nullable) VALUES(?, ?, ?)"
--- + cql_multibind(&_rc_, _db_, &_temp_stmt, 3,
+-- + cql_multibind(&_rc_, _db_, &_temp0_stmt, 3,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, blob_id_,
 -- +               CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, b_notnull_,
 -- +               CQL_DATA_TYPE_BLOB, b_nullable_);
@@ -2097,22 +2097,22 @@ set i2 := 'x' LIKE 'y';
 set i2 := 'x' NOT LIKE 'y';
 
 -- TEST: use like in a SQL statement
--- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- +  _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +  "SELECT 'x' LIKE 'y'"
 set i2 := (select 'x' LIKE 'y');
 
 -- TEST: use not like in a SQL statement
--- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- +  _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +  "SELECT 'x' NOT LIKE 'y'"
 set i2 := (select 'x' NOT LIKE 'y');
 
 -- TEST: use match in a SQL statement
--- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- +  _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +  "SELECT 'x' MATCH 'y'"
 set i2 := (select 'x' MATCH 'y');
 
 -- TEST: use glob in a SQL statement
--- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- +  _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +  "SELECT 'x' GLOB 'y'"
 set i2 := (select 'x' GLOB 'y');
 
@@ -2448,7 +2448,7 @@ BEGIN
 END;
 
 -- TEST: try to use a WITH_SELECT form in a select expression
--- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- +  _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +   "WITH "
 -- +   "threads2 (count) AS (SELECT 1) "
 -- +   "SELECT COUNT(*) "
@@ -2702,7 +2702,7 @@ begin
 end;
 
 -- TEST: generate a compound select statement in an expression (this is a legal form)
--- + _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- + _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- + "SELECT 1 "
 -- + "WHERE 0 "
 -- + "UNION "
@@ -3834,7 +3834,7 @@ insert into virtual_with_hidden(vx, vy) values(1,2);
 -- TEST: get row from the bar table or else -1
 -- + if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
 -- + if (_rc_ == SQLITE_ROW) {
--- +   cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+-- +   cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
 -- +   cql_set_nullable(i0_nullable, _tmp_n_int_1.is_null, _tmp_n_int_1.value);
 -- + }
 -- + else {
@@ -3845,18 +3845,18 @@ set i0_nullable := (select type from bar if nothing -1);
 -- TEST: normal code gen for if nothing throw
 -- + SET i0_nullable := ( SELECT type
 -- + FROM bar IF NOTHING THROW );
--- + _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- + _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- +   "SELECT type "
 -- +     "FROM bar");
 -- + if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
--- + _rc_ = sqlite3_step(_temp_stmt);
+-- + _rc_ = sqlite3_step(_temp0_stmt);
 -- + if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
 set i0_nullable := (select type from bar if nothing throw);
 
 -- TEST: get row from bar if no row or null -1
 -- + if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
 -- + if (_rc_ == SQLITE_ROW) {
--- +   cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+-- +   cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
 -- + }
 -- + if (_rc_ == SQLITE_DONE || _tmp_n_int_1.is_null) {
 -- +   i2 = - 1;
@@ -3868,7 +3868,7 @@ set i2 := (select type from bar if nothing or null -1);
 -- TEST: get row from the bar table or else ""
 -- + if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
 -- + if (_rc_ == SQLITE_ROW) {
--- +   cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+-- +   cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
 -- +   cql_set_string_ref(&t0_nullable, _tmp_n_text_1);
 -- + }
 -- + else {
@@ -3879,7 +3879,7 @@ set t0_nullable := (select name from bar if nothing "");
 -- TEST: get row from the bar table or else "garbonzo"
 -- + if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
 -- + if (_rc_ == SQLITE_ROW) {
--- +   cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+-- +   cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
 -- + }
 -- + if (_rc_ == SQLITE_DONE || !_tmp_n_text_1) {
 -- +   cql_set_string_ref(&t2, _literal_%_garbonzo_);
@@ -5207,7 +5207,7 @@ begin
 end;
 
 -- TEST: likely() is correctly emitted
--- +  _rc_ = cql_prepare(_db_, &_temp_stmt,
+-- +  _rc_ = cql_prepare(_db_, &_temp0_stmt,
 -- + "SELECT likely(1)");
 -- + if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
 set b2 := ( select likely(1) );

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -829,7 +829,7 @@ DECLARE arg2 INTEGER NOT NULL;
 cql_int32 arg2 = 0;
 sqlite3_stmt *exchange_cursor_stmt = NULL;
 cql_bool _exchange_cursor_has_row_ = 0;
-sqlite3_stmt *_temp_stmt = NULL;
+sqlite3_stmt *_temp0_stmt = NULL;
 
 // The statement ending at line XXXX
 
@@ -850,22 +850,22 @@ CQL_WARN_UNUSED cql_code outparm_test(sqlite3 *_Nonnull _db_, cql_int32 *_Nonnul
   cql_contract_argument_notnull((void *)foo, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *foo = 0; // set out arg to non-garbage
   *foo = 1;
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "DELETE FROM bar WHERE id = ?");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, *foo);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -2764,21 +2764,21 @@ DECLARE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER) USING TRANSACTI
 */
 CQL_WARN_UNUSED cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cql_nullable_int32 type_) {
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO bar(id, type) VALUES(?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_,
                 CQL_DATA_TYPE_INT32, &type_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -3046,25 +3046,25 @@ DECLARE PROC dummy_user () USING TRANSACTION;
 CQL_WARN_UNUSED cql_code dummy_user(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_int32 _seed_ = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   _seed_ = 123;
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO bar(id, name, rate, type, size) VALUES(?, printf('name_%d', ?), ?, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 5,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 5,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -4609,24 +4609,24 @@ CQL_WARN_UNUSED cql_code multi_rewrite(sqlite3 *_Nonnull _db_, cql_int32 blob_id
   cql_contract_argument_notnull((void *)out_arg, 9);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *out_arg = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO blob_table(blob_id, b_notnull, b_nullable) VALUES(?, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 3,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 3,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, blob_id_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, b_notnull_,
                 CQL_DATA_TYPE_BLOB, b_nullable_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   *out_arg = 1;
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -4900,7 +4900,7 @@ CQL_WARN_UNUSED cql_code call_in_loop(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     cql_finalize_stmt(&C_stmt);
     _rc_ = simple_select(_db_, &C_stmt);
@@ -4957,7 +4957,7 @@ CQL_WARN_UNUSED cql_code call_in_loop_with_nullable_condition(sqlite3 *_Nonnull 
   cql_set_notnull(i, 0);
   for (;;) {
   cql_set_nullable(_tmp_n_bool_0, i.is_null, i.value < 5);
-  if (!cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) break;
+    if (!cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) break;
     cql_set_nullable(i, i.is_null, i.value + 1);
     cql_finalize_stmt(&C_stmt);
     _rc_ = simple_select(_db_, &C_stmt);
@@ -5019,7 +5019,7 @@ CQL_WARN_UNUSED cql_code call_in_loop_boxed(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     C_stmt = NULL;
     _rc_ = simple_select(_db_, &C_stmt);
@@ -5233,7 +5233,7 @@ CQL_WARN_UNUSED cql_code call_out_union_in_loop(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     cql_object_release(C_result_set_);
     out_union_helper_fetch_results(&C_result_set_);
@@ -6594,23 +6594,23 @@ CQL_WARN_UNUSED cql_code use_with_select(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_nullable_int32 x = { .is_null = 1 };
   cql_int32 _tmp_int_0 = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "WITH "
     "threads2 (count) AS (SELECT 1) "
     "SELECT COUNT(*) "
       "FROM threads2");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(x, _tmp_int_0);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -6741,21 +6741,21 @@ DECLARE PROC upsert_do_nothing (id_ INTEGER NOT NULL) USING TRANSACTION;
 */
 CQL_WARN_UNUSED cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_) {
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO foo(id) VALUES(?) "
     "ON CONFLICT DO NOTHING");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -7500,24 +7500,24 @@ CQL_WARN_UNUSED cql_code compound_select_expr(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_nullable_int32 x = { .is_null = 1 };
   cql_int32 _tmp_int_0 = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 1 "
       "WHERE 0 "
     "UNION "
     "SELECT 2 "
     "LIMIT 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(x, _tmp_int_0);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -7842,7 +7842,7 @@ CQL_WARN_UNUSED cql_code empty_blocks(sqlite3 *_Nonnull _db_) {
     }
   }
   for (;;) {
-  if (!(1)) break;
+    if (!(1)) break;
   }
   _rc_ = cql_prepare(_db_, &c_stmt,
     "SELECT 1");
@@ -13374,7 +13374,7 @@ void out_decl_loop_test(cql_nullable_int32 x) {
   cql_int32 v = 0;
 
   for (;;) {
-  if (!(1)) break;
+    if (!(1)) break;
     out2_proc(x, &u, &v);
     out2_proc(x, &u, &v);
   }
@@ -17499,10 +17499,10 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
   cql_contract_argument_notnull((void *)x, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *x = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare_var(_db_, &_temp_stmt,
+  _rc_ = cql_prepare_var(_db_, &_temp0_stmt,
     3, NULL,
   "WITH "
     "backed (rowid, pk, flag, id, name, age, storage) AS (",
@@ -17514,14 +17514,14 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
       "FROM backed"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    *x = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    *x = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -17591,10 +17591,10 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
   cql_contract_argument_notnull((void *)x, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *x = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare_var(_db_, &_temp_stmt,
+  _rc_ = cql_prepare_var(_db_, &_temp0_stmt,
     3, NULL,
   "WITH "
     "backed (rowid, pk, flag, id, name, age, storage) AS (",
@@ -17606,14 +17606,14 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
       "FROM backed"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    *x = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    *x = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -17862,33 +17862,33 @@ CQL_WARN_UNUSED cql_code test_blob_update_expand(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_blob_ref b = NULL;
   cql_blob_ref x = NULL;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
   cql_blob_ref z = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT bupdatekey(?, 0, 1)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, b);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &x);
-  cql_finalize_stmt(&_temp_stmt);
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+    cql_column_blob_ref(_temp0_stmt, 0, &x);
+  cql_finalize_stmt(&_temp0_stmt);
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT bupdateval(?, -3683705396192132539, 21, 3, -6946718245010482247, 'dave', 4)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, b);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &z);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_blob_ref(_temp0_stmt, 0, &z);
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
   cql_blob_release(b);
   cql_blob_release(x);
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_blob_release(z);
   return _rc_;
 }
@@ -18823,30 +18823,30 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT i2 + 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ? + 1");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, i2);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    i2 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    i2 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
   /*
   SET i0_nullable := ( SELECT i0_nullable + 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ? + 1");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_INT32, &i0_nullable);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_int32(_temp_stmt, 0, &i0_nullable);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_int32(_temp0_stmt, 0, &i0_nullable);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19157,13 +19157,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET s := ( SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, nullable(5), TRUE, NULL, FALSE, NULL, 6L, 7, 0.0, NULL, NULL, 8) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, 5, 1, NULL, 0, NULL, 6, 7, 0.0, NULL, NULL, 8)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_string_ref(_temp_stmt, 0, &s);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_string_ref(_temp0_stmt, 0, &s);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19437,14 +19437,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET b2 := ( SELECT EXISTS (SELECT *
     FROM bar) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT EXISTS (SELECT * "
       "FROM bar)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    b2 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    b2 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19672,15 +19672,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     FROM blob_table
     WHERE blob_id = 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT b_nullable "
       "FROM blob_table "
       "WHERE blob_id = 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_blob_ref(_temp_stmt, 0, &blob_var);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_blob_ref(_temp0_stmt, 0, &blob_var);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19689,15 +19689,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     FROM blob_table
     WHERE blob_id = 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT b_notnull "
       "FROM blob_table "
       "WHERE blob_id = 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &_tmp_blob_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_blob_ref(_temp0_stmt, 0, &_tmp_blob_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_blob_ref(&blob_var, _tmp_blob_0);
 
   // The statement ending at line XXXX
@@ -19712,15 +19712,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
                 CQL_DATA_TYPE_BLOB, blob_var,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19781,13 +19781,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET r2 := ( SELECT SqlUserFunc(123) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT SqlUserFunc(123)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    r2 = sqlite3_column_double(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    r2 = sqlite3_column_double(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19829,13 +19829,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' LIKE 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' LIKE 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19843,13 +19843,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' NOT LIKE 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' NOT LIKE 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19857,13 +19857,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' MATCH 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' MATCH 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19871,13 +19871,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' GLOB 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' GLOB 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19943,15 +19943,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET l0_nullable := cql_get_blob_size(( SELECT blob_var ));
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ?");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, blob_var);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_blob_ref(_temp_stmt, 0, &_tmp_n_blob_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_blob_ref(_temp0_stmt, 0, &_tmp_n_blob_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(l0_nullable, cql_get_blob_size(_tmp_n_blob_0));
 
   // The statement ending at line XXXX
@@ -20216,20 +20216,20 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING -1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
     cql_set_nullable(i0_nullable, _tmp_n_int_1.is_null, _tmp_n_int_1.value);
   }
   else {
     cql_set_notnull(i0_nullable, - 1);
   }
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20237,14 +20237,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING THROW );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_nullable(i0_nullable, _tmp_n_int_0.is_null, _tmp_n_int_0.value);
 
   // The statement ending at line XXXX
@@ -20253,14 +20253,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i2 := ( SELECT type
     FROM bar IF NOTHING OR NULL -1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
   }
   if (_rc_ == SQLITE_DONE || _tmp_n_int_1.is_null) {
     i2 = - 1;
@@ -20268,7 +20268,7 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     i2 = _tmp_n_int_1.value;
   }
   _rc_ = SQLITE_OK;
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20276,20 +20276,20 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET t0_nullable := ( SELECT name
     FROM bar IF NOTHING "" );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT name "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+    cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
     cql_set_string_ref(&t0_nullable, _tmp_n_text_1);
   }
   else {
     cql_set_string_ref(&t0_nullable, _literal_12_);
   }
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20297,14 +20297,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET t2 := ( SELECT name
     FROM bar IF NOTHING OR NULL "garbonzo" );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT name "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+    cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
   }
   if (_rc_ == SQLITE_DONE || !_tmp_n_text_1) {
     cql_set_string_ref(&t2, _literal_13_garbonzo_);
@@ -20312,7 +20312,7 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     cql_set_string_ref(&t2, _tmp_n_text_1);
   }
   _rc_ = SQLITE_OK;
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20559,13 +20559,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET b2 := ( SELECT likely(1) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT likely(1)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   b2 = !!(_tmp_int_0);
 
   // The statement ending at line XXXX
@@ -20581,7 +20581,7 @@ cql_cleanup:
   cql_finalize_stmt(&foo_cursor_stmt);
   cql_finalize_stmt(&basic_cursor_stmt);
   cql_finalize_stmt(&exchange_cursor_stmt);
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_string_release(_between_6_);
   cql_string_release(_between_7_);
   cql_string_release(_between_8_);

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -829,7 +829,7 @@ DECLARE arg2 INTEGER NOT NULL;
 cql_int32 arg2 = 0;
 sqlite3_stmt *exchange_cursor_stmt = NULL;
 cql_bool _exchange_cursor_has_row_ = 0;
-sqlite3_stmt *_temp_stmt = NULL;
+sqlite3_stmt *_temp0_stmt = NULL;
 
 // The statement ending at line XXXX
 
@@ -850,22 +850,22 @@ CQL_WARN_UNUSED cql_code outparm_test(sqlite3 *_Nonnull _db_, cql_int32 *_Nonnul
   cql_contract_argument_notnull((void *)foo, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *foo = 0; // set out arg to non-garbage
   *foo = 1;
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "DELETE FROM bar WHERE id = ?");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, *foo);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -2764,21 +2764,21 @@ DECLARE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER) USING TRANSACTI
 */
 CQL_WARN_UNUSED cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cql_nullable_int32 type_) {
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO bar(id, type) VALUES(?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_,
                 CQL_DATA_TYPE_INT32, &type_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -3046,25 +3046,25 @@ DECLARE PROC dummy_user () USING TRANSACTION;
 CQL_WARN_UNUSED cql_code dummy_user(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_int32 _seed_ = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   _seed_ = 123;
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO bar(id, name, rate, type, size) VALUES(?, printf('name_%d', ?), ?, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 5,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 5,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -4609,24 +4609,24 @@ CQL_WARN_UNUSED cql_code multi_rewrite(sqlite3 *_Nonnull _db_, cql_int32 blob_id
   cql_contract_argument_notnull((void *)out_arg, 9);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *out_arg = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO blob_table(blob_id, b_notnull, b_nullable) VALUES(?, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 3,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 3,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, blob_id_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, b_notnull_,
                 CQL_DATA_TYPE_BLOB, b_nullable_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   *out_arg = 1;
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -4900,7 +4900,7 @@ CQL_WARN_UNUSED cql_code call_in_loop(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     cql_finalize_stmt(&C_stmt);
     _rc_ = simple_select(_db_, &C_stmt);
@@ -4957,7 +4957,7 @@ CQL_WARN_UNUSED cql_code call_in_loop_with_nullable_condition(sqlite3 *_Nonnull 
   cql_set_notnull(i, 0);
   for (;;) {
   cql_set_nullable(_tmp_n_bool_0, i.is_null, i.value < 5);
-  if (!cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) break;
+    if (!cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) break;
     cql_set_nullable(i, i.is_null, i.value + 1);
     cql_finalize_stmt(&C_stmt);
     _rc_ = simple_select(_db_, &C_stmt);
@@ -5019,7 +5019,7 @@ CQL_WARN_UNUSED cql_code call_in_loop_boxed(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     C_stmt = NULL;
     _rc_ = simple_select(_db_, &C_stmt);
@@ -5233,7 +5233,7 @@ CQL_WARN_UNUSED cql_code call_out_union_in_loop(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     cql_object_release(C_result_set_);
     out_union_helper_fetch_results(&C_result_set_);
@@ -6594,23 +6594,23 @@ CQL_WARN_UNUSED cql_code use_with_select(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_nullable_int32 x = { .is_null = 1 };
   cql_int32 _tmp_int_0 = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "WITH "
     "threads2 (count) AS (SELECT 1) "
     "SELECT COUNT(*) "
       "FROM threads2");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(x, _tmp_int_0);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -6741,21 +6741,21 @@ DECLARE PROC upsert_do_nothing (id_ INTEGER NOT NULL) USING TRANSACTION;
 */
 CQL_WARN_UNUSED cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_) {
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO foo(id) VALUES(?) "
     "ON CONFLICT DO NOTHING");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -7500,24 +7500,24 @@ CQL_WARN_UNUSED cql_code compound_select_expr(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_nullable_int32 x = { .is_null = 1 };
   cql_int32 _tmp_int_0 = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 1 "
       "WHERE 0 "
     "UNION "
     "SELECT 2 "
     "LIMIT 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(x, _tmp_int_0);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -7842,7 +7842,7 @@ CQL_WARN_UNUSED cql_code empty_blocks(sqlite3 *_Nonnull _db_) {
     }
   }
   for (;;) {
-  if (!(1)) break;
+    if (!(1)) break;
   }
   _rc_ = cql_prepare(_db_, &c_stmt,
     "SELECT 1");
@@ -13374,7 +13374,7 @@ void out_decl_loop_test(cql_nullable_int32 x) {
   cql_int32 v = 0;
 
   for (;;) {
-  if (!(1)) break;
+    if (!(1)) break;
     out2_proc(x, &u, &v);
     out2_proc(x, &u, &v);
   }
@@ -17499,10 +17499,10 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
   cql_contract_argument_notnull((void *)x, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *x = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare_var(_db_, &_temp_stmt,
+  _rc_ = cql_prepare_var(_db_, &_temp0_stmt,
     3, NULL,
   "WITH "
     "backed (rowid, pk, flag, id, name, age, storage) AS (",
@@ -17514,14 +17514,14 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
       "FROM backed"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    *x = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    *x = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -17591,10 +17591,10 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
   cql_contract_argument_notnull((void *)x, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *x = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare_var(_db_, &_temp_stmt,
+  _rc_ = cql_prepare_var(_db_, &_temp0_stmt,
     3, NULL,
   "WITH "
     "backed (rowid, pk, flag, id, name, age, storage) AS (",
@@ -17606,14 +17606,14 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
       "FROM backed"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    *x = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    *x = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -17862,33 +17862,33 @@ CQL_WARN_UNUSED cql_code test_blob_update_expand(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_blob_ref b = NULL;
   cql_blob_ref x = NULL;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
   cql_blob_ref z = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT bupdatekey(?, 0, 1)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, b);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &x);
-  cql_finalize_stmt(&_temp_stmt);
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+    cql_column_blob_ref(_temp0_stmt, 0, &x);
+  cql_finalize_stmt(&_temp0_stmt);
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT bupdateval(?, -3683705396192132539, 21, 3, -6946718245010482247, 'dave', 4)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, b);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &z);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_blob_ref(_temp0_stmt, 0, &z);
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
   cql_blob_release(b);
   cql_blob_release(x);
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_blob_release(z);
   return _rc_;
 }
@@ -18823,30 +18823,30 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT i2 + 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ? + 1");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, i2);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    i2 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    i2 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
   /*
   SET i0_nullable := ( SELECT i0_nullable + 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ? + 1");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_INT32, &i0_nullable);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_int32(_temp_stmt, 0, &i0_nullable);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_int32(_temp0_stmt, 0, &i0_nullable);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19157,13 +19157,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET s := ( SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, nullable(5), TRUE, NULL, FALSE, NULL, 6L, 7, 0.0, NULL, NULL, 8) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, 5, 1, NULL, 0, NULL, 6, 7, 0.0, NULL, NULL, 8)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_string_ref(_temp_stmt, 0, &s);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_string_ref(_temp0_stmt, 0, &s);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19437,14 +19437,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET b2 := ( SELECT EXISTS (SELECT *
     FROM bar) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT EXISTS (SELECT * "
       "FROM bar)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    b2 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    b2 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19672,15 +19672,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     FROM blob_table
     WHERE blob_id = 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT b_nullable "
       "FROM blob_table "
       "WHERE blob_id = 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_blob_ref(_temp_stmt, 0, &blob_var);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_blob_ref(_temp0_stmt, 0, &blob_var);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19689,15 +19689,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     FROM blob_table
     WHERE blob_id = 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT b_notnull "
       "FROM blob_table "
       "WHERE blob_id = 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &_tmp_blob_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_blob_ref(_temp0_stmt, 0, &_tmp_blob_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_blob_ref(&blob_var, _tmp_blob_0);
 
   // The statement ending at line XXXX
@@ -19712,15 +19712,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
                 CQL_DATA_TYPE_BLOB, blob_var,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19781,13 +19781,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET r2 := ( SELECT SqlUserFunc(123) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT SqlUserFunc(123)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    r2 = sqlite3_column_double(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    r2 = sqlite3_column_double(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19829,13 +19829,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' LIKE 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' LIKE 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19843,13 +19843,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' NOT LIKE 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' NOT LIKE 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19857,13 +19857,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' MATCH 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' MATCH 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19871,13 +19871,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' GLOB 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' GLOB 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19943,15 +19943,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET l0_nullable := cql_get_blob_size(( SELECT blob_var ));
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ?");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, blob_var);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_blob_ref(_temp_stmt, 0, &_tmp_n_blob_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_blob_ref(_temp0_stmt, 0, &_tmp_n_blob_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(l0_nullable, cql_get_blob_size(_tmp_n_blob_0));
 
   // The statement ending at line XXXX
@@ -20216,20 +20216,20 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING -1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
     cql_set_nullable(i0_nullable, _tmp_n_int_1.is_null, _tmp_n_int_1.value);
   }
   else {
     cql_set_notnull(i0_nullable, - 1);
   }
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20237,14 +20237,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING THROW );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_nullable(i0_nullable, _tmp_n_int_0.is_null, _tmp_n_int_0.value);
 
   // The statement ending at line XXXX
@@ -20253,14 +20253,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i2 := ( SELECT type
     FROM bar IF NOTHING OR NULL -1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
   }
   if (_rc_ == SQLITE_DONE || _tmp_n_int_1.is_null) {
     i2 = - 1;
@@ -20268,7 +20268,7 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     i2 = _tmp_n_int_1.value;
   }
   _rc_ = SQLITE_OK;
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20276,20 +20276,20 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET t0_nullable := ( SELECT name
     FROM bar IF NOTHING "" );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT name "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+    cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
     cql_set_string_ref(&t0_nullable, _tmp_n_text_1);
   }
   else {
     cql_set_string_ref(&t0_nullable, _literal_12_);
   }
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20297,14 +20297,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET t2 := ( SELECT name
     FROM bar IF NOTHING OR NULL "garbonzo" );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT name "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+    cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
   }
   if (_rc_ == SQLITE_DONE || !_tmp_n_text_1) {
     cql_set_string_ref(&t2, _literal_13_garbonzo_);
@@ -20312,7 +20312,7 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     cql_set_string_ref(&t2, _tmp_n_text_1);
   }
   _rc_ = SQLITE_OK;
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20559,13 +20559,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET b2 := ( SELECT likely(1) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT likely(1)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   b2 = !!(_tmp_int_0);
 
   // The statement ending at line XXXX
@@ -20581,7 +20581,7 @@ cql_cleanup:
   cql_finalize_stmt(&foo_cursor_stmt);
   cql_finalize_stmt(&basic_cursor_stmt);
   cql_finalize_stmt(&exchange_cursor_stmt);
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_string_release(_between_6_);
   cql_string_release(_between_7_);
   cql_string_release(_between_8_);

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -829,7 +829,7 @@ DECLARE arg2 INTEGER NOT NULL;
 cql_int32 arg2 = 0;
 sqlite3_stmt *exchange_cursor_stmt = NULL;
 cql_bool _exchange_cursor_has_row_ = 0;
-sqlite3_stmt *_temp_stmt = NULL;
+sqlite3_stmt *_temp0_stmt = NULL;
 
 // The statement ending at line XXXX
 
@@ -850,22 +850,22 @@ CQL_WARN_UNUSED cql_code outparm_test(sqlite3 *_Nonnull _db_, cql_int32 *_Nonnul
   cql_contract_argument_notnull((void *)foo, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *foo = 0; // set out arg to non-garbage
   *foo = 1;
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "DELETE FROM bar WHERE id = ?");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, *foo);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -2764,21 +2764,21 @@ DECLARE PROC insert_values (id_ INTEGER NOT NULL, type_ INTEGER) USING TRANSACTI
 */
 CQL_WARN_UNUSED cql_code insert_values(sqlite3 *_Nonnull _db_, cql_int32 id_, cql_nullable_int32 type_) {
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO bar(id, type) VALUES(?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_,
                 CQL_DATA_TYPE_INT32, &type_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -3046,25 +3046,25 @@ DECLARE PROC dummy_user () USING TRANSACTION;
 CQL_WARN_UNUSED cql_code dummy_user(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_int32 _seed_ = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   _seed_ = 123;
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO bar(id, name, rate, type, size) VALUES(?, printf('name_%d', ?), ?, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 5,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 5,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, _seed_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -4609,24 +4609,24 @@ CQL_WARN_UNUSED cql_code multi_rewrite(sqlite3 *_Nonnull _db_, cql_int32 blob_id
   cql_contract_argument_notnull((void *)out_arg, 9);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *out_arg = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO blob_table(blob_id, b_notnull, b_nullable) VALUES(?, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 3,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 3,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, blob_id_,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, b_notnull_,
                 CQL_DATA_TYPE_BLOB, b_nullable_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   *out_arg = 1;
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -4900,7 +4900,7 @@ CQL_WARN_UNUSED cql_code call_in_loop(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     cql_finalize_stmt(&C_stmt);
     _rc_ = simple_select(_db_, &C_stmt);
@@ -4957,7 +4957,7 @@ CQL_WARN_UNUSED cql_code call_in_loop_with_nullable_condition(sqlite3 *_Nonnull 
   cql_set_notnull(i, 0);
   for (;;) {
   cql_set_nullable(_tmp_n_bool_0, i.is_null, i.value < 5);
-  if (!cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) break;
+    if (!cql_is_nullable_true(_tmp_n_bool_0.is_null, _tmp_n_bool_0.value)) break;
     cql_set_nullable(i, i.is_null, i.value + 1);
     cql_finalize_stmt(&C_stmt);
     _rc_ = simple_select(_db_, &C_stmt);
@@ -5019,7 +5019,7 @@ CQL_WARN_UNUSED cql_code call_in_loop_boxed(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     C_stmt = NULL;
     _rc_ = simple_select(_db_, &C_stmt);
@@ -5233,7 +5233,7 @@ CQL_WARN_UNUSED cql_code call_out_union_in_loop(sqlite3 *_Nonnull _db_) {
 
   cql_set_notnull(i, 0);
   for (;;) {
-  if (!(i.value < 5)) break;
+    if (!(i.value < 5)) break;
     cql_set_notnull(i, i.value + 1);
     cql_object_release(C_result_set_);
     out_union_helper_fetch_results(&C_result_set_);
@@ -6594,23 +6594,23 @@ CQL_WARN_UNUSED cql_code use_with_select(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_nullable_int32 x = { .is_null = 1 };
   cql_int32 _tmp_int_0 = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "WITH "
     "threads2 (count) AS (SELECT 1) "
     "SELECT COUNT(*) "
       "FROM threads2");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(x, _tmp_int_0);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -6741,21 +6741,21 @@ DECLARE PROC upsert_do_nothing (id_ INTEGER NOT NULL) USING TRANSACTION;
 */
 CQL_WARN_UNUSED cql_code upsert_do_nothing(sqlite3 *_Nonnull _db_, cql_int32 id_) {
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO foo(id) VALUES(?) "
     "ON CONFLICT DO NOTHING");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, id_);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -7500,24 +7500,24 @@ CQL_WARN_UNUSED cql_code compound_select_expr(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_nullable_int32 x = { .is_null = 1 };
   cql_int32 _tmp_int_0 = 0;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 1 "
       "WHERE 0 "
     "UNION "
     "SELECT 2 "
     "LIMIT 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(x, _tmp_int_0);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -7842,7 +7842,7 @@ CQL_WARN_UNUSED cql_code empty_blocks(sqlite3 *_Nonnull _db_) {
     }
   }
   for (;;) {
-  if (!(1)) break;
+    if (!(1)) break;
   }
   _rc_ = cql_prepare(_db_, &c_stmt,
     "SELECT 1");
@@ -13374,7 +13374,7 @@ void out_decl_loop_test(cql_nullable_int32 x) {
   cql_int32 v = 0;
 
   for (;;) {
-  if (!(1)) break;
+    if (!(1)) break;
     out2_proc(x, &u, &v);
     out2_proc(x, &u, &v);
   }
@@ -17499,10 +17499,10 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
   cql_contract_argument_notnull((void *)x, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *x = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare_var(_db_, &_temp_stmt,
+  _rc_ = cql_prepare_var(_db_, &_temp0_stmt,
     3, NULL,
   "WITH "
     "backed (rowid, pk, flag, id, name, age, storage) AS (",
@@ -17514,14 +17514,14 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr(sqlite3 *_Nonnull _db_, cq
       "FROM backed"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    *x = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    *x = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -17591,10 +17591,10 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
   cql_contract_argument_notnull((void *)x, 1);
 
   cql_code _rc_ = SQLITE_OK;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
 
   *x = 0; // set out arg to non-garbage
-  _rc_ = cql_prepare_var(_db_, &_temp_stmt,
+  _rc_ = cql_prepare_var(_db_, &_temp0_stmt,
     3, NULL,
   "WITH "
     "backed (rowid, pk, flag, id, name, age, storage) AS (",
@@ -17606,14 +17606,14 @@ CQL_WARN_UNUSED cql_code use_backed_table_select_expr_value_offsets(sqlite3 *_No
       "FROM backed"
   );
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    *x = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    *x = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   return _rc_;
 }
 #undef _PROC_
@@ -17862,33 +17862,33 @@ CQL_WARN_UNUSED cql_code test_blob_update_expand(sqlite3 *_Nonnull _db_) {
   cql_code _rc_ = SQLITE_OK;
   cql_blob_ref b = NULL;
   cql_blob_ref x = NULL;
-  sqlite3_stmt *_temp_stmt = NULL;
+  sqlite3_stmt *_temp0_stmt = NULL;
   cql_blob_ref z = NULL;
 
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT bupdatekey(?, 0, 1)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, b);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &x);
-  cql_finalize_stmt(&_temp_stmt);
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+    cql_column_blob_ref(_temp0_stmt, 0, &x);
+  cql_finalize_stmt(&_temp0_stmt);
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT bupdateval(?, -3683705396192132539, 21, 3, -6946718245010482247, 'dave', 4)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, b);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &z);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_blob_ref(_temp0_stmt, 0, &z);
+  cql_finalize_stmt(&_temp0_stmt);
   _rc_ = SQLITE_OK;
 
 cql_cleanup:
   cql_blob_release(b);
   cql_blob_release(x);
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_blob_release(z);
   return _rc_;
 }
@@ -18823,30 +18823,30 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT i2 + 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ? + 1");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_INT32, i2);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    i2 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    i2 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
   /*
   SET i0_nullable := ( SELECT i0_nullable + 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ? + 1");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_INT32, &i0_nullable);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_int32(_temp_stmt, 0, &i0_nullable);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_int32(_temp0_stmt, 0, &i0_nullable);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19157,13 +19157,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET s := ( SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, nullable(5), TRUE, NULL, FALSE, NULL, 6L, 7, 0.0, NULL, NULL, 8) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, 5, 1, NULL, 0, NULL, 6, 7, 0.0, NULL, NULL, 8)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_string_ref(_temp_stmt, 0, &s);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_string_ref(_temp0_stmt, 0, &s);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19437,14 +19437,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET b2 := ( SELECT EXISTS (SELECT *
     FROM bar) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT EXISTS (SELECT * "
       "FROM bar)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    b2 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    b2 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19672,15 +19672,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     FROM blob_table
     WHERE blob_id = 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT b_nullable "
       "FROM blob_table "
       "WHERE blob_id = 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_blob_ref(_temp_stmt, 0, &blob_var);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_blob_ref(_temp0_stmt, 0, &blob_var);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19689,15 +19689,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     FROM blob_table
     WHERE blob_id = 1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT b_notnull "
       "FROM blob_table "
       "WHERE blob_id = 1");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_blob_ref(_temp_stmt, 0, &_tmp_blob_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_blob_ref(_temp0_stmt, 0, &_tmp_blob_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_blob_ref(&blob_var, _tmp_blob_0);
 
   // The statement ending at line XXXX
@@ -19712,15 +19712,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 2,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 2,
                 CQL_DATA_TYPE_BLOB, blob_var,
                 CQL_DATA_TYPE_NOT_NULL | CQL_DATA_TYPE_BLOB, blob_var_notnull);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
-  cql_finalize_stmt(&_temp_stmt);
+  sqlite3_reset(_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19781,13 +19781,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET r2 := ( SELECT SqlUserFunc(123) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT SqlUserFunc(123)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    r2 = sqlite3_column_double(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    r2 = sqlite3_column_double(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -19829,13 +19829,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' LIKE 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' LIKE 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19843,13 +19843,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' NOT LIKE 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' NOT LIKE 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19857,13 +19857,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' MATCH 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' MATCH 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19871,13 +19871,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET i2 := ( SELECT 'x' GLOB 'y' );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT 'x' GLOB 'y'");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_bool_0 = sqlite3_column_int(_temp_stmt, 0) != 0;
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_bool_0 = sqlite3_column_int(_temp0_stmt, 0) != 0;
+  cql_finalize_stmt(&_temp0_stmt);
   i2 = _tmp_bool_0;
 
   // The statement ending at line XXXX
@@ -19943,15 +19943,15 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET l0_nullable := cql_get_blob_size(( SELECT blob_var ));
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT ?");
-  cql_multibind(&_rc_, _db_, &_temp_stmt, 1,
+  cql_multibind(&_rc_, _db_, &_temp0_stmt, 1,
                 CQL_DATA_TYPE_BLOB, blob_var);
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_blob_ref(_temp_stmt, 0, &_tmp_n_blob_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_blob_ref(_temp0_stmt, 0, &_tmp_n_blob_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_notnull(l0_nullable, cql_get_blob_size(_tmp_n_blob_0));
 
   // The statement ending at line XXXX
@@ -20216,20 +20216,20 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING -1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
     cql_set_nullable(i0_nullable, _tmp_n_int_1.is_null, _tmp_n_int_1.value);
   }
   else {
     cql_set_notnull(i0_nullable, - 1);
   }
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20237,14 +20237,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING THROW );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_0);
-  cql_finalize_stmt(&_temp_stmt);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_0);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_set_nullable(i0_nullable, _tmp_n_int_0.is_null, _tmp_n_int_0.value);
 
   // The statement ending at line XXXX
@@ -20253,14 +20253,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET i2 := ( SELECT type
     FROM bar IF NOTHING OR NULL -1 );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT type "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_int32(_temp_stmt, 0, &_tmp_n_int_1);
+    cql_column_nullable_int32(_temp0_stmt, 0, &_tmp_n_int_1);
   }
   if (_rc_ == SQLITE_DONE || _tmp_n_int_1.is_null) {
     i2 = - 1;
@@ -20268,7 +20268,7 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     i2 = _tmp_n_int_1.value;
   }
   _rc_ = SQLITE_OK;
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20276,20 +20276,20 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET t0_nullable := ( SELECT name
     FROM bar IF NOTHING "" );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT name "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+    cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
     cql_set_string_ref(&t0_nullable, _tmp_n_text_1);
   }
   else {
     cql_set_string_ref(&t0_nullable, _literal_12_);
   }
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20297,14 +20297,14 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   SET t2 := ( SELECT name
     FROM bar IF NOTHING OR NULL "garbonzo" );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT name "
       "FROM bar");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW && _rc_ != SQLITE_DONE) { cql_error_trace(); goto cql_cleanup; }
   if (_rc_ == SQLITE_ROW) {
-    cql_column_nullable_string_ref(_temp_stmt, 0, &_tmp_n_text_1);
+    cql_column_nullable_string_ref(_temp0_stmt, 0, &_tmp_n_text_1);
   }
   if (_rc_ == SQLITE_DONE || !_tmp_n_text_1) {
     cql_set_string_ref(&t2, _literal_13_garbonzo_);
@@ -20312,7 +20312,7 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
     cql_set_string_ref(&t2, _tmp_n_text_1);
   }
   _rc_ = SQLITE_OK;
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
 
   // The statement ending at line XXXX
 
@@ -20559,13 +20559,13 @@ cql_code cql_startup(sqlite3 *_Nonnull _db_) {
   /*
   SET b2 := ( SELECT likely(1) );
   */
-  _rc_ = cql_prepare(_db_, &_temp_stmt,
+  _rc_ = cql_prepare(_db_, &_temp0_stmt,
     "SELECT likely(1)");
   if (_rc_ != SQLITE_OK) { cql_error_trace(); goto cql_cleanup; }
-  _rc_ = sqlite3_step(_temp_stmt);
+  _rc_ = sqlite3_step(_temp0_stmt);
   if (_rc_ != SQLITE_ROW) { cql_error_trace(); goto cql_cleanup; }
-    _tmp_int_0 = sqlite3_column_int(_temp_stmt, 0);
-  cql_finalize_stmt(&_temp_stmt);
+    _tmp_int_0 = sqlite3_column_int(_temp0_stmt, 0);
+  cql_finalize_stmt(&_temp0_stmt);
   b2 = !!(_tmp_int_0);
 
   // The statement ending at line XXXX
@@ -20581,7 +20581,7 @@ cql_cleanup:
   cql_finalize_stmt(&foo_cursor_stmt);
   cql_finalize_stmt(&basic_cursor_stmt);
   cql_finalize_stmt(&exchange_cursor_stmt);
-  cql_finalize_stmt(&_temp_stmt);
+  cql_finalize_stmt(&_temp0_stmt);
   cql_string_release(_between_6_);
   cql_string_release(_between_7_);
   cql_string_release(_between_8_);

--- a/sources/test/cg_test_lua.lua.ref
+++ b/sources/test/cg_test_lua.lua.ref
@@ -201,7 +201,7 @@ local exchange_cursor_stmt = nil
 local exchange_cursor = { _has_row_ = false }
 local exchange_cursor_fields_ = { "arg2", "arg1" }
 local exchange_cursor_types_ = "II"
-local _temp_stmt = nil
+local _temp0_stmt = nil
 
 -- The statement ending at line XXXX
 
@@ -216,23 +216,22 @@ END;
 function outparm_test(_db_)
   local _rc_ = CQL_OK
   local foo = 0
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
   foo = 1
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "DELETE FROM bar WHERE id = ?")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "I", {foo})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "I", {foo})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_reset_stmt(_temp0_stmt)
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_, foo
 end
 
@@ -1245,22 +1244,21 @@ function insert_values(_db_, id_, type_)
   cql_contract_argument_notnull(id_, 1)
 
   local _rc_ = CQL_OK
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "INSERT INTO bar(id, type) VALUES(?, ?)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "Ii", {id_, type_})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "Ii", {id_, type_})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_reset_stmt(_temp0_stmt)
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_
 end
 
@@ -1415,23 +1413,22 @@ END;
 function dummy_user(_db_)
   local _rc_ = CQL_OK
   local _seed_ = 0
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
   _seed_ = 123
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "INSERT INTO bar(id, name, rate, type, size) VALUES(?, printf('name_%d', ?), ?, ?, ?)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "IIIII", {_seed_, _seed_, _seed_, _seed_, _seed_})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "IIIII", {_seed_, _seed_, _seed_, _seed_, _seed_})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_reset_stmt(_temp0_stmt)
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_
 end
 
@@ -2234,23 +2231,22 @@ function multi_rewrite(_db_, blob_id_, b_notnull_, b_nullable_, id_, name_, rate
 
   local _rc_ = CQL_OK
   local out_arg = 0
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "INSERT INTO blob_table(blob_id, b_notnull, b_nullable) VALUES(?, ?, ?)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "IBb", {blob_id_, b_notnull_, b_nullable_})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "IBb", {blob_id_, b_notnull_, b_nullable_})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_reset_stmt(_temp0_stmt)
   out_arg = 1
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_, out_arg
 end
 
@@ -2428,7 +2424,7 @@ function call_in_loop(_db_)
   i = 0
   while true
   do
-  if not(i < 5) then break end
+    if not(i < 5) then break end
     i = i + 1
     cql_finalize_stmt(C_stmt)
     _rc_, C_stmt = simple_select(_db_)
@@ -2472,7 +2468,7 @@ function call_in_loop_with_nullable_condition(_db_)
   i = 0
   while true
   do
-  if not(cql_lt(i, 5)) then break end
+    if not(cql_lt(i, 5)) then break end
     i = cql_add(i, 1)
     cql_finalize_stmt(C_stmt)
     _rc_, C_stmt = simple_select(_db_)
@@ -2524,7 +2520,7 @@ function call_in_loop_boxed(_db_)
   i = 0
   while true
   do
-  if not(i < 5) then break end
+    if not(i < 5) then break end
     i = i + 1
     C_stmt = nil
     _rc_, C_stmt = simple_select(_db_)
@@ -2632,7 +2628,7 @@ function call_out_union_in_loop(_db_)
   i = 0
   while true
   do
-  if not(i < 5) then break end
+    if not(i < 5) then break end
     i = i + 1
     C_result_set_ = out_union_helper_fetch_results()
     C_row_num_ = 0
@@ -3345,22 +3341,22 @@ function use_with_select(_db_)
   local _rc_ = CQL_OK
   local x
   local _tmp_int_0 = 0
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "WITH threads2 (count) AS (SELECT 1) SELECT COUNT(*) FROM threads2")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_int_0 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_int_0 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   x = _tmp_int_0
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_
 end
 
@@ -3460,22 +3456,21 @@ function upsert_do_nothing(_db_, id_)
   cql_contract_argument_notnull(id_, 1)
 
   local _rc_ = CQL_OK
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "INSERT INTO foo(id) VALUES(?) ON CONFLICT DO NOTHING")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "I", {id_})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "I", {id_})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_reset_stmt(_temp0_stmt)
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_
 end
 local _seed_ = 0
@@ -3876,22 +3871,22 @@ function compound_select_expr(_db_)
   local _rc_ = CQL_OK
   local x
   local _tmp_int_0 = 0
-  local _temp_stmt = nil
+  local _temp0_stmt = nil
 
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT 1 WHERE 0 UNION SELECT 2 LIMIT 1")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_int_0 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_int_0 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   x = _tmp_int_0
   _rc_ = CQL_OK
 
 ::cql_cleanup::
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   return _rc_
 end
 
@@ -4100,7 +4095,7 @@ function empty_blocks(_db_)
   end
   while true
   do
-  if not(true) then break end
+    if not(true) then break end
   end
   _rc_, c_stmt = cql_prepare(_db_, 
     "SELECT 1")
@@ -6781,7 +6776,7 @@ function out_decl_loop_test(x)
 
   while true
   do
-  if not(true) then break end
+    if not(true) then break end
     u, v = out2_proc(x)
     u, v = out2_proc(x)
   end
@@ -8962,32 +8957,32 @@ function cql_startup(_db_)
   --[[
   SET i2 := ( SELECT i2 + 1 );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT ? + 1")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "I", {i2})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "I", {i2})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    i2 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    i2 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
   --[[
   SET i0_nullable := ( SELECT i0_nullable + 1 );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT ? + 1")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "i", {i0_nullable})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "i", {i0_nullable})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    i0_nullable = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    i0_nullable = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -9209,14 +9204,14 @@ function cql_startup(_db_)
   --[[
   SET s := ( SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, nullable(5), TRUE, NULL, FALSE, NULL, 6L, 7, 0.0, NULL, NULL, 8) );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT printf('%lld %lld %lld %llu %d %d %llu %d %f %f %s %f', 5, 5, 1, NULL, 0, NULL, 6, 7, 0.0, NULL, NULL, 8)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    s = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    s = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -9475,14 +9470,14 @@ function cql_startup(_db_)
   SET b2 := ( SELECT EXISTS (SELECT *
     FROM bar) );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT EXISTS (SELECT * FROM bar)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    b2 = cql_to_bool(cql_get_value(_temp_stmt, 0))
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    b2 = cql_to_bool(cql_get_value(_temp0_stmt, 0))
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -9707,14 +9702,14 @@ function cql_startup(_db_)
     FROM blob_table
     WHERE blob_id = 1 );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT b_nullable FROM blob_table WHERE blob_id = 1")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    blob_var = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    blob_var = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -9723,14 +9718,14 @@ function cql_startup(_db_)
     FROM blob_table
     WHERE blob_id = 1 );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT b_notnull FROM blob_table WHERE blob_id = 1")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_blob_0 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_blob_0 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   blob_var = _tmp_blob_0
 
   -- The statement ending at line XXXX
@@ -9745,15 +9740,14 @@ function cql_startup(_db_)
   --[[
   INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, blob_var, blob_var_notnull);
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "INSERT INTO blob_table(blob_id, b_nullable, b_notnull) VALUES(0, ?, ?)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "bB", {blob_var, blob_var_notnull})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "bB", {blob_var, blob_var_notnull})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_reset_stmt(_temp0_stmt)
 
   -- The statement ending at line XXXX
 
@@ -9811,14 +9805,14 @@ function cql_startup(_db_)
   --[[
   SET r2 := ( SELECT SqlUserFunc(123) );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT SqlUserFunc(123)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    r2 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    r2 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -9857,14 +9851,14 @@ function cql_startup(_db_)
   --[[
   SET i2 := ( SELECT 'x' LIKE 'y' );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT 'x' LIKE 'y'")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp_stmt, 0))
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp0_stmt, 0))
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   i2 = cql_to_num(_tmp_bool_0)
 
   -- The statement ending at line XXXX
@@ -9872,14 +9866,14 @@ function cql_startup(_db_)
   --[[
   SET i2 := ( SELECT 'x' NOT LIKE 'y' );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT 'x' NOT LIKE 'y'")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp_stmt, 0))
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp0_stmt, 0))
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   i2 = cql_to_num(_tmp_bool_0)
 
   -- The statement ending at line XXXX
@@ -9887,14 +9881,14 @@ function cql_startup(_db_)
   --[[
   SET i2 := ( SELECT 'x' MATCH 'y' );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT 'x' MATCH 'y'")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp_stmt, 0))
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp0_stmt, 0))
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   i2 = cql_to_num(_tmp_bool_0)
 
   -- The statement ending at line XXXX
@@ -9902,14 +9896,14 @@ function cql_startup(_db_)
   --[[
   SET i2 := ( SELECT 'x' GLOB 'y' );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT 'x' GLOB 'y'")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp_stmt, 0))
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_bool_0 = cql_to_bool(cql_get_value(_temp0_stmt, 0))
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   i2 = cql_to_num(_tmp_bool_0)
 
   -- The statement ending at line XXXX
@@ -9970,16 +9964,16 @@ function cql_startup(_db_)
   --[[
   SET l0_nullable := cql_get_blob_size(( SELECT blob_var ));
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT ?")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_multibind(_db_, _temp_stmt, "b", {blob_var})
+  _rc_ = cql_multibind(_db_, _temp0_stmt, "b", {blob_var})
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_n_blob_0 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_n_blob_0 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   l0_nullable = cql_get_blob_size(_tmp_n_blob_0)
 
   -- The statement ending at line XXXX
@@ -10244,19 +10238,19 @@ function cql_startup(_db_)
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING -1 );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT type FROM bar")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW and _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   if _rc_ == CQL_ROW then
-    _tmp_n_int_1 = cql_get_value(_temp_stmt, 0)
+    _tmp_n_int_1 = cql_get_value(_temp0_stmt, 0)
     i0_nullable = _tmp_n_int_1
   else
     i0_nullable = - 1
   end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -10264,14 +10258,14 @@ function cql_startup(_db_)
   SET i0_nullable := ( SELECT type
     FROM bar IF NOTHING THROW );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT type FROM bar")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_n_int_0 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_n_int_0 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   i0_nullable = _tmp_n_int_0
 
   -- The statement ending at line XXXX
@@ -10280,13 +10274,13 @@ function cql_startup(_db_)
   SET i2 := ( SELECT type
     FROM bar IF NOTHING OR NULL -1 );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT type FROM bar")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW and _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   if _rc_ == CQL_ROW then
-    _tmp_n_int_1 = cql_get_value(_temp_stmt, 0)
+    _tmp_n_int_1 = cql_get_value(_temp0_stmt, 0)
   end
   if _rc_ == CQL_DONE or _tmp_n_int_1 == nil then
     i2 = - 1
@@ -10294,8 +10288,8 @@ function cql_startup(_db_)
     i2 = _tmp_n_int_1
   end
   _rc_ = CQL_OK
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -10303,19 +10297,19 @@ function cql_startup(_db_)
   SET t0_nullable := ( SELECT name
     FROM bar IF NOTHING "" );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT name FROM bar")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW and _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   if _rc_ == CQL_ROW then
-    _tmp_n_text_1 = cql_get_value(_temp_stmt, 0)
+    _tmp_n_text_1 = cql_get_value(_temp0_stmt, 0)
     t0_nullable = _tmp_n_text_1
   else
     t0_nullable = ""
   end
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -10323,13 +10317,13 @@ function cql_startup(_db_)
   SET t2 := ( SELECT name
     FROM bar IF NOTHING OR NULL "garbonzo" );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT name FROM bar")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW and _rc_ ~= CQL_DONE then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
   if _rc_ == CQL_ROW then
-    _tmp_n_text_1 = cql_get_value(_temp_stmt, 0)
+    _tmp_n_text_1 = cql_get_value(_temp0_stmt, 0)
   end
   if _rc_ == CQL_DONE or _tmp_n_text_1 == nil then
     t2 = "garbonzo"
@@ -10337,8 +10331,8 @@ function cql_startup(_db_)
     t2 = _tmp_n_text_1
   end
   _rc_ = CQL_OK
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
 
   -- The statement ending at line XXXX
 
@@ -10584,14 +10578,14 @@ function cql_startup(_db_)
   --[[
   SET b2 := ( SELECT likely(1) );
   --]]
-  _rc_, _temp_stmt = cql_prepare(_db_, 
+  _rc_, _temp0_stmt = cql_prepare(_db_, 
     "SELECT likely(1)")
   if _rc_ ~= CQL_OK then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-  _rc_ = cql_step(_temp_stmt)
+  _rc_ = cql_step(_temp0_stmt)
   if _rc_ ~= CQL_ROW then cql_error_trace(_rc_, _db_); goto cql_cleanup; end
-    _tmp_int_0 = cql_get_value(_temp_stmt, 0)
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+    _tmp_int_0 = cql_get_value(_temp0_stmt, 0)
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   b2 = cql_to_bool(_tmp_int_0)
 
   -- The statement ending at line XXXX
@@ -10608,8 +10602,8 @@ function cql_startup(_db_)
   basic_cursor_stmt = nil
   cql_finalize_stmt(exchange_cursor_stmt)
   exchange_cursor_stmt = nil
-  cql_finalize_stmt(_temp_stmt)
-  _temp_stmt = nil
+  cql_finalize_stmt(_temp0_stmt)
+  _temp0_stmt = nil
   cql_finalize_stmt(expanded_select_stmt)
   expanded_select_stmt = nil
   cql_finalize_stmt(table_expanded_select_stmt)


### PR DESCRIPTION
Fixes for a better code generation for prepared statements inside loops, using sqlite3_reset instead of cql_finalize_stmt .
See details here https://github.com/facebookincubator/CG-SQL/issues/149