### PR TITLE
Add support for the FROM clause to the UPDATE statement

### DIFF
--- a/CQL_Guide/x4.md
+++ b/CQL_Guide/x4.md
@@ -4688,3 +4688,13 @@ However this is the only place SELECT NOTHING is allowed.  It must be:
 * in the else clause
 
 Any violation results in the present error.
+
+### CQL0497: FROM clause not supported when updating backed table, 'table_name'
+
+SQLite supports an extended format of the update statement with a FROM clause.  At this time backed tables cannot be updated using this form.  This is likely to change fairly soon.
+
+### CQL0498: strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
+
+@enforce_strict` has been use to enable strict update enforcement.  When enabled update statements may not include a FROM clause. 
+This is done if the code expects to target SQLite version 3.33 or lower.
+

--- a/sources/ast.h
+++ b/sources/ast.h
@@ -95,6 +95,7 @@
 #define ENFORCE_ENCODE_CONTEXT_TYPE_BLOB 19
 #define ENFORCE_IS_TRUE 20
 #define ENFORCE_CURSOR_HAS_ROW 21
+#define ENFORCE_UPDATE_FROM 22
 
 #define COMPOUND_OP_UNION 1
 #define COMPOUND_OP_UNION_ALL 2
@@ -807,6 +808,7 @@ AST(with_update_stmt)
 AST(update_stmt)
 AST(update_cursor_stmt)
 AST(update_set)
+AST(update_from)
 AST(update_where)
 AST(update_orderby)
 AST(with_upsert_stmt)

--- a/sources/cql.y
+++ b/sources/cql.y
@@ -1651,10 +1651,11 @@ insert_list[result]:
   ;
 
 basic_update_stmt:
-  UPDATE opt_name SET update_list opt_where  {
+  UPDATE opt_name SET update_list opt_from_query_parts opt_where  {
     struct ast_node *orderby = new_ast_update_orderby(NULL, NULL);
     struct ast_node *where = new_ast_update_where($opt_where, orderby);
-    struct ast_node *list = new_ast_update_set($update_list, where);
+    struct ast_node *from = new_ast_update_from($opt_from_query_parts, where);
+    struct ast_node *list = new_ast_update_set($update_list, from);
     $basic_update_stmt = new_ast_update_stmt($opt_name, list); }
   ;
 
@@ -1663,11 +1664,12 @@ with_update_stmt:
   ;
 
 update_stmt:
-  UPDATE name SET update_list opt_where opt_orderby opt_limit  {
+  UPDATE name SET update_list opt_from_query_parts opt_where opt_orderby opt_limit  {
     struct ast_node *limit = $opt_limit;
     struct ast_node *orderby = new_ast_update_orderby($opt_orderby, limit);
     struct ast_node *where = new_ast_update_where($opt_where, orderby);
-    struct ast_node *list = new_ast_update_set($update_list, where);
+    struct ast_node *from = new_ast_update_from($opt_from_query_parts, where);
+    struct ast_node *list = new_ast_update_set($update_list, from);
     $update_stmt = new_ast_update_stmt($name, list); }
   ;
 
@@ -2236,6 +2238,7 @@ enforcement_options:
   | CAST { $enforcement_options = new_ast_opt(ENFORCE_CAST); }
   | SIGN_FUNCTION { $enforcement_options = new_ast_opt(ENFORCE_SIGN_FUNCTION); }
   | CURSOR_HAS_ROW { $enforcement_options = new_ast_opt(ENFORCE_CURSOR_HAS_ROW); }
+  | UPDATE FROM { $enforcement_options = new_ast_opt(ENFORCE_UPDATE_FROM); }
   ;
 
 enforce_strict_stmt:

--- a/sources/gen_sql.c
+++ b/sources/gen_sql.c
@@ -3047,7 +3047,9 @@ static void gen_update_stmt(ast_node *ast) {
   Contract(is_ast_update_stmt(ast));
   EXTRACT_NOTNULL(update_set, ast->right);
   EXTRACT_NOTNULL(update_list, update_set->left);
-  EXTRACT_NOTNULL(update_where, update_set->right);
+  EXTRACT_NOTNULL(update_from, update_set->right);
+  EXTRACT_NOTNULL(update_where, update_from->right);
+  EXTRACT_ANY(query_parts, update_from->left);
   EXTRACT(opt_where, update_where->left);
   EXTRACT_NOTNULL(update_orderby, update_where->right);
   EXTRACT(opt_orderby, update_orderby->left);
@@ -3060,6 +3062,10 @@ static void gen_update_stmt(ast_node *ast) {
   }
   gen_printf("\nSET ");
   gen_update_list(update_list);
+  if (query_parts) {
+    gen_printf(" FROM ");
+    gen_query_parts(query_parts);
+  }
   if (opt_where) {
     gen_opt_where(opt_where);
   }
@@ -4320,6 +4326,10 @@ static void gen_enforcement_options(ast_node *ast) {
 
     case ENFORCE_CURSOR_HAS_ROW:
       gen_printf("CURSOR HAS ROW");
+      break;
+
+    case ENFORCE_UPDATE_FROM:
+      gen_printf("UPDATE FROM");
       break;
 
     default:

--- a/sources/rewrite.c
+++ b/sources/rewrite.c
@@ -3336,7 +3336,8 @@ cql_noexport void rewrite_update_statement_for_backed_table(
   Invariant(is_ast_update_stmt(stmt));
   EXTRACT_NOTNULL(update_set, stmt->right);
   EXTRACT_NOTNULL(update_list, update_set->left);
-  EXTRACT_NOTNULL(update_where, update_set->right);
+  EXTRACT_NOTNULL(update_from, update_set->right);
+  EXTRACT_NOTNULL(update_where, update_from->right);
   EXTRACT(opt_where, update_where->left);
   EXTRACT_NOTNULL(update_orderby, update_where->right);
   EXTRACT(opt_orderby, update_orderby->left);

--- a/sources/test/sem_test.err.ref
+++ b/sources/test/sem_test.err.ref
@@ -1716,4 +1716,7 @@ test/sem_test.sql:XXXX:1: error: in type_object : CQL0090: object<T SET> has a T
 test/sem_test.sql:XXXX:1: error: in call : CQL0080: function may not appear in this context 'cql_compressed'
 test/sem_test.sql:XXXX:1: error: in str : CQL0079: function got incorrect number of arguments 'cql_compressed'
 test/sem_test.sql:XXXX:1: error: in call : CQL0421: first argument must be a string literal 'cql_compressed'
+test/sem_test.sql:XXXX:1: error: in table_or_subquery : CQL0095: table/view not defined 'table_does_not_exist'
+test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0497: FROM clause not supported when updating backed table 'simple_backed_table'
+test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
 semantic errors present; no code gen.

--- a/sources/test/sem_test.out.ref
+++ b/sources/test/sem_test.out.ref
@@ -8618,12 +8618,13 @@ SET id = 1
     | | {update_entry}: id: integer notnull
     |   | {name id}: id: integer notnull
     |   | {int 1}: integer notnull
-    | {update_where}
-      | {opt_where}: bool notnull
-      | | {eq}: bool notnull
-      |   | {name id}: id: integer notnull
-      |   | {int 2}: integer notnull
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {opt_where}: bool notnull
+        | | {eq}: bool notnull
+        |   | {name id}: id: integer notnull
+        |   | {int 2}: integer notnull
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8637,8 +8638,9 @@ SET cost = price_d;
     | | {update_entry}: cost: real<dollars>
     |   | {name cost}: cost: real<dollars>
     |   | {name price_d}: price_d: real<dollars> variable
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8654,8 +8656,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0070: expressions of different kind
     | | {update_entry}: err
     |   | {name cost}: cost: real<dollars>
     |   | {name price_e}: err
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8671,8 +8674,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0155: cannot update a view 'myView'
     | | {update_entry}
     |   | {name id}
     |   | {int 1}
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8689,11 +8693,12 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
     | | {update_entry}: id: integer notnull
     |   | {name id}: id: integer notnull
     |   | {int 1}: integer notnull
-    | {update_where}
-      | {opt_where}: err
-      | | {not}: err
-      |   | {strlit 'x'}: text notnull
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {opt_where}: err
+        | | {not}: err
+        |   | {strlit 'x'}: text notnull
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8710,10 +8715,11 @@ test/sem_test.sql:XXXX:1: error: in opt_limit : CQL0015: expected numeric expres
     | | {update_entry}: id: integer notnull
     |   | {name id}: id: integer notnull
     |   | {int 1}: integer notnull
-    | {update_where}
-      | {update_orderby}
-        | {opt_limit}: err
-          | {strlit 'x'}: err
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
+          | {opt_limit}: err
+            | {strlit 'x'}: err
 
 The statement ending at line XXXX
 
@@ -8731,15 +8737,16 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
     | | {update_entry}: id: integer notnull
     |   | {name id}: id: integer notnull
     |   | {int 1}: integer notnull
-    | {update_where}
-      | {update_orderby}
-        | {opt_orderby}: err
-        | | {orderby_list}: err
-        |   | {orderby_item}
-        |     | {not}: err
-        |       | {strlit 'x'}: text notnull
-        | {opt_limit}
-          | {int 2}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
+          | {opt_orderby}: err
+          | | {orderby_list}: err
+          |   | {orderby_item}
+          |     | {not}: err
+          |       | {strlit 'x'}: text notnull
+          | {opt_limit}
+            | {int 2}
 
 The statement ending at line XXXX
 
@@ -8755,8 +8762,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'non_existent_
     | | {update_entry}: err
     |   | {name non_existent_column}: err
     |   | {int 1}
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8772,8 +8780,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0012: incompatible types in express
     | | {update_entry}: err
     |   | {name id}: id: integer notnull
     |   | {strlit 'x'}: err
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8790,12 +8799,13 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0242: lossy conversion from type 'L
     | | {update_entry}: err
     |   | {name id}: id: integer notnull
     |   | {longint 1}: longint notnull
-    | {update_where}
-      | {opt_where}
-      | | {eq}
-      |   | {name id}
-      |   | {int 2}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {opt_where}
+        | | {eq}
+        |   | {name id}
+        |   | {int 2}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8811,8 +8821,9 @@ test/sem_test.sql:XXXX:1: error: in num : CQL0009: incompatible types in express
     | | {update_entry}: err
     |   | {name name}: name: text
     |   | {int 2}: err
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8828,8 +8839,9 @@ test/sem_test.sql:XXXX:1: error: in null : CQL0013: cannot assign/copy possibly 
     | | {update_entry}: err
     |   | {name id}: id: integer notnull
     |   | {null}: null
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8845,8 +8857,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0069: name not found 'X'
     | | {update_entry}: err
     |   | {name X}: err
     |   | {int 1}
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8860,8 +8873,9 @@ SET rate = NULL;
     | | {update_entry}: rate: longint
     |   | {name rate}: rate: longint
     |   | {null}: null
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -8878,8 +8892,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0047: string operand not allowed in
     |   | {name id}: id: integer notnull
     |   | {not}: err
     |     | {strlit 'x'}: text notnull
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -13399,12 +13414,13 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0153: duplicate target column name 
     |   | {update_entry}: err
     |     | {name id}: err
     |     | {int 3}
-    | {update_where}
-      | {opt_where}
-      | | {eq}
-      |   | {name id}
-      |   | {int 2}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {opt_where}
+        | | {eq}
+        |   | {name id}
+        |   | {int 2}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -29088,8 +29104,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0154: table in update statement doe
     | | {update_entry}
     |   | {name x}
     |   | {int 1}
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -32284,20 +32301,21 @@ END;
                   |   | | {update_entry}: id: integer notnull
                   |   |   | {name id}: id: integer notnull
                   |   |   | {int 7}: integer notnull
-                  |   | {update_where}
-                  |     | {opt_where}: bool
-                  |     | | {and}: bool
-                  |     |   | {gt}: bool
-                  |     |   | | {name rate}: rate: longint
-                  |     |   | | {dot}: b: real notnull
-                  |     |   |   | {name old}
-                  |     |   |   | {name b}
-                  |     |   | {lt}: bool
-                  |     |     | {name rate}: rate: longint
-                  |     |     | {dot}: b: real notnull
-                  |     |       | {name new}
-                  |     |       | {name b}
-                  |     | {update_orderby}
+                  |   | {update_from}
+                  |     | {update_where}
+                  |       | {opt_where}: bool
+                  |       | | {and}: bool
+                  |       |   | {gt}: bool
+                  |       |   | | {name rate}: rate: longint
+                  |       |   | | {dot}: b: real notnull
+                  |       |   |   | {name old}
+                  |       |   |   | {name b}
+                  |       |   | {lt}: bool
+                  |       |     | {name rate}: rate: longint
+                  |       |     | {dot}: b: real notnull
+                  |       |       | {name new}
+                  |       |       | {name b}
+                  |       | {update_orderby}
                   | {insert_stmt}: ok
                     | {insert_normal}
                     | {name_columns_values}
@@ -32371,20 +32389,21 @@ END;
                   |   | | {update_entry}: id: integer notnull
                   |   |   | {name id}: id: integer notnull
                   |   |   | {int 7}: integer notnull
-                  |   | {update_where}
-                  |     | {opt_where}: bool
-                  |     | | {and}: bool
-                  |     |   | {gt}: bool
-                  |     |   | | {name rate}: rate: longint
-                  |     |   | | {dot}: b: real notnull
-                  |     |   |   | {name old}
-                  |     |   |   | {name b}
-                  |     |   | {lt}: bool
-                  |     |     | {name rate}: rate: longint
-                  |     |     | {dot}: b: real notnull
-                  |     |       | {name new}
-                  |     |       | {name b}
-                  |     | {update_orderby}
+                  |   | {update_from}
+                  |     | {update_where}
+                  |       | {opt_where}: bool
+                  |       | | {and}: bool
+                  |       |   | {gt}: bool
+                  |       |   | | {name rate}: rate: longint
+                  |       |   | | {dot}: b: real notnull
+                  |       |   |   | {name old}
+                  |       |   |   | {name b}
+                  |       |   | {lt}: bool
+                  |       |     | {name rate}: rate: longint
+                  |       |     | {dot}: b: real notnull
+                  |       |       | {name new}
+                  |       |       | {name b}
+                  |       | {update_orderby}
                   | {insert_stmt}: ok
                     | {insert_normal}
                     | {name_columns_values}
@@ -35226,12 +35245,13 @@ test/sem_test.sql:XXXX:1: error: in call : CQL0014: cannot assign/copy sensitive
     |         | {name _sens}: _sens: integer variable sensitive was_set
     |         | {arg_list}
     |           | {int 0}: integer notnull
-    | {update_where}
-      | {opt_where}
-      | | {eq}
-      |   | {name name}
-      |   | {strlit 'x'}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {opt_where}
+        | | {eq}
+        |   | {name name}
+        |   | {strlit 'x'}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -35336,8 +35356,9 @@ SET id = CAST('1' AS INTEGER);
     |   | {cast_expr}: integer notnull
     |     | {strlit '1'}: text notnull
     |     | {type_int}: integer
-    | {update_where}
-      | {update_orderby}
+    | {update_from}
+      | {update_where}
+        | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -35618,27 +35639,28 @@ END;
             | | {update_entry}: name: text
             |   | {name name}: name: text
             |   | {strlit 'xyzzy'}: text notnull
-            | {update_where}
-              | {opt_where}: bool notnull
-              | | {in_pred}: bool notnull
-              |   | {name id}: id: integer notnull
-              |   | {select_stmt}: id: integer
-              |     | {select_core_list}: select: { id: integer notnull }
-              |     | | {select_core}: select: { id: integer notnull }
-              |     |   | {select_expr_list_con}: select: { id: integer notnull }
-              |     |     | {select_expr_list}: select: { id: integer notnull }
-              |     |     | | {star}: select: { id: integer notnull }
-              |     |     | {select_from_etc}: TABLE { x: x }
-              |     |       | {table_or_subquery_list}: TABLE { x: x }
-              |     |       | | {table_or_subquery}: TABLE { x: x }
-              |     |       |   | {name x}: TABLE { x: x }
-              |     |       | {select_where}
-              |     |         | {select_groupby}
-              |     |           | {select_having}
-              |     | {select_orderby}
-              |       | {select_limit}
-              |         | {select_offset}
-              | {update_orderby}
+            | {update_from}
+              | {update_where}
+                | {opt_where}: bool notnull
+                | | {in_pred}: bool notnull
+                |   | {name id}: id: integer notnull
+                |   | {select_stmt}: id: integer
+                |     | {select_core_list}: select: { id: integer notnull }
+                |     | | {select_core}: select: { id: integer notnull }
+                |     |   | {select_expr_list_con}: select: { id: integer notnull }
+                |     |     | {select_expr_list}: select: { id: integer notnull }
+                |     |     | | {star}: select: { id: integer notnull }
+                |     |     | {select_from_etc}: TABLE { x: x }
+                |     |       | {table_or_subquery_list}: TABLE { x: x }
+                |     |       | | {table_or_subquery}: TABLE { x: x }
+                |     |       |   | {name x}: TABLE { x: x }
+                |     |       | {select_where}
+                |     |         | {select_groupby}
+                |     |           | {select_having}
+                |     | {select_orderby}
+                |       | {select_limit}
+                |         | {select_offset}
+                | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -35701,27 +35723,28 @@ test/sem_test.sql:XXXX:1: error: in select_core : CQL0012: incompatible types in
             | | {update_entry}
             |   | {name name}
             |   | {strlit 'xyzzy'}
-            | {update_where}
-              | {opt_where}
-              | | {in_pred}
-              |   | {name id}
-              |   | {select_stmt}
-              |     | {select_core_list}
-              |     | | {select_core}
-              |     |   | {select_expr_list_con}
-              |     |     | {select_expr_list}
-              |     |     | | {star}
-              |     |     | {select_from_etc}
-              |     |       | {table_or_subquery_list}
-              |     |       | | {table_or_subquery}
-              |     |       |   | {name x}
-              |     |       | {select_where}
-              |     |         | {select_groupby}
-              |     |           | {select_having}
-              |     | {select_orderby}
-              |       | {select_limit}
-              |         | {select_offset}
-              | {update_orderby}
+            | {update_from}
+              | {update_where}
+                | {opt_where}
+                | | {in_pred}
+                |   | {name id}
+                |   | {select_stmt}
+                |     | {select_core_list}
+                |     | | {select_core}
+                |     |   | {select_expr_list_con}
+                |     |     | {select_expr_list}
+                |     |     | | {star}
+                |     |     | {select_from_etc}
+                |     |       | {table_or_subquery_list}
+                |     |       | | {table_or_subquery}
+                |     |       |   | {name x}
+                |     |       | {select_where}
+                |     |         | {select_groupby}
+                |     |           | {select_having}
+                |     | {select_orderby}
+                |       | {select_limit}
+                |         | {select_offset}
+                | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -35784,27 +35807,28 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0154: table in update statement doe
             | | {update_entry}
             |   | {name name}
             |   | {strlit 'xyzzy'}
-            | {update_where}
-              | {opt_where}
-              | | {in_pred}
-              |   | {name id}
-              |   | {select_stmt}
-              |     | {select_core_list}
-              |     | | {select_core}
-              |     |   | {select_expr_list_con}
-              |     |     | {select_expr_list}
-              |     |     | | {star}
-              |     |     | {select_from_etc}
-              |     |       | {table_or_subquery_list}
-              |     |       | | {table_or_subquery}
-              |     |       |   | {name x}
-              |     |       | {select_where}
-              |     |         | {select_groupby}
-              |     |           | {select_having}
-              |     | {select_orderby}
-              |       | {select_limit}
-              |         | {select_offset}
-              | {update_orderby}
+            | {update_from}
+              | {update_where}
+                | {opt_where}
+                | | {in_pred}
+                |   | {name id}
+                |   | {select_stmt}
+                |     | {select_core_list}
+                |     | | {select_core}
+                |     |   | {select_expr_list_con}
+                |     |     | {select_expr_list}
+                |     |     | | {star}
+                |     |     | {select_from_etc}
+                |     |       | {table_or_subquery_list}
+                |     |       | | {table_or_subquery}
+                |     |       |   | {name x}
+                |     |       | {select_where}
+                |     |         | {select_groupby}
+                |     |           | {select_having}
+                |     | {select_orderby}
+                |       | {select_limit}
+                |         | {select_offset}
+                | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -48708,12 +48732,13 @@ END;
               |   | {add}: integer notnull
               |     | {name id}: id: integer notnull
               |     | {int 1}: integer notnull
-              | {update_where}
-                | {opt_where}: bool notnull
-                | | {eq}: bool notnull
-                |   | {name id}: id: integer notnull
-                |   | {int 20}: integer notnull
-                | {update_orderby}
+              | {update_from}
+                | {update_where}
+                  | {opt_where}: bool notnull
+                  | | {eq}: bool notnull
+                  |   | {name id}: id: integer notnull
+                  |   | {int 20}: integer notnull
+                  | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -48803,8 +48828,9 @@ test/sem_test.sql:XXXX:1: error: in str : CQL0281: upsert statement does not inc
               | | {update_entry}
               |   | {name id}
               |   | {int 0}
-              | {update_where}
-                | {update_orderby}
+              | {update_from}
+                | {update_where}
+                  | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -49001,12 +49027,13 @@ test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0282: update statement requ
                             | | {update_entry}
                             |   | {name id}
                             |   | {int 1}
-                            | {update_where}
-                              | {opt_where}
-                              | | {eq}
-                              |   | {name id}
-                              |   | {int 9}
-                              | {update_orderby}
+                            | {update_from}
+                              | {update_where}
+                                | {opt_where}
+                                | | {eq}
+                                |   | {name id}
+                                |   | {int 9}
+                                | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -50521,8 +50548,9 @@ rate = id + 1;
         |     | {add}: integer notnull
         |       | {name id}: id: integer notnull
         |       | {int 1}: integer notnull
-        | {update_where}
-          | {update_orderby}
+        | {update_from}
+          | {update_where}
+            | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -51036,12 +51064,13 @@ SET id = 1
       | | {update_entry}: id: integer notnull
       |   | {name id}: id: integer notnull
       |   | {int 1}: integer notnull
-      | {update_where}
-        | {opt_where}: bool
-        | | {eq}: bool
-        |   | {name name}: name: text
-        |   | {strlit 'Stella'}: text notnull
-        | {update_orderby}
+      | {update_from}
+        | {update_where}
+          | {opt_where}: bool
+          | | {eq}: bool
+          |   | {name name}: name: text
+          |   | {strlit 'Stella'}: text notnull
+          | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -89059,32 +89088,33 @@ SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
           |             | {dot}: integer notnull primary_key
           |               | {name basic_table}
           |               | {name id}
-          | {update_where}
-            | {opt_where}: bool notnull
-            | | {in_pred}: bool notnull
-            |   | {name rowid}: rowid: longint notnull
-            |   | {select_stmt}: rowid: longint
-            |     | {select_core_list}: select: { rowid: longint notnull }
-            |     | | {select_core}: select: { rowid: longint notnull }
-            |     |   | {select_expr_list_con}: select: { rowid: longint notnull }
-            |     |     | {select_expr_list}: select: { rowid: longint notnull }
-            |     |     | | {select_expr}: rowid: longint notnull
-            |     |     |   | {name rowid}: rowid: longint notnull
-            |     |     | {select_from_etc}: TABLE { basic_table: basic_table }
-            |     |       | {table_or_subquery_list}: TABLE { basic_table: basic_table }
-            |     |       | | {table_or_subquery}: TABLE { basic_table: basic_table }
-            |     |       |   | {name basic_table}: TABLE { basic_table: basic_table }
-            |     |       | {select_where}
-            |     |         | {opt_where}: bool notnull
-            |     |         | | {lt}: bool notnull
-            |     |         |   | {name id}: id: integer notnull
-            |     |         |   | {int 100}: integer notnull
-            |     |         | {select_groupby}
-            |     |           | {select_having}
-            |     | {select_orderby}
-            |       | {select_limit}
-            |         | {select_offset}
-            | {update_orderby}
+          | {update_from}
+            | {update_where}
+              | {opt_where}: bool notnull
+              | | {in_pred}: bool notnull
+              |   | {name rowid}: rowid: longint notnull
+              |   | {select_stmt}: rowid: longint
+              |     | {select_core_list}: select: { rowid: longint notnull }
+              |     | | {select_core}: select: { rowid: longint notnull }
+              |     |   | {select_expr_list_con}: select: { rowid: longint notnull }
+              |     |     | {select_expr_list}: select: { rowid: longint notnull }
+              |     |     | | {select_expr}: rowid: longint notnull
+              |     |     |   | {name rowid}: rowid: longint notnull
+              |     |     | {select_from_etc}: TABLE { basic_table: basic_table }
+              |     |       | {table_or_subquery_list}: TABLE { basic_table: basic_table }
+              |     |       | | {table_or_subquery}: TABLE { basic_table: basic_table }
+              |     |       |   | {name basic_table}: TABLE { basic_table: basic_table }
+              |     |       | {select_where}
+              |     |         | {opt_where}: bool notnull
+              |     |         | | {lt}: bool notnull
+              |     |         |   | {name id}: id: integer notnull
+              |     |         |   | {int 100}: integer notnull
+              |     |         | {select_groupby}
+              |     |           | {select_having}
+              |     | {select_orderby}
+              |       | {select_limit}
+              |         | {select_offset}
+              | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -89299,32 +89329,33 @@ SET k = cql_blob_update(k, cql_blob_get(k, basic_table.id) + 1, basic_table.id)
           |             | {dot}: integer notnull primary_key
           |               | {name basic_table}
           |               | {name id}
-          | {update_where}
-            | {opt_where}: bool notnull
-            | | {in_pred}: bool notnull
-            |   | {name rowid}: rowid: longint notnull
-            |   | {select_stmt}: rowid: longint
-            |     | {select_core_list}: select: { rowid: longint notnull }
-            |     | | {select_core}: select: { rowid: longint notnull }
-            |     |   | {select_expr_list_con}: select: { rowid: longint notnull }
-            |     |     | {select_expr_list}: select: { rowid: longint notnull }
-            |     |     | | {select_expr}: rowid: longint notnull
-            |     |     |   | {name rowid}: rowid: longint notnull
-            |     |     | {select_from_etc}: TABLE { basic_table: basic_table }
-            |     |       | {table_or_subquery_list}: TABLE { basic_table: basic_table }
-            |     |       | | {table_or_subquery}: TABLE { basic_table: basic_table }
-            |     |       |   | {name basic_table}: TABLE { basic_table: basic_table }
-            |     |       | {select_where}
-            |     |         | {opt_where}: bool notnull
-            |     |         | | {lt}: bool notnull
-            |     |         |   | {name id}: id: integer notnull
-            |     |         |   | {int 100}: integer notnull
-            |     |         | {select_groupby}
-            |     |           | {select_having}
-            |     | {select_orderby}
-            |       | {select_limit}
-            |         | {select_offset}
-            | {update_orderby}
+          | {update_from}
+            | {update_where}
+              | {opt_where}: bool notnull
+              | | {in_pred}: bool notnull
+              |   | {name rowid}: rowid: longint notnull
+              |   | {select_stmt}: rowid: longint
+              |     | {select_core_list}: select: { rowid: longint notnull }
+              |     | | {select_core}: select: { rowid: longint notnull }
+              |     |   | {select_expr_list_con}: select: { rowid: longint notnull }
+              |     |     | {select_expr_list}: select: { rowid: longint notnull }
+              |     |     | | {select_expr}: rowid: longint notnull
+              |     |     |   | {name rowid}: rowid: longint notnull
+              |     |     | {select_from_etc}: TABLE { basic_table: basic_table }
+              |     |       | {table_or_subquery_list}: TABLE { basic_table: basic_table }
+              |     |       | | {table_or_subquery}: TABLE { basic_table: basic_table }
+              |     |       |   | {name basic_table}: TABLE { basic_table: basic_table }
+              |     |       | {select_where}
+              |     |         | {opt_where}: bool notnull
+              |     |         | | {lt}: bool notnull
+              |     |         |   | {name id}: id: integer notnull
+              |     |         |   | {int 100}: integer notnull
+              |     |         | {select_groupby}
+              |     |           | {select_having}
+              |     | {select_orderby}
+              |       | {select_limit}
+              |         | {select_offset}
+              | {update_orderby}
 
 The statement ending at line XXXX
 
@@ -94591,26 +94622,234 @@ SET id = id + 1
       |   | {add}: integer
       |     | {name id}: id: integer
       |     | {int 1}: integer notnull
+      | {update_from}
+        | {update_where}
+          | {opt_where}: bool
+          | | {in_pred}: bool
+          |   | {name id}: id: integer
+          |   | {select_stmt}: id: integer
+          |     | {select_core_list}: select: { id: integer notnull }
+          |     | | {select_core}: select: { id: integer notnull }
+          |     |   | {select_expr_list_con}: select: { id: integer notnull }
+          |     |     | {select_expr_list}: select: { id: integer notnull }
+          |     |     | | {select_expr}: id: integer notnull
+          |     |     |   | {name id}: id: integer notnull
+          |     |     | {select_from_etc}: TABLE { simple_backed_table: simple_backed_table }
+          |     |       | {table_or_subquery_list}: TABLE { simple_backed_table: simple_backed_table }
+          |     |       | | {table_or_subquery}: TABLE { simple_backed_table: simple_backed_table }
+          |     |       |   | {name simple_backed_table}: TABLE { simple_backed_table: simple_backed_table }
+          |     |       | {select_where}
+          |     |         | {select_groupby}
+          |     |           | {select_having}
+          |     | {select_orderby}
+          |       | {select_limit}
+          |         | {select_offset}
+          | {update_orderby}
+
+The statement ending at line XXXX
+
+CREATE TABLE update_from_target(
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+
+  {create_table_stmt}: update_from_target: { id: integer notnull primary_key, name: text }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name update_from_target}
+  | {col_key_list}
+    | {col_def}: id: integer notnull primary_key
+    | | {col_def_type_attrs}: ok
+    |   | {col_def_name_type}
+    |   | | {name id}
+    |   | | {type_int}: integer
+    |   | {col_attrs_pk}: ok
+    |     | {autoinc_and_conflict_clause}
+    | {col_key_list}
+      | {col_def}: name: text
+        | {col_def_type_attrs}: ok
+          | {col_def_name_type}
+            | {name name}
+            | {type_text}: text
+
+The statement ending at line XXXX
+
+CREATE TABLE update_test_1(
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+
+  {create_table_stmt}: update_test_1: { id: integer notnull primary_key, name: text }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name update_test_1}
+  | {col_key_list}
+    | {col_def}: id: integer notnull primary_key
+    | | {col_def_type_attrs}: ok
+    |   | {col_def_name_type}
+    |   | | {name id}
+    |   | | {type_int}: integer
+    |   | {col_attrs_pk}: ok
+    |     | {autoinc_and_conflict_clause}
+    | {col_key_list}
+      | {col_def}: name: text
+        | {col_def_type_attrs}: ok
+          | {col_def_name_type}
+            | {name name}
+            | {type_text}: text
+
+The statement ending at line XXXX
+
+CREATE TABLE update_test_2(
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+
+  {create_table_stmt}: update_test_2: { id: integer notnull primary_key, name: text }
+  | {create_table_name_flags}
+  | | {table_flags_attrs}
+  | | | {int 0}
+  | | {name update_test_2}
+  | {col_key_list}
+    | {col_def}: id: integer notnull primary_key
+    | | {col_def_type_attrs}: ok
+    |   | {col_def_name_type}
+    |   | | {name id}
+    |   | | {type_int}: integer
+    |   | {col_attrs_pk}: ok
+    |     | {autoinc_and_conflict_clause}
+    | {col_key_list}
+      | {col_def}: name: text
+        | {col_def_type_attrs}: ok
+          | {col_def_name_type}
+            | {name name}
+            | {type_text}: text
+
+The statement ending at line XXXX
+
+UPDATE update_from_target
+SET name = update_test_2.name FROM update_test_1
+  INNER JOIN update_test_2 ON update_test_1.id = update_test_2.id
+  WHERE update_test_1.name = 'x' AND update_from_target.id = update_test_1.id;
+
+  {update_stmt}: update_from_target: { id: integer notnull primary_key, name: text }
+  | {name update_from_target}: update_from_target: { id: integer notnull primary_key, name: text }
+  | {update_set}
+    | {update_list}: ok
+    | | {update_entry}: name: text
+    |   | {name name}: name: text
+    |   | {dot}: name: text
+    |     | {name update_test_2}
+    |     | {name name}
+    | {update_from}
+      | {join_clause}: JOIN { update_test_1: update_test_1, update_test_2: update_test_2 }
+      | | {table_or_subquery}: TABLE { update_test_1: update_test_1 }
+      | | | {name update_test_1}: TABLE { update_test_1: update_test_1 }
+      | | {join_target_list}
+      |   | {join_target}: JOIN { update_test_1: update_test_1, update_test_2: update_test_2 }
+      |     | {int 1} {join_inner}
+      |     | {table_join}
+      |       | {table_or_subquery}: TABLE { update_test_2: update_test_2 }
+      |       | | {name update_test_2}: TABLE { update_test_2: update_test_2 }
+      |       | {join_cond}: JOIN { update_test_1: update_test_1, update_test_2: update_test_2 }
+      |         | {on}: bool notnull
+      |         | {eq}: bool notnull
+      |           | {dot}: id: integer notnull
+      |           | | {name update_test_1}
+      |           | | {name id}
+      |           | {dot}: id: integer notnull
+      |             | {name update_test_2}
+      |             | {name id}
       | {update_where}
         | {opt_where}: bool
-        | | {in_pred}: bool
-        |   | {name id}: id: integer
-        |   | {select_stmt}: id: integer
-        |     | {select_core_list}: select: { id: integer notnull }
-        |     | | {select_core}: select: { id: integer notnull }
-        |     |   | {select_expr_list_con}: select: { id: integer notnull }
-        |     |     | {select_expr_list}: select: { id: integer notnull }
-        |     |     | | {select_expr}: id: integer notnull
-        |     |     |   | {name id}: id: integer notnull
-        |     |     | {select_from_etc}: TABLE { simple_backed_table: simple_backed_table }
-        |     |       | {table_or_subquery_list}: TABLE { simple_backed_table: simple_backed_table }
-        |     |       | | {table_or_subquery}: TABLE { simple_backed_table: simple_backed_table }
-        |     |       |   | {name simple_backed_table}: TABLE { simple_backed_table: simple_backed_table }
-        |     |       | {select_where}
-        |     |         | {select_groupby}
-        |     |           | {select_having}
-        |     | {select_orderby}
-        |       | {select_limit}
-        |         | {select_offset}
+        | | {and}: bool
+        |   | {eq}: bool
+        |   | | {dot}: name: text
+        |   | | | {name update_test_1}
+        |   | | | {name name}
+        |   | | {strlit 'x'}: text notnull
+        |   | {eq}: bool notnull
+        |     | {dot}: id: integer notnull
+        |     | | {name update_from_target}
+        |     | | {name id}
+        |     | {dot}: id: integer notnull
+        |       | {name update_test_1}
+        |       | {name id}
+        | {update_orderby}
+
+The statement ending at line XXXX
+
+UPDATE update_from_target
+SET name = update_test_2.name FROM table_does_not_exist;
+
+test/sem_test.sql:XXXX:1: error: in table_or_subquery : CQL0095: table/view not defined 'table_does_not_exist'
+
+  {update_stmt}: err
+  | {name update_from_target}: update_from_target: { id: integer notnull primary_key, name: text }
+  | {update_set}
+    | {update_list}
+    | | {update_entry}
+    |   | {name name}
+    |   | {dot}
+    |     | {name update_test_2}
+    |     | {name name}
+    | {update_from}
+      | {table_or_subquery_list}: err
+      | | {table_or_subquery}: err
+      |   | {name table_does_not_exist}
+      | {update_where}
+        | {update_orderby}
+
+The statement ending at line XXXX
+
+UPDATE simple_backed_table
+SET id = 5 FROM update_test_1;
+
+test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0497: FROM clause not supported when updating backed table 'simple_backed_table'
+
+  {update_stmt}: err
+  | {name simple_backed_table}: simple_backed_table: { id: integer notnull primary_key, name: text<cool_text> notnull } backed
+  | {update_set}
+    | {update_list}: ok
+    | | {update_entry}: id: integer notnull
+    |   | {name id}: id: integer notnull
+    |   | {int 5}: integer notnull
+    | {update_from}
+      | {table_or_subquery_list}: TABLE { update_test_1: update_test_1 }
+      | | {table_or_subquery}: TABLE { update_test_1: update_test_1 }
+      |   | {name update_test_1}: TABLE { update_test_1: update_test_1 }
+      | {update_where}
+        | {update_orderby}
+
+The statement ending at line XXXX
+
+@ENFORCE_STRICT UPDATE FROM;
+
+  {enforce_strict_stmt}: ok
+  | {int 22}
+
+The statement ending at line XXXX
+
+UPDATE update_from_target
+SET name = update_test_2.name FROM update_test_1;
+
+test/sem_test.sql:XXXX:1: error: in update_stmt : CQL0498: strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
+
+  {update_stmt}: err
+  | {name update_from_target}
+  | {update_set}
+    | {update_list}
+    | | {update_entry}
+    |   | {name name}
+    |   | {dot}
+    |     | {name update_test_2}
+    |     | {name name}
+    | {update_from}
+      | {table_or_subquery_list}
+      | | {table_or_subquery}
+      |   | {name update_test_1}
+      | {update_where}
         | {update_orderby}
 

--- a/sources/test/sem_test.sql
+++ b/sources/test/sem_test.sql
@@ -23793,3 +23793,46 @@ delete from dummy_table_for_backed_test where id in (select id from simple_backe
 -- + simple_backed_table (rowid, id, name) AS (CALL _simple_backed_table())
 -- - error:
 update dummy_table_for_backed_test set id = id + 1 where id in (select id from simple_backed_table);
+
+create table update_from_target(
+  id integer primary key,
+  name text
+);
+
+create table update_test_1(
+  id integer primary key,
+  name text
+);
+
+create table update_test_2(
+  id integer primary key,
+  name text
+);
+
+-- TEST: update with from clause
+-- + {update_stmt}: update_from_target: { id: integer notnull primary_key, name: text }
+-- - error:
+update update_from_target
+set name = update_test_2.name from update_test_1
+  inner join update_test_2 on update_test_1.id = update_test_2.id
+  where update_test_1.name = 'x' and update_from_target.id = update_test_1.id;
+
+-- TEST: update with from clause
+-- + {update_stmt}: err
+-- + error: % table/view not defined 'table_does_not_exist'
+-- +1 error:
+update update_from_target set name = update_test_2.name from table_does_not_exist;
+
+-- TEST: update backed table with from clause -- not supported
+-- + {update_stmt}: err
+-- + error: % FROM clause not supported when updating backed table 'simple_backed_table'
+-- +1 error:
+update simple_backed_table set id = 5 from update_test_1;
+
+@ENFORCE_STRICT UPDATE FROM;
+
+-- TEST: update with from clause
+-- + {update_stmt}: err
+-- + error: % strict UPDATE ... FROM validation requires that the UPDATE statement not include a FROM clause
+-- +1 error:
+UPDATE update_from_target SET name = update_test_2.name FROM update_test_1;

--- a/sources/test/sem_test_migrate.out.ref
+++ b/sources/test/sem_test_migrate.out.ref
@@ -617,12 +617,13 @@ END;
           | | {update_entry}: id: integer notnull
           |   | {name id}: id: integer notnull
           |   | {int 1}: integer notnull
-          | {update_where}
-            | {opt_where}: bool notnull
-            | | {eq}: bool notnull
-            |   | {name id}: id: integer notnull
-            |   | {int 2}: integer notnull
-            | {update_orderby}
+          | {update_from}
+            | {update_where}
+              | {opt_where}: bool notnull
+              | | {eq}: bool notnull
+              |   | {name id}: id: integer notnull
+              |   | {int 2}: integer notnull
+              | {update_orderby}
 
 The statement ending at line XXXX
 

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -368,6 +368,8 @@ DECLARE a CURSOR FOR SELECT b
 DECLARE a CURSOR FOR SELECT b
   FROM c;
 
+DECLARE a CURSOR LIKE (id INTEGER);
+
 LOOP FETCH a INTO b
 BEGIN
   INSERT INTO d VALUES(e, f);
@@ -1839,3 +1841,16 @@ SET file := 'path/I/do/not/like';
 SET file := 'long/path/I/do/not/like';
 
 SET file := 'long/path/I/do/not/like';
+
+@ATTRIBUTE(cql:backing_table)
+CREATE TABLE backing(
+  k BLOB NOT NULL PRIMARY KEY,
+  v BLOB
+);
+
+@ENFORCE_STRICT UPDATE FROM;
+
+UPDATE foo
+SET name = baz.name FROM bar
+  INNER JOIN baz ON bar.id = baz.id
+  WHERE bar.name = 'x' AND foo.id = bar.id;

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -352,6 +352,9 @@ declare a cursor for select b from c;
 -- simple cursor declare, short form
 cursor a for select b from c;
 
+-- cursor shape short form
+cursor a like (id integer);
+
 -- loop over cursor
 loop fetch a into b
 begin
@@ -1688,3 +1691,12 @@ let z := "abc\n" "123\r\n\x02" "lmnop''";
 set file := @FILE('path/');  -- take starting at path
 set file := @FILE('');  -- keep the whole string
 set file := @FILE('xxxx');  -- pattern not found, keep it all
+@attribute(cql:backing_table)
+create table backing(
+  k blob not null primary key,
+  v blob
+);
+
+@enforce_strict UPDATE FROM;
+
+update foo set name = baz.name from bar join baz on bar.id = baz.id where bar.name = 'x' and foo.id = bar.id;


### PR DESCRIPTION
SQLite 3.33 includes support for a FROM clause in the UPDATE statement, so this is added to the grammar.

However, we also add `@enforce_strict UPDATE FROM` to disable this feature because some products target SQLite versions older than 3.33.