### PR TITLE
two issues discovered on fresh enlistment

### DIFF
--- a/sources/cg_c.c
+++ b/sources/cg_c.c
@@ -916,7 +916,13 @@ static void cg_store(charbuf *output, CSTR var, sem_t sem_type_var, sem_t sem_ty
   CHARBUF_OPEN(adjusted_value);
   CG_BEGIN_ADJUST_FOR_OUTARG(var, sem_type_var);
 
-  // Most types convert correctly with no help, the C compiler will convert.  This is not true for bool.
+  // Normalize floats and bools for storage
+  if (is_real(sem_type_var) && !is_real(sem_type_expr)) {
+    bprintf(&adjusted_value, "(%s)(%s)", rt->cql_double, value);
+    value = adjusted_value.ptr;
+  }
+
+  // Normalize bools for storage
   if (is_bool(sem_type_var) && !is_bool(sem_type_expr)) {
     // exclude some things that are already normalized
     if (strcmp("0", value) && strcmp("1", value) && value[0] != '!') {

--- a/sources/cqlrt.lua
+++ b/sources/cqlrt.lua
@@ -907,10 +907,14 @@ function cql_rebuild_recreate_group(db, tables, indices, deletes)
   local deleteList = _cql_create_upgrader_input_statement_list(deletes, "DROP ");
 
   local rc = sqlite3.OK
-  for i = 1, #deleteList, -1 do
+  -- these are deleted or unsubscribed tables
+  -- note that tables in the list are in create order, so we reverse to get drop order
+  for i = #deleteList, 1, -1 do 
     rc = cql_exec(db, deleteList[i])
     if rc ~= sqlite3.OK then return rc end
   end
+  -- drop all the tables we are going to recreate, we have to drop in the reverse order
+  -- tables are in create order in this list
   for i = #tableList, 1, -1 do
     local table_name = _cql_create_table_name_from_table_creation_statement(tableList[i])
     local drop = "DROP TABLE IF EXISTS "
@@ -918,6 +922,7 @@ function cql_rebuild_recreate_group(db, tables, indices, deletes)
     rc = cql_exec(db, drop)
     if rc ~= sqlite3.OK then return rc end
   end
+  -- now create all the tables we need (list is in create order)
   for i = 1, #tableList do
     rc = cql_exec(db, tableList[i])
     if rc ~= sqlite3.OK then return rc end

--- a/sources/test/cg_test.sql
+++ b/sources/test/cg_test.sql
@@ -1616,7 +1616,7 @@ end;
 -- + cql_set_string_ref(&C.name, _tmp_text_0);
 -- + cql_set_notnull(C.rate, _seed_);
 -- + cql_set_notnull(C.type, _seed_);
--- + cql_set_notnull(C.size, _seed_);
+-- + cql_set_notnull(C.size, (cql_double)(_seed_));
 -- This should not be a dml proc, it doesn't actually use the db
 -- + fetch_values_dummy(void)
 -- - _rc_
@@ -1640,8 +1640,8 @@ end;
 -- + cql_set_string_ref(&C.name, _tmp_text_0);
 -- + cql_set_notnull(C.rate, _seed_);
 -- + cql_set_notnull(C.type, _seed_);
--- + cql_set_notnull(C.size, _seed_);
--- + cql_set_notnull(C.xx, _seed_);
+-- + cql_set_notnull(C.size, (cql_double)(_seed_));
+-- + cql_set_notnull(C.xx, (cql_double)(_seed_));
 -- + fetch_values_extended(void)
 create proc fetch_values_extended()
 begin
@@ -1692,7 +1692,7 @@ end;
 -- + out_no_db_C_row C = { 0 };
 -- + C._has_row_ = 1;
 -- + C.A = 3;
--- + C.B = 12;
+-- + C.B = (cql_double)(12);
 -- + _result_->_has_row_ = C._has_row_;
 -- + _result_->A = C.A;
 -- + _result_->B = C.B;
@@ -1710,7 +1710,7 @@ end;
 -- + memset(_result_, 0, sizeof(*_result_));
 -- + C1._has_row_ = 1;
 -- + C1.A = 3;
--- + C1.B = 12;
+-- + C1.B = (cql_double)(12);
 -- + _result_->_has_row_ = C1._has_row_;
 -- + _result_->A = C1.A;
 -- + _result_->B = C1.B;

--- a/sources/test/cg_test_c.c.ref
+++ b/sources/test/cg_test_c.c.ref
@@ -3819,7 +3819,7 @@ void fetch_values_dummy(void) {
   cql_set_string_ref(&C.name, _tmp_text_0);
   cql_set_notnull(C.rate, _seed_);
   cql_set_notnull(C.type, _seed_);
-  cql_set_notnull(C.size, _seed_);
+  cql_set_notnull(C.size, (cql_double)(_seed_));
 
   cql_teardown_row(C);
   cql_string_release(_tmp_text_0);
@@ -3874,8 +3874,8 @@ void fetch_values_extended(void) {
   cql_set_string_ref(&C.name, _tmp_text_0);
   cql_set_notnull(C.rate, _seed_);
   cql_set_notnull(C.type, _seed_);
-  cql_set_notnull(C.size, _seed_);
-  cql_set_notnull(C.xx, _seed_);
+  cql_set_notnull(C.size, (cql_double)(_seed_));
+  cql_set_notnull(C.xx, (cql_double)(_seed_));
   {
     char *_printf_result = sqlite3_mprintf("yy_%d", _seed_);
     cql_string_release(_tmp_text_1);
@@ -4086,7 +4086,7 @@ void out_no_db(out_no_db_row *_Nonnull _result_) {
 
   C._has_row_ = 1;
   C.A = 3;
-  C.B = 12;
+  C.B = (cql_double)(12);
   _result_->_has_row_ = C._has_row_;
   _result_->A = C.A;
   _result_->B = C.B;
@@ -4179,7 +4179,7 @@ void declare_cursor_like_cursor(declare_cursor_like_cursor_row *_Nonnull _result
 
   C1._has_row_ = 1;
   C1.A = 3;
-  C1.B = 12;
+  C1.B = (cql_double)(12);
   _result_->_has_row_ = C1._has_row_;
   _result_->A = C1.A;
   _result_->B = C1.B;

--- a/sources/test/cg_test_c_with_header.c.ref
+++ b/sources/test/cg_test_c_with_header.c.ref
@@ -3819,7 +3819,7 @@ void fetch_values_dummy(void) {
   cql_set_string_ref(&C.name, _tmp_text_0);
   cql_set_notnull(C.rate, _seed_);
   cql_set_notnull(C.type, _seed_);
-  cql_set_notnull(C.size, _seed_);
+  cql_set_notnull(C.size, (cql_double)(_seed_));
 
   cql_teardown_row(C);
   cql_string_release(_tmp_text_0);
@@ -3874,8 +3874,8 @@ void fetch_values_extended(void) {
   cql_set_string_ref(&C.name, _tmp_text_0);
   cql_set_notnull(C.rate, _seed_);
   cql_set_notnull(C.type, _seed_);
-  cql_set_notnull(C.size, _seed_);
-  cql_set_notnull(C.xx, _seed_);
+  cql_set_notnull(C.size, (cql_double)(_seed_));
+  cql_set_notnull(C.xx, (cql_double)(_seed_));
   {
     char *_printf_result = sqlite3_mprintf("yy_%d", _seed_);
     cql_string_release(_tmp_text_1);
@@ -4086,7 +4086,7 @@ void out_no_db(out_no_db_row *_Nonnull _result_) {
 
   C._has_row_ = 1;
   C.A = 3;
-  C.B = 12;
+  C.B = (cql_double)(12);
   _result_->_has_row_ = C._has_row_;
   _result_->A = C.A;
   _result_->B = C.B;
@@ -4179,7 +4179,7 @@ void declare_cursor_like_cursor(declare_cursor_like_cursor_row *_Nonnull _result
 
   C1._has_row_ = 1;
   C1.A = 3;
-  C1.B = 12;
+  C1.B = (cql_double)(12);
   _result_->_has_row_ = C1._has_row_;
   _result_->A = C1.A;
   _result_->B = C1.B;

--- a/sources/test/cg_test_c_with_namespace.c.ref
+++ b/sources/test/cg_test_c_with_namespace.c.ref
@@ -3819,7 +3819,7 @@ void fetch_values_dummy(void) {
   cql_set_string_ref(&C.name, _tmp_text_0);
   cql_set_notnull(C.rate, _seed_);
   cql_set_notnull(C.type, _seed_);
-  cql_set_notnull(C.size, _seed_);
+  cql_set_notnull(C.size, (cql_double)(_seed_));
 
   cql_teardown_row(C);
   cql_string_release(_tmp_text_0);
@@ -3874,8 +3874,8 @@ void fetch_values_extended(void) {
   cql_set_string_ref(&C.name, _tmp_text_0);
   cql_set_notnull(C.rate, _seed_);
   cql_set_notnull(C.type, _seed_);
-  cql_set_notnull(C.size, _seed_);
-  cql_set_notnull(C.xx, _seed_);
+  cql_set_notnull(C.size, (cql_double)(_seed_));
+  cql_set_notnull(C.xx, (cql_double)(_seed_));
   {
     char *_printf_result = sqlite3_mprintf("yy_%d", _seed_);
     cql_string_release(_tmp_text_1);
@@ -4086,7 +4086,7 @@ void out_no_db(out_no_db_row *_Nonnull _result_) {
 
   C._has_row_ = 1;
   C.A = 3;
-  C.B = 12;
+  C.B = (cql_double)(12);
   _result_->_has_row_ = C._has_row_;
   _result_->A = C.A;
   _result_->B = C.B;
@@ -4179,7 +4179,7 @@ void declare_cursor_like_cursor(declare_cursor_like_cursor_row *_Nonnull _result
 
   C1._has_row_ = 1;
   C1.A = 3;
-  C1.B = 12;
+  C1.B = (cql_double)(12);
   _result_->_has_row_ = C1._has_row_;
   _result_->A = C1.A;
   _result_->B = C1.B;


### PR DESCRIPTION
* conversion to cql_double is mandatory on later versions of clang, or you get errors
  * likely we will have to add other conversions in places too, luckily cg_lua.c has a helper for this and you can find all the places we do it in lua, in lua it was already mandator
* the cqlrt.lua version of the rebuild helper had a small bug in the downcount of the drop methods
  *  I added comments and fixed it