### PR TITLE
Add update_docs.sh script for updating documentation

### DIFF
--- a/diagrams/rr-replacements.txt
+++ b/diagrams/rr-replacements.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# This converts the railroads output to standard looking html
+# Some of the xhtml output just doesn't parse in most versions of Chrome
+# when it's embedded on the page like we do.  So we strip out the header
+# and replace it with something more normal looking as well as some
+# internal node names.  This was done by comparing what Chrome has in
+# its dom after a successful load with the raw output of the railroads tool.
+
+1,2d
+s_ xmlns:xhtml="http://www.w3.org/1999/xhtml"__g
+s_ xmlns:svg="http://www.w3.org/2000/svg"__g
+s_ xmlns="http://www.w3.org/2000/svg"__g
+s_ xmlns:xlink="http://www.w3.org/1999/xlink"__g
+s_ xmlns="http://www.w3.org/1999/xhtml"__g
+s_<xhtml:_<_g
+s_</xhtml:_</_g
+s_svg:path_path_g
+s_xlink:__g
+/<\/style><svg>/,/<\/style>/d
+s_.*</defs></svg></head>_</style></head>_

--- a/sources/common/update_docs.sh
+++ b/sources/common/update_docs.sh
@@ -1,0 +1,105 @@
+
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+RR=~/rr-1.63-java8
+
+rr_missing() {
+  echo "This tool needs the railroad diagram JAR from bottlecaps"
+  echo "Download it from https://www.bottlecaps.de/rr/download/rr-1.63-java8.zip"
+  echo "put it in your home directory under rr-1.63-java8"
+  echo "Or if you have it into a custom folder use -r flag to provide that path. e.g: ./update_docs.sh -r ~/rr-1.63-java8"
+  exit 1
+}
+
+echo "making clean text version of grammars"
+
+while getopts r: flag
+do
+    case "${flag}" in
+        r) RR=${OPTARG};;
+    esac
+done
+
+cd ${GRAMMAR_DOCS}
+
+./make_grammar.sh;
+./make_json_grammar.sh
+
+echo "copying CQL grammar into CQL Guide Appendix 2"
+cp cql_grammar.md "${CQL_GUIDE}/x2.md"
+
+echo "copying JSON grammar into CQL Guide Appendix 5"
+cp json_grammar.md "${CQL_GUIDE}/x5.md"
+
+echo "creating Guide HTML files"
+cd "${CQL_GUIDE}/generated"
+./make_guide.sh
+
+echo "creating Internals HTML files"
+./make_internal.sh
+
+echo "making railroad diagrams"
+
+cd ${RR} || rr_missing
+
+cd ${DIAGRAMS}
+
+echo "...CQL grammar"
+sed -f "${GRAMMAR_DOCS}/diagram_tweaks.txt" < "${GRAMMAR_DOCS}/cql_grammar.txt" > "${CQL_SOURCES}/out/cql_rr.txt"
+java -jar ${RR}/rr.war -out:cql.xhtml "${CQL_SOURCES}/out/cql_rr.txt"
+
+echo "...JSON grammar"
+java -jar ${RR}/rr.war -out:json.xhtml "${GRAMMAR_DOCS}/json_grammar.txt"
+
+echo "fixing headers and rewriting xhtml to html in CQL diagram"
+
+cat >cql.html <<EOF
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+<!--
+-- Copyright (c) Meta Platforms, Inc. and affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+--
+-- @generated
+-->
+EOF
+
+echo "fixing headers and rewriting xhtml to html in JSON diagram"
+
+sed -f rr-replacements.txt <cql.xhtml >>cql.html
+
+cat >json.html <<EOF
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+<!--
+-- Copyright (c) Meta Platforms, Inc. and affiliates.
+--
+-- This source code is licensed under the MIT license found in the
+-- LICENSE file in the root directory of this source tree.
+--
+-- @generated
+-->
+EOF
+sed -f rr-replacements.txt <json.xhtml >>json.html
+
+echo "placing output in the pickup directory"
+
+mv cql.html "${DIAGRAMS}/railroad_diagram.html"
+mv json.html "${DIAGRAMS}/json_output_railroad_diagram.html"
+
+echo "cleaning up"
+
+rm cql.xhtml
+rm json.xhtml
+
+echo "running diagram font changes"
+
+cd "${DIAGRAMS}"
+
+./format_diagrams.sh
+
+echo "done"

--- a/sources/grammar_docs/diagram_tweaks.txt
+++ b/sources/grammar_docs/diagram_tweaks.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# First we get rid of all of the versions of the operators that do not have NOT
+
+s/math_expr "BETWEEN" math_expr "AND" math_expr \|//
+s/math_expr "IS" math_expr \|//
+s/math_expr "LIKE" math_expr \|//
+s/math_expr "MATCH" math_expr \|//
+s/math_expr "GLOB" math_expr \|//
+s/math_expr "REGEXP" math_expr \|//
+s/math_expr "IN" '(' expr_list ')' \|//
+s/math_expr "IN" '(' select_stmt ')' \|//
+s/math_expr "IS TRUE" \|//
+s/math_expr "IS FALSE" \|//
+
+# then we make all the NOT versions have optional NOT
+
+s/math_expr "IS NOT" /math_expr "IS" "NOT" ? /g
+s/math_expr "IS NOT TRUE"/math_expr "IS" "NOT" ? "TRUE"/g
+s/math_expr "IS NOT FALSE"/math_expr "IS" "NOT" ? "FALSE"/g
+s/math_expr "NOT BETWEEN"/math_expr "NOT" ? "BETWEEN"/
+s/math_expr "NOT LIKE"/math_expr "NOT" ? "LIKE"/
+s/math_expr "NOT MATCH"/math_expr "NOT" ? "MATCH"/
+s/math_expr "NOT GLOB"/math_expr "NOT" ? "GLOB"/
+s/math_expr "NOT REGEXP"/math_expr "NOT" ? "REGEXP"/
+s/math_expr "NOT IN" '(' /math_expr "NOT" ? "IN" '(' /g

--- a/sources/grammar_docs/grammar.js
+++ b/sources/grammar_docs/grammar.js
@@ -6,7 +6,7 @@
  */
 
 
-// Snapshot as of Fri Dec 16 21:11:50 2022
+// Snapshot as of Mon Dec 19 13:18:57 2022
 
 
 const PREC = {

--- a/sources/update_docs.sh
+++ b/sources/update_docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+
+CQL_SOURCES=./sources
+GRAMMAR_DOCS=${CQL_SOURCES}/grammar_docs
+CQL_GUIDE=./CQL_Guide
+DIAGRAMS=./diagrams
+
+# shellcheck disable=SC1091
+source common/update_docs.sh || exit 1


### PR DESCRIPTION
Summary: Add a new script that let's us easily update auto-generated parts of CQL documentation, such as the railroad diagrams and grammar information.

Reviewed By: RaoulFoaleng

Differential Revision: D42120725

