### PR TITLE
Support two shorthand forms: `[[private]]` for cql attributes and `proc` instead of `create proc`

### DIFF
--- a/sources/cql.l
+++ b/sources/cql.l
@@ -340,6 +340,8 @@ CURSOR{sp}HAS{sp}ROW/{stop}  { return CURSOR_HAS_ROW; }
 '(''|[^'\n])*'               { yylval.sval = Strdup(yytext); return STRLIT; }
 X'({hex}{hex})*'             { yylval.sval = Strdup(yytext); return BLOBLIT; }
 [-+&~|^/%*(),.;!<>:=]        { return yytext[0]; }
+\[                           { return yytext[0]; }
+\]                           { return yytext[0]; }
 [_A-Z][A-Z0-9_]*             { yylval.sval = Strdup(yytext); return ID; }
 
 [ \t\n]                      ;

--- a/sources/test/test.out.ref
+++ b/sources/test/test.out.ref
@@ -1858,3 +1858,11 @@ UPDATE foo
 SET name = baz.name FROM bar
   INNER JOIN baz ON bar.id = baz.id
   WHERE bar.name = 'x' AND foo.id = bar.id;
+
+@ATTRIBUTE(cql:private)
+@ATTRIBUTE(cql:potato=bar)
+@ATTRIBUTE(cql:garbonzo=(bar, baz))
+@ATTRIBUTE(other:something)
+CREATE PROC foo ()
+BEGIN
+END;

--- a/sources/test/test.sql
+++ b/sources/test/test.sql
@@ -1706,3 +1706,12 @@ create table backing(
 @enforce_strict UPDATE FROM;
 
 update foo set name = baz.name from bar join baz on bar.id = baz.id where bar.name = 'x' and foo.id = bar.id;
+
+/* test abbreviated cql: attributes  and abbreviated proc */
+[[private]] -- gets cql: 
+[[potato=bar]]  -- gets cql:
+[[garbonzo=(bar, baz)]] -- gets cql:
+[[other:something]]  -- does not get cql:
+proc foo() -- equivalent to create proc 
+begin
+end;


### PR DESCRIPTION
This change lets you write
```
[[private]]  -- borrowing C++ syntax and avoiding issues with future arrays maybe
proc foo()
begin
end;
```
instead of
```
@attribute(cql:private)
create proc foo()
begin
end;
```

They are equivalent.

`[[foo]]` becomes `@attribute(cql:foo)`
`[[foo:bar]]` becomes `@attribute(foo:bar)`

i.e. when using `[[foo]]`  `cql:` is the default namespace for the attribute.  This means you can't do unscoped names with the `[[]]` form but that's a small price to pay.
